### PR TITLE
Wire Sabt GF submissions into allocation flow

### DIFF
--- a/smart-alloc.php
+++ b/smart-alloc.php
@@ -132,3 +132,5 @@ add_action('admin_menu', function() {
         function() { SmartAlloc\Http\Admin\AdminController::logs(); }
     );
 });
+
+add_action('gform_after_submission_150', [\SmartAlloc\Infra\GF\SabtSubmissionHandler::class, 'handle'], 10, 2);

--- a/src/Infra/GF/SabtSubmissionHandler.php
+++ b/src/Infra/GF/SabtSubmissionHandler.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SmartAlloc\Infra\GF;
+
+use SmartAlloc\Bootstrap;
+use SmartAlloc\Contracts\LoggerInterface;
+use SmartAlloc\Infra\Settings\Settings;
+use SmartAlloc\Services\AllocationService;
+
+/**
+ * Handle Sabt form submissions from Gravity Forms.
+ */
+final class SabtSubmissionHandler
+{
+    public function __construct(
+        private SabtEntryMapper $mapper,
+        private AllocationService $allocator,
+        private LoggerInterface $logger,
+        private \wpdb $wpdb
+    ) {
+    }
+
+    /**
+     * WordPress hook entrypoint.
+     *
+     * @param array<string,mixed> $entry
+     * @param array<string,mixed> $form
+     */
+    public static function handle(array $entry, array $form): void
+    {
+        $c = Bootstrap::container();
+        $handler = new self(
+            new SabtEntryMapper(),
+            $c->get(AllocationService::class),
+            $c->get(LoggerInterface::class),
+            $GLOBALS['wpdb']
+        );
+        $handler->process($entry, $form);
+    }
+
+    /**
+     * Process a Sabt entry.
+     *
+     * @param array<string,mixed> $entry
+     * @param array<string,mixed> $form
+     */
+    public function process(array $entry, array $form): void
+    {
+        $entryId = absint($entry['id'] ?? 0);
+        if ($entryId <= 0) {
+            return;
+        }
+
+        $table = $this->wpdb->prefix . 'smartalloc_allocations';
+
+        // Idempotency check
+        $existing = $this->wpdb->get_row(
+            $this->wpdb->prepare("SELECT status, mentor_id FROM {$table} WHERE entry_id = %d", $entryId),
+            'ARRAY_A'
+        );
+        if ($existing) {
+            do_action('smartalloc/event', 'AllocationProcessed', [
+                'entry_id' => $entryId,
+                'status' => $existing['status'],
+                'mentor_id' => $existing['mentor_id'] ? (int) $existing['mentor_id'] : null,
+            ]);
+            return;
+        }
+
+        $map = $this->mapper->mapEntry($entry);
+        if (!($map['ok'] ?? false)) {
+            $this->wpdb->insert($table, [
+                'entry_id' => $entryId,
+                'student_hash' => hash('sha256', wp_json_encode($entry), true),
+                'status' => 'reject',
+                'mentor_id' => null,
+                'candidates' => wp_json_encode(['reason' => $map['code'] ?? 'unknown']),
+                'created_at' => current_time('mysql'),
+                'updated_at' => current_time('mysql'),
+            ]);
+
+            $this->logger->warning('sabt.reject', ['entry_id' => $entryId]);
+            do_action('smartalloc/event', 'AllocationProcessed', [
+                'entry_id' => $entryId,
+                'status' => 'reject',
+                'mentor_id' => null,
+            ]);
+            return;
+        }
+
+        $student = $map['student'];
+        $student['id'] = $entryId;
+        $studentHash = hash('sha256', wp_json_encode($student), true);
+
+        $mode = Settings::getAllocationMode();
+        $result = [];
+
+        try {
+            if ($mode === 'rest') {
+                $response = wp_remote_post(
+                    rest_url('smartalloc/v1/allocate'),
+                    [
+                        'headers' => ['Content-Type' => 'application/json'],
+                        'body' => wp_json_encode(['student' => $student]),
+                        'timeout' => 5,
+                    ]
+                );
+                if (is_wp_error($response)) {
+                    throw new \RuntimeException($response->get_error_message());
+                }
+                $result = json_decode((string) ($response['body'] ?? ''), true)['result'] ?? [];
+            } else {
+                $result = $this->allocator->assign($student);
+            }
+        } catch (\Throwable $e) {
+            $this->logger->error('sabt.allocate_error', [
+                'entry_id' => $entryId,
+                'error' => $e->getMessage(),
+            ]);
+            return;
+        }
+
+        $score = (float) ($result['school_match_score'] ?? 0);
+        $mentorId = isset($result['mentor_id']) ? (int) $result['mentor_id'] : null;
+        $status = 'reject';
+        $candidatesJson = null;
+
+        if (($result['committed'] ?? false) && $score >= 0.90) {
+            $status = 'auto';
+        } elseif ($score >= 0.80 && $score < 0.90) {
+            $status = 'manual';
+            if (!empty($result['candidates']) && is_array($result['candidates'])) {
+                $candidatesJson = wp_json_encode(array_slice($result['candidates'], 0, 5));
+            }
+            $mentorId = null;
+        } else {
+            $status = 'reject';
+            if (!empty($result['reason'])) {
+                $candidatesJson = wp_json_encode(['reason' => $result['reason']]);
+            }
+            $mentorId = null;
+        }
+
+        $this->wpdb->insert($table, [
+            'entry_id' => $entryId,
+            'student_hash' => $studentHash,
+            'status' => $status,
+            'mentor_id' => $mentorId,
+            'candidates' => $candidatesJson,
+            'created_at' => current_time('mysql'),
+            'updated_at' => current_time('mysql'),
+        ]);
+
+        $this->logger->info('sabt.processed', [
+            'entry_id' => $entryId,
+            'status' => $status,
+        ]);
+
+        do_action('smartalloc/event', 'AllocationProcessed', [
+            'entry_id' => $entryId,
+            'status' => $status,
+            'mentor_id' => $mentorId,
+        ]);
+    }
+}

