### PR TITLE
Add Excel exporter with config-driven workbook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 # Build artifacts
 /build/
 *.zip
+*.xlsx
 
 # IDE files
 .vscode/

--- a/SmartAlloc_Exporter_Config_v1.json
+++ b/SmartAlloc_Exporter_Config_v1.json
@@ -1,0 +1,14 @@
+{
+  "Summary": [
+    {"key": "allocated", "label": "Allocated"},
+    {"key": "manual", "label": "Manual"},
+    {"key": "rejected", "label": "Rejected"},
+    {"key": "capacity_usage", "label": "Capacity Usage"},
+    {"key": "fuzzy_rate", "label": "Fuzzy Rate"}
+  ],
+  "Errors": [
+    {"key": "id", "label": "ID"},
+    {"key": "status", "label": "Status"},
+    {"key": "reason_code", "label": "Reason"}
+  ]
+}

--- a/src/Infra/Export/ExcelExporter.php
+++ b/src/Infra/Export/ExcelExporter.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SmartAlloc\Infra\Export;
+
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Writer\Xlsx;
+use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
+
+/**
+ * Excel exporter aligned with SmartAlloc spec.
+ */
+class ExcelExporter
+{
+    private array $config;
+    private string $configPath;
+    private string $exportDir;
+
+    private static int $batchCounter = 1;
+    private static string $lastDate = '';
+    private static int $dailyCounter = 0;
+
+    public function __construct(private $wpdb, ?string $configPath = null, ?string $exportDir = null)
+    {
+        $this->configPath = $configPath ?? dirname(__DIR__, 3) . '/SmartAlloc_Exporter_Config_v1.json';
+        $this->exportDir  = $exportDir  ?? sys_get_temp_dir();
+        $configContent    = file_get_contents($this->configPath) ?: '{}';
+        $this->config     = json_decode($configContent, true) ?: [];
+    }
+
+    /**
+     * Export data by batch id.
+     *
+     * @return array{path:string, spreadsheet:Spreadsheet}
+     */
+    public function exportByBatchId(int $batchId): array
+    {
+        $table = $this->wpdb->prefix . 'allocations';
+        $sql   = $this->wpdb->prepare("SELECT * FROM {$table} WHERE batch_id = %d", absint($batchId));
+        /** @var list<array<string,mixed>> $rows */
+        $rows  = $this->wpdb->get_results($sql, 'ARRAY_A') ?: [];
+        return $this->buildSpreadsheet($rows);
+    }
+
+    /**
+     * Export data by date range.
+     *
+     * @return array{path:string, spreadsheet:Spreadsheet}
+     */
+    public function exportByDateRange(string $from, string $to): array
+    {
+        $table = $this->wpdb->prefix . 'allocations';
+        $sql   = $this->wpdb->prepare(
+            "SELECT * FROM {$table} WHERE created_at BETWEEN %s AND %s",
+            $from,
+            $to
+        );
+        /** @var list<array<string,mixed>> $rows */
+        $rows  = $this->wpdb->get_results($sql, 'ARRAY_A') ?: [];
+        return $this->buildSpreadsheet($rows);
+    }
+
+    /**
+     * Build spreadsheet from rows and save to disk.
+     *
+     * @param list<array<string,mixed>> $rows
+     * @return array{path:string, spreadsheet:Spreadsheet}
+     */
+    public function exportFromRows(array $rows): array
+    {
+        return $this->buildSpreadsheet($rows);
+    }
+
+    /**
+     * @param list<array<string,mixed>> $rows
+     * @return array{path:string, spreadsheet:Spreadsheet}
+     */
+    private function buildSpreadsheet(array $rows): array
+    {
+        $spreadsheet = new Spreadsheet();
+        $spreadsheet->removeSheetByIndex(0);
+
+        $summarySheet = $spreadsheet->createSheet()->setTitle('Summary');
+        $errorSheet   = $spreadsheet->createSheet()->setTitle('Errors');
+
+        $this->buildSummarySheet($summarySheet, $rows);
+        $this->buildErrorsSheet($errorSheet, $rows);
+
+        foreach ($spreadsheet->getWorksheetIterator() as $sheet) {
+            $sheet->freezePane('A2');
+            $highestColumn = $sheet->getHighestColumn();
+            $highestIndex  = Coordinate::columnIndexFromString($highestColumn);
+            for ($i = 1; $i <= $highestIndex; $i++) {
+                $sheet->getColumnDimensionByColumn($i)->setAutoSize(true);
+            }
+        }
+
+        $filename = $this->generateFilename();
+        $path     = $this->exportDir . DIRECTORY_SEPARATOR . $filename;
+        $writer   = new Xlsx($spreadsheet);
+        $writer->save($path);
+
+        return ['path' => $path, 'spreadsheet' => $spreadsheet];
+    }
+
+    /**
+     * @param list<array<string,mixed>> $rows
+     */
+    private function buildSummarySheet($sheet, array $rows): void
+    {
+        $allocated = $this->countByStatus($rows, 'allocated');
+        $manual    = $this->countByStatus($rows, 'manual');
+        $rejected  = $this->countByStatus($rows, 'rejected');
+        $total     = count($rows);
+        $fuzzy     = count(array_filter($rows, static fn($r) => !empty($r['fuzzy'])));
+
+        $data = [
+            'allocated'      => $allocated,
+            'manual'         => $manual,
+            'rejected'       => $rejected,
+            'capacity_usage' => $total > 0 ? round($allocated / $total, 2) : 0,
+            'fuzzy_rate'     => $total > 0 ? round($fuzzy / $total, 2) : 0,
+        ];
+
+        $columns = $this->config['Summary'] ?? [];
+        $col = 1;
+        foreach ($columns as $column) {
+            $key = $column['key'] ?? '';
+            $label = $column['label'] ?? $key;
+            $sheet->setCellValueByColumnAndRow($col, 1, $label);
+            $sheet->setCellValueByColumnAndRow($col, 2, $data[$key] ?? '');
+            $col++;
+        }
+    }
+
+    /**
+     * @param list<array<string,mixed>> $rows
+     */
+    private function buildErrorsSheet($sheet, array $rows): void
+    {
+        $columns = $this->config['Errors'] ?? [];
+        $col = 1;
+        foreach ($columns as $column) {
+            $label = $column['label'] ?? '';
+            $sheet->setCellValueByColumnAndRow($col, 1, $label);
+            $col++;
+        }
+
+        $rowIndex = 2;
+        foreach ($rows as $row) {
+            $status = $row['status'] ?? '';
+            if ($status === 'rejected' || $status === 'manual') {
+                $col = 1;
+                foreach ($columns as $column) {
+                    $key = $column['key'] ?? '';
+                    $sheet->setCellValueByColumnAndRow($col, $rowIndex, $row[$key] ?? '');
+                    $col++;
+                }
+                $rowIndex++;
+            }
+        }
+    }
+
+    /**
+     * Count rows by status
+     *
+     * @param list<array<string,mixed>> $rows
+     */
+    private function countByStatus(array $rows, string $status): int
+    {
+        return count(array_filter($rows, static fn($r) => ($r['status'] ?? '') === $status));
+    }
+
+    private function generateFilename(): string
+    {
+        $date = date('Y_m_d');
+        if (self::$lastDate !== $date) {
+            self::$dailyCounter = 0;
+            self::$lastDate     = $date;
+        }
+        self::$dailyCounter++;
+        $daily = str_pad((string) self::$dailyCounter, 4, '0', STR_PAD_LEFT);
+
+        $batch = str_pad((string) self::$batchCounter, 3, '0', STR_PAD_LEFT);
+        self::$batchCounter++;
+
+        return sprintf('SabtExport-ALLOCATED-%s-%s-B%s.xlsx', $date, $daily, $batch);
+    }
+}
+

