### PR TITLE
Fix liaison phone inequality check in GravityForms validation

### DIFF
--- a/src/Integration/GravityForms.php
+++ b/src/Integration/GravityForms.php
@@ -259,9 +259,9 @@ final class GravityForms
 
         foreach ($otherLiaisonFields as $otherFieldId) {
             $otherField = $this->getFieldById($form, $otherFieldId);
-            if ($otherField && !empty($otherField['value']) && !empty($value)) {
+            if ($otherField && !empty($otherField->value) && !empty($value)) {
                 $normalizedValue = $this->normalizeDigits($value);
-                $normalizedOther = $this->normalizeDigits($otherField['value']);
+                $normalizedOther = $this->normalizeDigits($otherField->value);
                 
                 if ($normalizedValue === $normalizedOther) {
                     $result['is_valid'] = false;


### PR DESCRIPTION
## Summary
- ensure liaison phone fields compare using object property access

## Testing
- `composer test` (fails: Call to undefined function apply_filters)
- `composer lint` (fails: phpcs returned error code 2)
- `composer analyze` (fails: 395 errors)


------
https://chatgpt.com/codex/tasks/task_e_68a24f417b9c832185243c7ec4dd7546