### PR TITLE
Add WordPress stubs and security test script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
         "lint": "phpcs --standard=phpcs.xml",
         "analyze": "phpstan analyse --memory-limit=1G",
         "test": "phpunit --colors=always",
+        "test:security": "phpunit tests/Security && psalm --taint-analysis src/Infra/Export",
         "prezip": "php -d detect_unicode=0 bin/check-version-sync.php",
         "zip": "bash bin/make-zip.sh"
     },

--- a/psalm.xml
+++ b/psalm.xml
@@ -14,4 +14,7 @@
             <directory name="vendor" />
         </ignoreFiles>
     </projectFiles>
+    <stubs>
+        <file name="stubs/wp-stubs.php" />
+    </stubs>
 </psalm>

--- a/stubs/wp-stubs.php
+++ b/stubs/wp-stubs.php
@@ -1,0 +1,45 @@
+<?php
+// WordPress function stubs for tests and static analysis.
+
+if (!function_exists('apply_filters')) {
+    /**
+     * @param string $hook
+     * @param mixed $value
+     * @param mixed ...$args
+     * @return mixed
+     */
+    function apply_filters($hook, $value, ...$args) {
+        return $value;
+    }
+}
+
+if (!function_exists('add_action')) {
+    function add_action($hook, $callback, $priority = 10, $accepted_args = 1) {
+        return true;
+    }
+}
+
+if (!function_exists('add_filter')) {
+    function add_filter($hook, $callback, $priority = 10, $accepted_args = 1) {
+        return true;
+    }
+}
+
+if (!function_exists('do_action')) {
+    function do_action($hook, ...$args) {
+        return true;
+    }
+}
+
+if (!function_exists('get_option')) {
+    function get_option($key, $default = false) {
+        return $default;
+    }
+}
+
+if (!function_exists('update_option')) {
+    function update_option($key, $value) {
+        return true;
+    }
+}
+

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -6,6 +6,7 @@
 
 // Load Composer autoloader
 require_once __DIR__ . '/../vendor/autoload.php';
+require_once __DIR__ . '/../stubs/wp-stubs.php';
 
 // Mock WordPress functions for testing
 if (!function_exists('wp_cache_get')) {
@@ -77,18 +78,6 @@ if (!function_exists('wp_mkdir_p')) {
     }
 }
 
-if (!function_exists('get_option')) {
-    function get_option($key, $default = false) {
-        return $default;
-    }
-}
-
-if (!function_exists('update_option')) {
-    function update_option($key, $value) {
-        return true;
-    }
-}
-
 if (!function_exists('sanitize_text_field')) {
     function sanitize_text_field($str) {
         return trim(strip_tags($str));
@@ -101,33 +90,9 @@ if (!function_exists('current_user_can')) {
     }
 }
 
-if (!function_exists('add_action')) {
-    function add_action($hook, $callback, $priority = 10, $accepted_args = 1) {
-        return true;
-    }
-}
-
-if (!function_exists('add_filter')) {
-    function add_filter($hook, $callback, $priority = 10, $accepted_args = 1) {
-        return true;
-    }
-}
-
 if (!function_exists('register_rest_route')) {
     function register_rest_route($namespace, $route, $args = []) {
         return true;
-    }
-}
-
-if (!function_exists('do_action')) {
-    function do_action($hook, ...$args) {
-        return true;
-    }
-}
-
-if (!function_exists('apply_filters')) {
-    function apply_filters($hook, $value, ...$args) {
-        return $value;
     }
 }
 


### PR DESCRIPTION
## Summary
- centralize WordPress stubs for tests and Psalm
- load stubs in test bootstrap and Psalm config
- add composer script for security-focused tests

## Testing
- `composer test:security`

------
https://chatgpt.com/codex/tasks/task_e_68a2ecd08e6c832183f12ad14ef948aa