### PR TITLE
Add admin export UI and registry

### DIFF
--- a/smart-alloc.php
+++ b/smart-alloc.php
@@ -133,4 +133,8 @@ add_action('admin_menu', function() {
     );
 });
 
+add_action('admin_menu', ['SmartAlloc\\Admin\\Menu', 'register']);
+add_action('admin_post_smartalloc_export_generate', ['SmartAlloc\\Admin\\Actions\\ExportGenerateAction', 'handle']);
+add_action('admin_post_smartalloc_export_download', ['SmartAlloc\\Admin\\Actions\\ExportDownloadAction', 'handle']);
+
 add_action('gform_after_submission_150', [\SmartAlloc\Infra\GF\SabtSubmissionHandler::class, 'handle'], 10, 2);

--- a/src/Admin/Actions/ExportDownloadAction.php
+++ b/src/Admin/Actions/ExportDownloadAction.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SmartAlloc\Admin\Actions;
+
+final class ExportDownloadAction
+{
+    public static function handle(): void
+    {
+        $id = isset($_GET['export_id']) ? absint($_GET['export_id']) : 0;
+
+        if (!current_user_can(SMARTALLOC_CAP)) {
+            wp_die(esc_html__('Access denied', 'smartalloc'));
+        }
+
+        if (!$id) {
+            wp_die(esc_html__('Invalid export.', 'smartalloc'));
+        }
+
+        check_admin_referer('smartalloc_export_download_' . $id);
+
+        global $wpdb;
+        $table = $wpdb->prefix . 'smartalloc_exports';
+        $row   = $wpdb->get_row($wpdb->prepare("SELECT * FROM {$table} WHERE id = %d", $id), ARRAY_A);
+        if (!$row) {
+            wp_die(esc_html__('Export not found.', 'smartalloc'));
+        }
+
+        $upload = wp_upload_dir();
+        $base   = realpath(trailingslashit($upload['basedir']) . 'smartalloc/exports');
+        $path   = realpath($row['path']);
+        if (!$path || !$base || !str_starts_with($path, $base)) {
+            wp_die(esc_html__('Invalid file path.', 'smartalloc'));
+        }
+
+        if (!is_file($path) || !is_readable($path)) {
+            wp_die(esc_html__('File not found.', 'smartalloc'));
+        }
+
+        nocache_headers();
+        header('Content-Type: application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+        header('Content-Disposition: attachment; filename="' . basename($row['filename']) . '"');
+        header('Content-Length: ' . filesize($path));
+        readfile($path);
+    }
+}

--- a/src/Admin/Actions/ExportGenerateAction.php
+++ b/src/Admin/Actions/ExportGenerateAction.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SmartAlloc\Admin\Actions;
+
+use SmartAlloc\Infra\Export\ExcelExporter;
+
+final class ExportGenerateAction
+{
+    public static function handle(): void
+    {
+        if (!current_user_can(SMARTALLOC_CAP)) {
+            wp_die(esc_html__('Access denied', 'smartalloc'));
+        }
+
+        check_admin_referer('smartalloc_export_generate', 'smartalloc_export_nonce');
+
+        $mode    = sanitize_text_field($_POST['mode'] ?? '');
+        $from    = sanitize_text_field($_POST['date_from'] ?? '');
+        $to      = sanitize_text_field($_POST['date_to'] ?? '');
+        $batchId = isset($_POST['batch_id']) ? absint($_POST['batch_id']) : 0;
+
+        $filters = [];
+        if ($mode === 'date-range') {
+            if (!self::validDate($from) || !self::validDate($to)) {
+                wp_die(esc_html__('Invalid date range.', 'smartalloc'));
+            }
+            $filters = ['mode' => 'date-range', 'from' => $from, 'to' => $to];
+        } elseif ($mode === 'batch') {
+            if ($batchId <= 0) {
+                wp_die(esc_html__('Invalid batch ID.', 'smartalloc'));
+            }
+            $filters = ['mode' => 'batch', 'batch_id' => $batchId];
+        } else {
+            wp_die(esc_html__('Invalid mode.', 'smartalloc'));
+        }
+
+        $upload = wp_upload_dir();
+        $dir    = trailingslashit($upload['basedir']) . 'smartalloc/exports/' . gmdate('Y/m/');
+        wp_mkdir_p($dir);
+        if (!is_writable($dir)) {
+            wp_die(esc_html__('Export directory not writable.', 'smartalloc'));
+        }
+
+        global $wpdb;
+        $exporter = new ExcelExporter($wpdb, null, $dir);
+        if ($mode === 'date-range') {
+            $result = $exporter->exportByDateRange($from . ' 00:00:00', $to . ' 23:59:59');
+        } else {
+            $result = $exporter->exportByBatchId($batchId);
+        }
+
+        $path     = $result['path'];
+        $filename = basename($path);
+        $size     = file_exists($path) ? filesize($path) : 0;
+        $checksum = file_exists($path) ? hash_file('sha256', $path) : '';
+
+        $table = $wpdb->prefix . 'smartalloc_exports';
+        $wpdb->insert($table, [
+            'filename'   => $filename,
+            'path'       => $path,
+            'filters'    => wp_json_encode($filters),
+            'size'       => $size,
+            'checksum'   => $checksum ?: null,
+            'created_at' => current_time('mysql'),
+        ]);
+
+        $url = add_query_arg(
+            ['page' => 'smartalloc-export', 'smartalloc_export_success' => 1],
+            admin_url('admin.php')
+        );
+        wp_safe_redirect($url);
+    }
+
+    private static function validDate(string $date): bool
+    {
+        if (!preg_match('/^\d{4}-\d{2}-\d{2}$/', $date)) {
+            return false;
+        }
+        [$y, $m, $d] = array_map('intval', explode('-', $date));
+        return wp_checkdate($m, $d, $y, $date);
+    }
+}

--- a/src/Admin/Menu.php
+++ b/src/Admin/Menu.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SmartAlloc\Admin;
+
+use SmartAlloc\Admin\Pages\ExportPage;
+
+final class Menu
+{
+    public static function register(): void
+    {
+        add_submenu_page(
+            'smartalloc-dashboard',
+            esc_html__('Export', 'smartalloc'),
+            esc_html__('Export', 'smartalloc'),
+            SMARTALLOC_CAP,
+            'smartalloc-export',
+            [ExportPage::class, 'render']
+        );
+    }
+}

--- a/src/Admin/Pages/ExportPage.php
+++ b/src/Admin/Pages/ExportPage.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SmartAlloc\Admin\Pages;
+
+final class ExportPage
+{
+    public static function render(): void
+    {
+        if (!current_user_can(SMARTALLOC_CAP)) {
+            wp_die(esc_html__('Access denied', 'smartalloc'));
+        }
+
+        global $wpdb;
+        $table   = $wpdb->prefix . 'smartalloc_exports';
+        $exports = $wpdb->get_results(
+            $wpdb->prepare("SELECT * FROM {$table} ORDER BY created_at DESC LIMIT %d", 20),
+            ARRAY_A
+        );
+
+        echo '<div class="wrap">';
+        echo '<h1>' . esc_html__('Export', 'smartalloc') . '</h1>';
+
+        if (isset($_GET['smartalloc_export_success'])) {
+            echo '<div class="notice notice-success"><p>' . esc_html__('Export generated.', 'smartalloc') . '</p></div>';
+        }
+
+        echo '<form method="post" action="' . esc_url(admin_url('admin-post.php')) . '">';
+        echo '<input type="hidden" name="action" value="smartalloc_export_generate" />';
+        wp_nonce_field('smartalloc_export_generate', 'smartalloc_export_nonce');
+
+        echo '<table class="form-table"><tbody>';
+        echo '<tr><th scope="row"><label for="sa_mode">' . esc_html__('Mode', 'smartalloc') . '</label></th><td><select id="sa_mode" name="mode">';
+        echo '<option value="date-range">' . esc_html__('Date range', 'smartalloc') . '</option>';
+        echo '<option value="batch">' . esc_html__('Batch', 'smartalloc') . '</option>';
+        echo '</select></td></tr>';
+
+        echo '<tr><th scope="row"><label for="sa_date_from">' . esc_html__('Date from', 'smartalloc') . '</label></th><td><input type="date" id="sa_date_from" name="date_from" /></td></tr>';
+        echo '<tr><th scope="row"><label for="sa_date_to">' . esc_html__('Date to', 'smartalloc') . '</label></th><td><input type="date" id="sa_date_to" name="date_to" /></td></tr>';
+        echo '<tr><th scope="row"><label for="sa_batch_id">' . esc_html__('Batch ID', 'smartalloc') . '</label></th><td><input type="number" id="sa_batch_id" name="batch_id" min="1" /></td></tr>';
+        echo '</tbody></table>';
+
+        submit_button(esc_html__('Generate export', 'smartalloc'));
+        echo '</form>';
+
+        echo '<h2>' . esc_html__('Recent exports', 'smartalloc') . '</h2>';
+        echo '<table class="wp-list-table widefat striped">';
+        echo '<thead><tr>';
+        echo '<th>' . esc_html__('Filename', 'smartalloc') . '</th>';
+        echo '<th>' . esc_html__('Created', 'smartalloc') . '</th>';
+        echo '<th>' . esc_html__('Filters', 'smartalloc') . '</th>';
+        echo '<th>' . esc_html__('Size', 'smartalloc') . '</th>';
+        echo '<th>' . esc_html__('Checksum', 'smartalloc') . '</th>';
+        echo '<th>' . esc_html__('Action', 'smartalloc') . '</th>';
+        echo '</tr></thead><tbody>';
+
+        foreach ($exports as $export) {
+            $filters  = json_decode($export['filters'] ?? '', true) ?: [];
+            $summary  = self::summary($filters);
+            $download = wp_nonce_url(
+                admin_url('admin-post.php?action=smartalloc_export_download&export_id=' . absint($export['id'])),
+                'smartalloc_export_download_' . absint($export['id'])
+            );
+            echo '<tr>';
+            echo '<td>' . esc_html($export['filename']) . '</td>';
+            echo '<td>' . esc_html($export['created_at']) . '</td>';
+            echo '<td>' . esc_html($summary) . '</td>';
+            echo '<td>' . esc_html(size_format((int) $export['size'])) . '</td>';
+            echo '<td>' . esc_html($export['checksum'] ?? '') . '</td>';
+            echo '<td><a href="' . esc_url($download) . '">' . esc_html__('Download', 'smartalloc') . '</a></td>';
+            echo '</tr>';
+        }
+
+        if (empty($exports)) {
+            echo '<tr><td colspan="6">' . esc_html__('No exports found.', 'smartalloc') . '</td></tr>';
+        }
+
+        echo '</tbody></table>';
+        echo '</div>';
+    }
+
+    private static function summary(array $filters): string
+    {
+        if (($filters['mode'] ?? '') === 'date-range') {
+            return ($filters['from'] ?? '') . ' - ' . ($filters['to'] ?? '');
+        }
+        if (($filters['mode'] ?? '') === 'batch') {
+            return 'Batch ' . ($filters['batch_id'] ?? '');
+        }
+        return '';
+    }
+}

--- a/src/Services/Db.php
+++ b/src/Services/Db.php
@@ -91,6 +91,20 @@ class Db
             UNIQUE KEY uniq_id (id)
         ) $charset";
 