--- a/src/Infra/Export/ExporterService.php
+++ b/src/Infra/Export/ExporterService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace SmartAlloc\Infra\Export;
 
 use InvalidArgumentException;
+use SmartAlloc\Infra\Export\ExcelExporter;
 
 /**
  * Exporter using WordPress database access with table name safety.
@@ -13,9 +14,12 @@ use InvalidArgumentException;
  */
 class ExporterService
 {
-    public function __construct(private $wpdb = null)
+    private ExcelExporter $excelExporter;
+
+    public function __construct(private $wpdb = null, ?ExcelExporter $excelExporter = null)
     {
-        $this->wpdb = $wpdb ?? $GLOBALS['wpdb'];
+        $this->wpdb          = $wpdb ?? $GLOBALS['wpdb'];
+        $this->excelExporter = $excelExporter ?? new ExcelExporter($this->wpdb);
     }
 
     /**
@@ -34,5 +38,42 @@ class ExporterService
         $results = $this->wpdb->get_results($sql, 'ARRAY_A') ?: [];
 
         return $results;
+    }
+
+    /**
+     * Export allocations by batch id to Excel.
+     *
+     * @return array{path:string, spreadsheet:\PhpOffice\PhpSpreadsheet\Spreadsheet}
+     */
+    public function exportToExcelByBatch(int $batchId): array
+    {
+        $table = $this->wpdb->prefix . 'allocations';
+        $sql   = $this->wpdb->prepare(
+            "SELECT * FROM {$table} WHERE batch_id = %d",
+            absint($batchId)
+        );
+        /** @var list<array<string,mixed>> $rows */
+        $rows = $this->wpdb->get_results($sql, 'ARRAY_A') ?: [];
+
+        return $this->excelExporter->exportFromRows($rows);
+    }
+
+    /**
+     * Export allocations by date range to Excel.
+     *
+     * @return array{path:string, spreadsheet:\PhpOffice\PhpSpreadsheet\Spreadsheet}
+     */
+    public function exportToExcelByDateRange(string $from, string $to): array
+    {
+        $table = $this->wpdb->prefix . 'allocations';
+        $sql   = $this->wpdb->prepare(
+            "SELECT * FROM {$table} WHERE created_at BETWEEN %s AND %s",
+            $from,
+            $to
+        );
+        /** @var list<array<string,mixed>> $rows */
+        $rows = $this->wpdb->get_results($sql, 'ARRAY_A') ?: [];
+
+        return $this->excelExporter->exportFromRows($rows);
     }
 }

