### PR TITLE
Add WP bootstrap stubs and export service tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ wp-content/wp-cache-config.php
 *.temp 
 # Debug artifacts
 allocation-test-debug.json
+tests/debug/*.json
 focused-tests.xml
 focused-tests.json
 critical-issues.json

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
         "squizlabs/php_codesniffer": "^3.7",
         "phpstan/phpstan": "^1.10",
         "phpunit/phpunit": "^10.0",
-        "vimeo/psalm": "^5.0"
+        "vimeo/psalm": "^5.0",
+        "brain/monkey": "^2.6"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "04fc88d8b781c75bedad0288177ea117",
+    "content-hash": "7c058eb6389f9a5c38fc794720133b87",
     "packages": [
         {
             "name": "composer/pcre",
@@ -811,6 +811,124 @@
             "time": "2024-04-13T18:00:56+00:00"
         },
         {
+            "name": "antecedent/patchwork",
+            "version": "2.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/antecedent/patchwork.git",
+                "reference": "1bf183a3e1bd094f231a2128b9ecc5363c269245"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/antecedent/patchwork/zipball/1bf183a3e1bd094f231a2128b9ecc5363c269245",
+                "reference": "1bf183a3e1bd094f231a2128b9ecc5363c269245",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": ">=4"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignas Rudaitis",
+                    "email": "ignas.rudaitis@gmail.com"
+                }
+            ],
+            "description": "Method redefinition (monkey-patching) functionality for PHP.",
+            "homepage": "https://antecedent.github.io/patchwork/",
+            "keywords": [
+                "aop",
+                "aspect",
+                "interception",
+                "monkeypatching",
+                "redefinition",
+                "runkit",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/antecedent/patchwork/issues",
+                "source": "https://github.com/antecedent/patchwork/tree/2.2.1"
+            },
+            "time": "2024-12-11T10:19:54+00:00"
+        },
+        {
+            "name": "brain/monkey",
+            "version": "2.6.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Brain-WP/BrainMonkey.git",
+                "reference": "d95a9d895352c30f47604ad1b825ab8fa9d1a373"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Brain-WP/BrainMonkey/zipball/d95a9d895352c30f47604ad1b825ab8fa9d1a373",
+                "reference": "d95a9d895352c30f47604ad1b825ab8fa9d1a373",
+                "shasum": ""
+            },
+            "require": {
+                "antecedent/patchwork": "^2.1.17",
+                "mockery/mockery": "^1.3.5 || ^1.4.4",
+                "php": ">=5.6.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
+                "phpcompatibility/php-compatibility": "^9.3.0",
+                "phpunit/phpunit": "^5.7.26 || ^6.0 || ^7.0 || >=8.0 <8.5.12 || ^8.5.14 || ^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev",
+                    "dev-version/1": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "inc/api.php"
+                ],
+                "psr-4": {
+                    "Brain\\Monkey\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Giuseppe Mazzapica",
+                    "email": "giuseppe.mazzapica@gmail.com",
+                    "homepage": "https://gmazzap.me",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Mocking utility for PHP functions and WordPress plugin API",
+            "keywords": [
+                "Monkey Patching",
+                "interception",
+                "mock",
+                "mock functions",
+                "mockery",
+                "patchwork",
+                "redefinition",
+                "runkit",
+                "test",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/Brain-WP/BrainMonkey/issues",
+                "source": "https://github.com/Brain-WP/BrainMonkey"
+            },
+            "time": "2024-08-29T20:15:04+00:00"
+        },
+        {
             "name": "composer/semver",
             "version": "3.4.3",
             "source": {
@@ -1299,6 +1417,140 @@
                 }
             ],
             "time": "2025-08-14T07:29:31+00:00"
+        },
+        {
+            "name": "hamcrest/hamcrest-php",
+            "version": "v2.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/hamcrest/hamcrest-php.git",
+                "reference": "f8b1c0173b22fa6ec77a81fe63e5b01eba7e6487"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/hamcrest/hamcrest-php/zipball/f8b1c0173b22fa6ec77a81fe63e5b01eba7e6487",
+                "reference": "f8b1c0173b22fa6ec77a81fe63e5b01eba7e6487",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0"
+            },
+            "replace": {
+                "cordoval/hamcrest-php": "*",
+                "davedevelopment/hamcrest-php": "*",
+                "kodova/hamcrest-php": "*"
+            },
+            "require-dev": {
+                "phpunit/php-file-iterator": "^1.4 || ^2.0 || ^3.0",
+                "phpunit/phpunit": "^4.8.36 || ^5.7 || ^6.5 || ^7.0 || ^8.0 || ^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "hamcrest"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "This is the PHP port of Hamcrest Matchers",
+            "keywords": [
+                "test"
+            ],
+            "support": {
+                "issues": "https://github.com/hamcrest/hamcrest-php/issues",
+                "source": "https://github.com/hamcrest/hamcrest-php/tree/v2.1.1"
+            },
+            "time": "2025-04-30T06:54:44+00:00"
+        },
+        {
+            "name": "mockery/mockery",
+            "version": "1.6.12",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mockery/mockery.git",
+                "reference": "1f4efdd7d3beafe9807b08156dfcb176d18f1699"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mockery/mockery/zipball/1f4efdd7d3beafe9807b08156dfcb176d18f1699",
+                "reference": "1f4efdd7d3beafe9807b08156dfcb176d18f1699",
+                "shasum": ""
+            },
+            "require": {
+                "hamcrest/hamcrest-php": "^2.0.1",
+                "lib-pcre": ">=7.0",
+                "php": ">=7.3"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5 || ^9.6.17",
+                "symplify/easy-coding-standard": "^12.1.14"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "library/helpers.php",
+                    "library/Mockery.php"
+                ],
+                "psr-4": {
+                    "Mockery\\": "library/Mockery"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Pádraic Brady",
+                    "email": "padraic.brady@gmail.com",
+                    "homepage": "https://github.com/padraic",
+                    "role": "Author"
+                },
+                {
+                    "name": "Dave Marshall",
+                    "email": "dave.marshall@atstsolutions.co.uk",
+                    "homepage": "https://davedevelopment.co.uk",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Nathanael Esayeas",
+                    "email": "nathanael.esayeas@protonmail.com",
+                    "homepage": "https://github.com/ghostwriter",
+                    "role": "Lead Developer"
+                }
+            ],
+            "description": "Mockery is a simple yet flexible PHP mock object framework",
+            "homepage": "https://github.com/mockery/mockery",
+            "keywords": [
+                "BDD",
+                "TDD",
+                "library",
+                "mock",
+                "mock objects",
+                "mockery",
+                "stub",
+                "test",
+                "test double",
+                "testing"
+            ],
+            "support": {
+                "docs": "https://docs.mockery.io/",
+                "issues": "https://github.com/mockery/mockery/issues",
+                "rss": "https://github.com/mockery/mockery/releases.atom",
+                "security": "https://github.com/mockery/mockery/security/advisories",
+                "source": "https://github.com/mockery/mockery"
+            },
+            "time": "2024-05-16T03:13:13+00:00"
         },
         {
             "name": "myclabs/deep-copy",

--- a/src/Infra/Export/ExporterService.php
+++ b/src/Infra/Export/ExporterService.php
@@ -25,7 +25,7 @@ class ExporterService
      */
     public function exportData(string $id): array
     {
-        if (!ctype_digit($id)) {
+        if (!ctype_digit($id) || (int) $id <= 0) {
             throw new InvalidArgumentException('Invalid id');
         }
 

--- a/tests/Security/ExportServiceTest.php
+++ b/tests/Security/ExportServiceTest.php
@@ -1,13 +1,48 @@
 <?php
+
 use PHPUnit\Framework\TestCase;
 use SmartAlloc\Infra\Export\ExporterService;
 
 final class ExportServiceTest extends TestCase
 {
-    public function testSQLInjectionProtection(): void
+    /**
+     * @dataProvider invalidIdProvider
+     */
+    public function testInvalidIds(string $input): void
     {
         $service = new ExporterService();
-        $this->expectException(InvalidArgumentException::class);
-        $service->exportData('1; DROP TABLE exports;');
+        $this->expectException(\InvalidArgumentException::class);
+        $service->exportData($input);
+    }
+
+    /**
+     * @return array<int, array{0:string}>
+     */
+    public function invalidIdProvider(): array
+    {
+        return [
+            ['1; DROP TABLE exports;'],
+            ['0'],
+            ['-1'],
+            [''],
+            ['abc'],
+        ];
+    }
+
+    public function testValidIdReturnsData(): void
+    {
+        $pdo = new \PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->exec('CREATE TABLE exports (id INTEGER PRIMARY KEY, name TEXT)');
+        $stmt = $pdo->prepare('INSERT INTO exports (id, name) VALUES (1, :name)');
+        $stmt->execute([':name' => 'test']);
+
+        $service = new ExporterService($pdo);
+        $result = $service->exportData('1');
+
+        $this->assertSame([
+            ['id' => 1, 'name' => 'test'],
+        ], $result);
     }
 }
+

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -125,6 +125,12 @@ if (!function_exists('do_action')) {
     }
 }
 
+if (!function_exists('apply_filters')) {
+    function apply_filters($hook, $value, ...$args) {
+        return $value;
+    }
+}
+
 if (!function_exists('rgar')) {
     function rgar($array, $key, $default = '') {
         return $array[$key] ?? $default;

--- a/tests/debug/run_allocation_test.php
+++ b/tests/debug/run_allocation_test.php
@@ -1,6 +1,6 @@
 <?php
 declare(strict_types=1);
-require __DIR__ . '/../../vendor/autoload.php';
+require __DIR__ . '/../bootstrap.php';
 
 use SmartAlloc\Tests\AllocationServiceTest;
 
@@ -9,6 +9,11 @@ try {
     $test = new AllocationServiceTest();
     $test->testDuplicateStudent(); // یا تست موردنظر
     $report['status'] = 'success';
+} catch (\InvalidArgumentException $e) {
+    $report = [
+        'status' => 'invalid',
+        'error'  => $e->getMessage(),
+    ];
 } catch (\Throwable $e) {
     $report = [
         'status' => 'error',


### PR DESCRIPTION
## Summary
- Mock `apply_filters` in the test bootstrap and wire debug runner through bootstrap
- Strengthen `ExportServiceTest` with data providers and valid dataset
- Add `brain/monkey` dev dependency and reject non-positive export IDs

## Testing
- `vendor/bin/phpunit tests/Security/ExportServiceTest.php`
- `vendor/bin/psalm --no-cache` *(fails: undefined WordPress functions)*
- `composer test` *(fails: multiple TypeErrors in unrelated tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a2eac5ae7883218133878c4e8abed4