--- a/src/Infra/Settings/Settings.php
+++ b/src/Infra/Settings/Settings.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SmartAlloc\Infra\Settings;
+
+/**
+ * Plugin settings helper.
+ */
+final class Settings
+{
+    /**
+     * Get allocation mode setting.
+     */
+    public static function getAllocationMode(): string
+    {
+        $mode = $GLOBALS['smartalloc_allocation_mode'] ?? null;
+        if ($mode === null && defined('SMARTALLOC_ALLOCATION_MODE')) {
+            $mode = constant('SMARTALLOC_ALLOCATION_MODE');
+        }
+        if ($mode === null) {
+            $settings = (array) get_option('smartalloc_settings', []);
+            $mode = $settings['allocation_mode'] ?? 'direct';
+        }
+        return in_array($mode, ['direct', 'rest'], true) ? $mode : 'direct';
+    }
+}

--- a/src/Services/Db.php
+++ b/src/Services/Db.php
@@ -78,6 +78,19 @@ class Db
             allocations_committed INT UNSIGNED DEFAULT 0
         ) $charset";
 
+        // Allocation results table
+        $sql[] = "CREATE TABLE {$prefix}smartalloc_allocations (
+            id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+            entry_id BIGINT UNSIGNED NOT NULL,
+            student_hash VARBINARY(32) NOT NULL,
+            status ENUM('auto','manual','reject') NOT NULL,
+            mentor_id BIGINT UNSIGNED NULL,
+            candidates JSON NULL,
+            created_at DATETIME NOT NULL,
+            updated_at DATETIME NOT NULL,
+            UNIQUE KEY uniq_entry (entry_id)
+        ) $charset";
+
         // Execute migrations
         foreach ($sql as $query) {
             dbDelta($query);

--- a/tests/GF/SabtSubmissionHandlerTest.php
+++ b/tests/GF/SabtSubmissionHandlerTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use SmartAlloc\Contracts\LoggerInterface;
+use SmartAlloc\Infra\GF\SabtEntryMapper;
+use SmartAlloc\Infra\GF\SabtSubmissionHandler;
+use SmartAlloc\Services\AllocationService;
+
+final class SabtSubmissionHandlerTest extends \PHPUnit\Framework\TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Monkey\setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    private function makeHandler(array $allocationResult, WpdbStub $wpdb): SabtSubmissionHandler
+    {
+        $mapper = new SabtEntryMapper();
+        $allocator = new class($allocationResult) extends AllocationService {
+            public int $called = 0; public function __construct(private array $result) {}
+            public function assign(array $student): array { $this->called++; return $this->result; }
+        };
+        $logger = new class implements LoggerInterface {
+            public function debug(string $message, array $context = []): void {}
+            public function info(string $message, array $context = []): void {}
+            public function warning(string $message, array $context = []): void {}
+            public function error(string $message, array $context = []): void {}
+        };
+        return new SabtSubmissionHandler($mapper, $allocator, $logger, $wpdb);
+    }
+
+    public function test_handle_rejects_invalid_mapper_output_records_reason(): void
+    {
+        $wpdb = new WpdbStub();
+
+        $handler = $this->makeHandler([], $wpdb);
+        $handler->process(['id' => 1, '20' => '091234'], []);
+
+        $this->assertArrayHasKey(1, $wpdb->rows);
+        $this->assertSame('reject', $wpdb->rows[1]['status']);
+    }
+
+    public function test_handle_direct_mode_auto_commit_saves_allocation(): void
+    {
+        $wpdb = new WpdbStub();
+
+        $allocRes = ['committed' => true, 'mentor_id' => 10, 'school_match_score' => 0.95];
+        $handler = $this->makeHandler($allocRes, $wpdb);
+        $handler->process(['id' => 2, '20'=>'09123456789', '76'=>'1234567890123456'], []);
+
+        $this->assertSame('auto', $wpdb->rows[2]['status']);
+        $this->assertSame(10, $wpdb->rows[2]['mentor_id']);
+    }
+
+    public function test_handle_fuzzy_manual_enqueues_candidates_without_commit(): void
+    {
+        $wpdb = new WpdbStub();
+
+        $allocRes = [
+            'committed' => false,
+            'school_match_score' => 0.85,
+            'candidates' => [ ['mentor_id'=>1], ['mentor_id'=>2], ['mentor_id'=>3] ]
+        ];
+        $handler = $this->makeHandler($allocRes, $wpdb);
+        $handler->process(['id' => 3, '20'=>'09123456789', '76'=>'1234567890123456'], []);
+
+        $this->assertSame('manual', $wpdb->rows[3]['status']);
+        $this->assertNull($wpdb->rows[3]['mentor_id']);
+        $this->assertNotNull($wpdb->rows[3]['candidates']);
+    }
+
+    public function test_handle_fuzzy_reject_records_without_commit(): void
+    {
+        $wpdb = new WpdbStub();
+
+        $allocRes = [
+            'committed' => false,
+            'school_match_score' => 0.5,
+            'reason' => 'no_match'
+        ];
+        $handler = $this->makeHandler($allocRes, $wpdb);
+        $handler->process(['id' => 4, '20'=>'09123456789', '76'=>'1234567890123456'], []);
+
+        $this->assertSame('reject', $wpdb->rows[4]['status']);
+        $this->assertNull($wpdb->rows[4]['mentor_id']);
+    }
+
+    public function test_idempotency_returns_existing_result_on_repeat_entry(): void
+    {
+        $wpdb = new WpdbStub();
+
+        $allocRes = ['committed' => true, 'mentor_id' => 5, 'school_match_score' => 0.95];
+        $handler = $this->makeHandler($allocRes, $wpdb);
+        $entry = ['id' => 5, '20'=>'09123456789', '76'=>'1234567890123456'];
+        $handler->process($entry, []);
+        $handler->process($entry, []);
+
+        $this->assertCount(1, $wpdb->rows);
+    }
+
+    public function test_handle_rest_mode_calls_allocate_endpoint_and_persists_result(): void
+    {
+        $wpdb = new WpdbStub();
+        $GLOBALS['smartalloc_allocation_mode'] = 'rest';
+        Functions\expect('rest_url')->andReturn('http://example.com');
+        Functions\expect('wp_remote_post')->andReturn([
+            'body' => json_encode(['result' => ['committed' => true, 'mentor_id' => 7, 'school_match_score' => 0.93]])
+        ]);
+
+        $handler = $this->makeHandler([], $wpdb);
+        $handler->process(['id' => 6, '20'=>'09123456789', '76'=>'1234567890123456'], []);
+
+        $this->assertSame('auto', $wpdb->rows[6]['status']);
+        $this->assertSame(7, $wpdb->rows[6]['mentor_id']);
+        unset($GLOBALS['smartalloc_allocation_mode']);
+    }
+}
+
+class wpdb {}
+
+class WpdbStub extends wpdb
+{
+    public string $prefix = 'wp_';
+    public array $rows = [];
+    public string $last_error = '';
+
+    public function prepare(string $query, ...$args): string
+    {
+        foreach ($args as &$a) {
+            $a = is_numeric($a) ? (int)$a : $a;
+        }
+        return vsprintf(str_replace('%d', '%u', $query), $args);
+    }
+
+    public function get_row(string $sql, $output = ARRAY_A)
+    {
+        if (preg_match('/entry_id = (\d+)/', $sql, $m)) {
+            $id = (int) $m[1];
+            return $this->rows[$id] ?? null;
+        }
+        return null;
+    }
+
+    public function insert(string $table, array $data)
+    {
+        $id = $data['entry_id'];
+        if (isset($this->rows[$id])) {
+            $this->last_error = 'duplicate';
+            return false;
+        }
+        $this->rows[$id] = $data;
+        return 1;
+    }
+}


### PR DESCRIPTION
## Summary
- handle Sabt Gravity Forms submissions and allocate via service or REST
- record allocation outcomes in `smartalloc_allocations` table with idempotency and fuzzy handling
- expose allocation mode setting and add coverage for all paths

## Testing
- `composer lint`
- `composer test:security`
- `composer test`
- `composer ci`


------
https://chatgpt.com/codex/tasks/task_e_68a2f8f2de2c8321bfdb718d271f10bd