+        // Export registry
+        $dbVersion = $wpdb->get_var('SELECT VERSION()');
+        $filtersType = ($dbVersion && version_compare($dbVersion, '5.7', '>=')) ? 'JSON' : 'LONGTEXT';
+        $sql[] = "CREATE TABLE {$prefix}smartalloc_exports (
+            id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+            filename VARCHAR(255) NOT NULL,
+            path TEXT NOT NULL,
+            filters {$filtersType} NULL,
+            size BIGINT NOT NULL DEFAULT 0,
+            checksum CHAR(64) NULL,
+            created_at DATETIME NOT NULL,
+            INDEX created_at (created_at)
+        ) $charset";
+
         // Allocation results table
         $sql[] = "CREATE TABLE {$prefix}smartalloc_allocations (
             id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,

--- a/tests/Admin/ExportActionsTest.php
+++ b/tests/Admin/ExportActionsTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SmartAlloc\Tests\Admin;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use SmartAlloc\Tests\BaseTestCase;
+use SmartAlloc\Admin\Actions\{ExportGenerateAction, ExportDownloadAction};
+
+final class ExportActionsTest extends BaseTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Monkey\setUp();
+        global $wpdb;
+        $wpdb = new class {
+            public $prefix = 'wp_';
+            public array $inserted = [];
+            public array $rows = [];
+            public function prepare($sql, ...$args) { return $sql; }
+            public function insert($table, $data) { $this->inserted[] = ['table'=>$table,'data'=>$data]; return true; }
+            public function get_row($sql, $output) { return $this->rows[0] ?? null; }
+            public function get_results($sql, $output) { return []; }
+            public function get_var($sql) { return '1'; }
+            public function query($sql) { return true; }
+        };
+    }
+
+    protected function tearDown(): void
+    {
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    public function test_generate_action_validates_and_calls_exporter(): void
+    {
+        $_POST = [
+            'mode' => 'date-range',
+            'date_from' => '2024-01-01',
+            'date_to' => '2024-01-02',
+            'smartalloc_export_nonce' => 'nonce',
+        ];
+        Functions\expect('current_user_can')->once()->with(SMARTALLOC_CAP)->andReturn(true);
+        Functions\expect('check_admin_referer')->once()->with('smartalloc_export_generate', 'smartalloc_export_nonce');
+        Functions\expect('add_query_arg')->andReturn('/admin.php');
+        Functions\expect('admin_url')->andReturn('/admin.php');
+        Functions\expect('wp_safe_redirect')->once()->with('/admin.php')->andThrow(new \RuntimeException('redirect'));
+        Functions\when('wp_checkdate')->justReturn(true);
+
+        try {
+            ExportGenerateAction::handle();
+        } catch (\RuntimeException $e) {
+            $this->assertSame('redirect', $e->getMessage());
+        }
+
+        $insert = $GLOBALS['wpdb']->inserted[0]['data'];
+        $this->assertFileExists($insert['path']);
+        unlink($insert['path']);
+    }
+
+    public function test_registry_record_persisted_with_checksum_and_size(): void
+    {
+        $_POST = [
+            'mode' => 'batch',
+            'batch_id' => '5',
+            'smartalloc_export_nonce' => 'nonce',
+        ];
+        Functions\expect('current_user_can')->once()->with(SMARTALLOC_CAP)->andReturn(true);
+        Functions\expect('check_admin_referer')->once()->with('smartalloc_export_generate', 'smartalloc_export_nonce');
+        Functions\expect('add_query_arg')->andReturn('/admin.php');
+        Functions\expect('admin_url')->andReturn('/admin.php');
+        Functions\expect('wp_safe_redirect')->once()->with('/admin.php')->andThrow(new \RuntimeException('redirect'));
+        Functions\when('wp_checkdate')->justReturn(true);
+
+        try {
+            ExportGenerateAction::handle();
+        } catch (\RuntimeException $e) {
+            $this->assertSame('redirect', $e->getMessage());
+        }
+
+        $insert = $GLOBALS['wpdb']->inserted[0]['data'];
+        $this->assertArrayHasKey('checksum', $insert);
+        $this->assertGreaterThan(0, $insert['size']);
+        $filters = json_decode($insert['filters'], true);
+        $this->assertSame(5, $filters['batch_id']);
+        unlink($insert['path']);
+    }
+
+    public function test_download_action_requires_valid_nonce_and_streams_file(): void
+    {
+        $baseDir = sys_get_temp_dir() . '/smartalloc/exports/2024/01';
+        if (!is_dir($baseDir)) {
+            mkdir($baseDir, 0777, true);
+        }
+        $tmp = tempnam($baseDir, 'exp');
+        file_put_contents($tmp, 'data');
+        $GLOBALS['wpdb']->rows = [[
+            'id' => 1,
+            'filename' => basename($tmp),
+            'path' => $tmp,
+            'filters' => '{}',
+            'size' => 4,
+            'checksum' => hash_file('sha256', $tmp),
+            'created_at' => '2024-01-01 00:00:00',
+        ]];
+
+        $_GET = ['export_id' => '1'];
+        Functions\expect('current_user_can')->once()->with(SMARTALLOC_CAP)->andReturn(true);
+        Functions\expect('check_admin_referer')->once()->with('smartalloc_export_download_1');
+        Functions\when('nocache_headers')->justReturn(true);
+        Functions\when('esc_html__')->alias(fn($v) => $v);
+
+        ob_start();
+        ExportDownloadAction::handle();
+        $content = ob_get_clean();
+
+        $this->assertSame('data', $content);
+        unlink($tmp);
+    }
+}