--- a/tests/Export/ExcelExporterTest.php
+++ b/tests/Export/ExcelExporterTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SmartAlloc\Tests\Export;
+
+use PhpOffice\PhpSpreadsheet\IOFactory;
+use SmartAlloc\Infra\Export\ExcelExporter;
+use SmartAlloc\Tests\BaseTestCase;
+
+final class ExcelExporterTest extends BaseTestCase
+{
+    private function sampleRows(): array
+    {
+        return [
+            ['id' => 1, 'status' => 'allocated', 'reason_code' => '', 'fuzzy' => 0],
+            ['id' => 2, 'status' => 'manual', 'reason_code' => 'MISSING_DOC', 'fuzzy' => 0],
+            ['id' => 3, 'status' => 'rejected', 'reason_code' => 'INVALID_INFO', 'fuzzy' => 1],
+        ];
+    }
+
+    private function createExporter(): ExcelExporter
+    {
+        $wpdb = $this->mockWpdb($this->sampleRows());
+        $configPath = dirname(__DIR__, 2) . '/SmartAlloc_Exporter_Config_v1.json';
+        return new ExcelExporter($wpdb, $configPath, sys_get_temp_dir());
+    }
+
+    public function test_file_naming_pattern(): void
+    {
+        $exporter = $this->createExporter();
+        $result   = $exporter->exportFromRows($this->sampleRows());
+        $this->assertMatchesRegularExpression('/^SabtExport-ALLOCATED-\d{4}_\d{2}_\d{2}-\d{4}-B\d{3}\.xlsx$/', basename($result['path']));
+        $this->assertFileExists($result['path']);
+        unlink($result['path']);
+    }
+
+    public function test_summary_and_errors_sheets_exist(): void
+    {
+        $exporter = $this->createExporter();
+        $result   = $exporter->exportFromRows($this->sampleRows());
+        $spreadsheet = IOFactory::load($result['path']);
+        $this->assertNotNull($spreadsheet->getSheetByName('Summary'));
+        $this->assertNotNull($spreadsheet->getSheetByName('Errors'));
+        unlink($result['path']);
+    }
+
+    public function test_column_layout_matches_config(): void
+    {
+        $exporter = $this->createExporter();
+        $result   = $exporter->exportFromRows($this->sampleRows());
+        $spreadsheet   = IOFactory::load($result['path']);
+        $summarySheet  = $spreadsheet->getSheetByName('Summary');
+        $errorsSheet   = $spreadsheet->getSheetByName('Errors');
+        $config = json_decode(file_get_contents(dirname(__DIR__, 2) . '/SmartAlloc_Exporter_Config_v1.json'), true);
+
+        $summaryHeaders = [];
+        $summaryMax = \PhpOffice\PhpSpreadsheet\Cell\Coordinate::columnIndexFromString($summarySheet->getHighestColumn());
+        for ($i = 1; $i <= $summaryMax; $i++) {
+            $summaryHeaders[] = (string) $summarySheet->getCellByColumnAndRow($i, 1)->getValue();
+        }
+        $this->assertSame(array_column($config['Summary'], 'label'), $summaryHeaders);
+
+        $errorHeaders = [];
+        $errorMax = \PhpOffice\PhpSpreadsheet\Cell\Coordinate::columnIndexFromString($errorsSheet->getHighestColumn());
+        for ($i = 1; $i <= $errorMax; $i++) {
+            $errorHeaders[] = (string) $errorsSheet->getCellByColumnAndRow($i, 1)->getValue();
+        }
+        $this->assertSame(array_column($config['Errors'], 'label'), $errorHeaders);
+        unlink($result['path']);
+    }
+
+    public function test_reject_and_manual_rows_appear_with_reason_codes(): void
+    {
+        $exporter = $this->createExporter();
+        $result   = $exporter->exportFromRows($this->sampleRows());
+        $spreadsheet = IOFactory::load($result['path']);
+        $errorsSheet = $spreadsheet->getSheetByName('Errors');
+        $rows = $errorsSheet->toArray();
+        $this->assertCount(3, $rows); // header + 2 rows
+        $this->assertSame('manual', strtolower((string) $rows[1][1]));
+        $this->assertSame('MISSING_DOC', $rows[1][2]);
+        $this->assertSame('rejected', strtolower((string) $rows[2][1]));
+        $this->assertSame('INVALID_INFO', $rows[2][2]);
+        unlink($result['path']);
+    }
+
+    private function mockWpdb(array $results)
+    {
+        return new class($results) {
+            public $prefix = 'wp_';
+            public function __construct(private array $results) {}
+            public function prepare($query, ...$args) { return vsprintf($query, $args); }
+            public function get_results($sql, $mode) { return $this->results; }
+        };
+    }
+}
+


### PR DESCRIPTION
## Summary
- add PhpSpreadsheet Excel exporter that reads SmartAlloc_Exporter_Config_v1.json and builds Summary and Errors sheets
- wire ExporterService to use the new Excel exporter
- cover exporter with unit tests and ignore generated `.xlsx` files

## Testing
- `composer lint`
- `composer test:security`
- `composer test`
- `composer ci`


------
https://chatgpt.com/codex/tasks/task_e_68a2ff7243b08321aa79cbac651f03a9