### PR TITLE
chore: expand qa tooling and debug safeguards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,14 +9,19 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: ['8.0', '8.2']
+        php: ['7.4', '8.0', '8.1', '8.2', '8.3']
+        wp: ['latest', 'latest-1', 'latest-2']
+    env:
+      WP_VERSION: ${{ matrix.wp }}
     steps:
       - uses: actions/checkout@v3
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
       - run: composer install --no-progress --no-interaction --ignore-platform-req=php
-      - run: composer ci
+      - run: composer qa
+      - run: composer test:security
+      - run: composer test
       - if: failure()
         uses: actions/upload-artifact@v3
         with:

--- a/bin/wp-plugin-check.sh
+++ b/bin/wp-plugin-check.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+WP_VERSION="${WP_VERSION:-latest}"
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+wp core download --path="$WORKDIR/wordpress" --version="$WP_VERSION" --skip-content >/dev/null
+cp -R "$(pwd)" "$WORKDIR/wordpress/wp-content/plugins/smart-alloc"
+wp plugin install plugin-check --path="$WORKDIR/wordpress" --activate --quiet
+wp plugin activate smart-alloc --path="$WORKDIR/wordpress" --quiet
+wp plugin check smart-alloc --path="$WORKDIR/wordpress" "$@"

--- a/composer.json
+++ b/composer.json
@@ -30,9 +30,13 @@
         }
     },
     "scripts": {
-        "lint": "phpcs --standard=phpcs.xml.dist",
-        "test:security": "vendor/bin/phpunit tests/Security && vendor/bin/psalm --no-cache --taint-analysis --show-info=false",
-        "test": "vendor/bin/phpunit",
+        "lint": "phpcs --standard=phpcs.xml.dist -p",
+        "stan": "phpstan analyse",
+        "psalm": "psalm --no-cache --taint-analysis --show-info=false",
+        "test": "phpunit",
+        "test:security": "phpunit --testsuite Security && psalm --no-cache --taint-analysis --show-info=false",
+        "test:e2e": "phpunit --testsuite E2E",
+        "qa": "composer lint && composer psalm && composer test",
         "ci": "composer lint && composer test:security && composer test",
         "build": "rm -rf dist && mkdir dist && VERSION=$(php -r \"include 'smart-alloc.php'; echo SMARTALLOC_VERSION;\") && rsync -a . dist/smartalloc --exclude 'tests' --exclude 'stubs' --exclude 'docs' --exclude 'node_modules' --exclude '.github' --exclude 'dist' && cd dist && zip -r smartalloc-v$VERSION.zip smartalloc && rm -rf smartalloc",
         "dist": "composer lint && composer test:security && composer test && composer build"

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -15,4 +15,5 @@
     <exclude-pattern>vendor/</exclude-pattern>
     <exclude-pattern>tests/</exclude-pattern>
     <exclude-pattern>stubs/</exclude-pattern>
+    <exclude-pattern>docs/</exclude-pattern>
 </ruleset>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,6 +9,12 @@
         <testsuite name="SmartAlloc Test Suite">
             <directory>tests</directory>
         </testsuite>
+        <testsuite name="Security">
+            <directory>tests/Security</directory>
+        </testsuite>
+        <testsuite name="E2E">
+            <directory>tests/E2E</directory>
+        </testsuite>
     </testsuites>
     <coverage>
         <include>

--- a/tests/E2E/ExportSmokeTest.php
+++ b/tests/E2E/ExportSmokeTest.php
@@ -9,6 +9,7 @@ use SmartAlloc\Tests\BaseTestCase;
 final class ExportSmokeTest extends BaseTestCase
 {
     private $oldWpdb;
+    private $oldUploadDir;
 
     protected function setUp(): void
     {
@@ -17,17 +18,25 @@ final class ExportSmokeTest extends BaseTestCase
         $this->oldWpdb = $wpdb;
         $wpdb = new class {
             public $prefix = 'wp_';
+            public $insert_id = 1;
             public function insert($table, $data) { return true; }
             public function get_results($q, $type) { return []; }
             public function prepare($q, ...$a) { return $q; }
             public function query($q) { return true; }
         };
+        $this->oldUploadDir = $GLOBALS['wp_upload_dir_basedir'] ?? null;
+        $GLOBALS['wp_upload_dir_basedir'] = sys_get_temp_dir();
     }
 
     protected function tearDown(): void
     {
         global $wpdb;
         $wpdb = $this->oldWpdb;
+        if ($this->oldUploadDir !== null) {
+            $GLOBALS['wp_upload_dir_basedir'] = $this->oldUploadDir;
+        } else {
+            unset($GLOBALS['wp_upload_dir_basedir']);
+        }
         parent::tearDown();
     }
     public function test_export_creates_file_and_sheets(): void

--- a/tests/Security/WpDebugTest.php
+++ b/tests/Security/WpDebugTest.php
@@ -1,0 +1,15 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class WpDebugTest extends TestCase
+{
+    public function test_wp_debug_and_display_errors(): void
+    {
+        $this->assertTrue(defined('WP_DEBUG') && WP_DEBUG);
+        $this->assertSame('0', ini_get('display_errors'));
+
+        $this->expectException(\ErrorException::class);
+        trigger_error('Notice for testing', E_USER_NOTICE);
+    }
+}


### PR DESCRIPTION
## Summary
- broaden composer QA scripts and CI matrix for multiple PHP/WP versions
- add defensive error handling in test bootstrap and plugin check script
- verify WP_DEBUG behavior with dedicated test

## Testing
- `composer lint`
- `composer psalm`
- `composer test`
- `composer test:security`


------
https://chatgpt.com/codex/tasks/task_e_68a32168fa408321a9f6d659a18cf965