--- a/tests/Admin/ExportPageTest.php
+++ b/tests/Admin/ExportPageTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SmartAlloc\Tests\Admin;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use SmartAlloc\Tests\BaseTestCase;
+use SmartAlloc\Admin\Pages\ExportPage;
+
+final class ExportPageTest extends BaseTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Monkey\setUp();
+        global $wpdb;
+        $wpdb = new class {
+            public $prefix = 'wp_';
+            public function prepare($sql, $limit) { return $sql; }
+            public function get_results($sql, $output) { return []; }
+        };
+    }
+
+    protected function tearDown(): void
+    {
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    public function test_capability_required_for_export_page(): void
+    {
+        Functions\expect('current_user_can')->once()->with(SMARTALLOC_CAP)->andReturn(false);
+        Functions\when('esc_html__')->alias(fn($v) => $v);
+        Functions\when('esc_url')->alias(fn($v) => $v);
+        Functions\expect('wp_die')->once()->andThrow(new \RuntimeException('die'));
+
+        $this->expectException(\RuntimeException::class);
+        ExportPage::render();
+    }
+
+    public function test_form_renders_inputs_and_nonce(): void
+    {
+        Functions\expect('current_user_can')->andReturn(true);
+        Functions\expect('wp_nonce_field')->once()->with('smartalloc_export_generate', 'smartalloc_export_nonce')->andReturn('');
+        Functions\when('admin_url')->justReturn('/admin-post.php');
+        Functions\when('esc_url')->alias(fn($v) => $v);
+        Functions\when('esc_html__')->alias(fn($v) => $v);
+        Functions\when('esc_html')->alias(fn($v) => $v);
+        Functions\when('size_format')->alias(fn($v) => (string) $v);
+        Functions\when('wp_nonce_url')->alias(fn($v) => $v);
+        Functions\when('submit_button')->alias(fn($v) => $v);
+
+        ob_start();
+        ExportPage::render();
+        $html = ob_get_clean();
+
+        $this->assertStringContainsString('name="mode"', $html);
+        $this->assertStringContainsString('name="date_from"', $html);
+        $this->assertStringContainsString('name="date_to"', $html);
+        $this->assertStringContainsString('name="batch_id"', $html);
+    }
+}


### PR DESCRIPTION
## Summary
- add Export admin submenu with form and recent export listing
- handle export generation and secure download via nonce-protected actions
- record exports in new smartalloc_exports table

## Testing
- `composer lint`
- `composer test:security`
- `composer test`
- `composer ci`


------
https://chatgpt.com/codex/tasks/task_e_68a305aebef88321bef0f3f6e52f8da7