### PR TITLE
Add test foundation helpers

### DIFF
--- a/tests/Helpers/AdminTest.php
+++ b/tests/Helpers/AdminTest.php
@@ -1,0 +1,81 @@
+<?php
+
+use Brain\Monkey\Functions;
+
+if (!function_exists('makeNonce')) {
+    function makeNonce(string $action): string {
+        Functions\when('check_admin_referer')->alias(function (string $expected = '-1', string $query_arg = '_wpnonce') use ($action) {
+            $nonce = $_REQUEST[$query_arg] ?? '';
+            return $expected === $action && $nonce === 'sa-test-nonce';
+        });
+        return 'sa-test-nonce';
+    }
+}
+
+if (!function_exists('withCapability')) {
+    function withCapability(bool $allowed): void {
+        Functions\when('current_user_can')->alias(function (string $cap) use ($allowed) {
+            return $cap === (defined('SMARTALLOC_CAP') ? SMARTALLOC_CAP : 'manage_smartalloc') ? $allowed : false;
+        });
+    }
+}
+
+if (!function_exists('runAdminPost')) {
+    function runAdminPost(string $action, array $post = [], array $get = []): array {
+        $_POST = $post;
+        $_GET = $get;
+        $_REQUEST = array_merge($get, $post);
+
+        $headers = [];
+        $status = 200;
+        $body   = '';
+
+        if (function_exists('stub_wp_redirect')) {
+            stub_wp_redirect(function ($location, $code) use (&$status, &$headers) {
+                $status = $code;
+                $headers[] = 'Location: ' . $location;
+            });
+        }
+
+        if (function_exists('stub_wp_die')) {
+            stub_wp_die(function ($message, $title, $args) use (&$status, &$body) {
+                $status = $args['response'] ?? 500;
+                $body   = is_string($message) ? $message : '';
+            });
+        }
+
+        if (function_exists('stub_header')) {
+            stub_header(function ($header) use (&$headers) {
+                $headers[] = $header;
+            });
+        }
+
+        if (function_exists('do_action')) {
+            do_action('admin_post_' . $action);
+        } elseif (function_exists($cb = 'admin_post_' . $action)) {
+            $cb();
+        }
+
+        return ['status' => $status, 'body' => $body, 'headers' => $headers];
+    }
+}
+
+if (!function_exists('renderPage')) {
+    function renderPage(callable $renderer, array $get = [], array $post = []): string {
+        $_GET = $get;
+        $_POST = $post;
+        $_REQUEST = array_merge($get, $post);
+        ob_start();
+        $renderer();
+        return ob_get_clean();
+    }
+}
+
+if (!class_exists('AdminTest')) {
+    class AdminTest extends \PHPUnit\Framework\TestCase {
+        public function test_placeholder(): void {
+            $this->assertTrue(true);
+        }
+    }
+}
+

--- a/tests/Helpers/EnvReset.php
+++ b/tests/Helpers/EnvReset.php
@@ -1,0 +1,65 @@
+<?php
+
+use Brain\Monkey\Functions;
+
+if (!function_exists('sa_test_freeze_time')) {
+    function sa_test_freeze_time(int $ts): void {
+        Functions\when('time')->justReturn($ts);
+        Functions\when('current_time')->alias(function (string $type = 'mysql') use ($ts) {
+            if ($type === 'timestamp') {
+                return $ts;
+            }
+            $format = $type === 'mysql' ? 'Y-m-d H:i:s' : $type;
+            return gmdate($format, $ts);
+        });
+    }
+}
+
+if (!function_exists('sa_test_unfreeze_time')) {
+    function sa_test_unfreeze_time(): void {
+        Functions\when('time')->passThrough();
+        Functions\when('current_time')->passThrough();
+    }
+}
+
+if (!function_exists('sa_test_seed_rng')) {
+    function sa_test_seed_rng(int $seed = 1337): void {
+        mt_srand($seed);
+        srand($seed);
+    }
+}
+
+if (!function_exists('sa_test_flush_cache')) {
+    function sa_test_flush_cache(): void {
+        if (function_exists('sa_cache_flush')) {
+            sa_cache_flush();
+            return;
+        }
+        if (function_exists('wp_cache_flush')) {
+            wp_cache_flush();
+        }
+    }
+}
+
+if (!function_exists('sa_test_reset_counters')) {
+    function sa_test_reset_counters(): void {
+        global $wpdb;
+        if (!isset($wpdb) || !method_exists($wpdb, 'query') || !method_exists($wpdb, 'prepare')) {
+            return;
+        }
+        $table = $wpdb->prefix . 'smartalloc_counters';
+        $wpdb->query($wpdb->prepare("DELETE FROM {$table} WHERE %d = %d", 1, 1));
+    }
+}
+
+if (!function_exists('sa_test_clear_options')) {
+    function sa_test_clear_options(array $keys): void {
+        if (!function_exists('delete_option')) {
+            return;
+        }
+        foreach ($keys as $key) {
+            delete_option($key);
+        }
+    }
+}
+

--- a/tests/Helpers/HttpTest.php
+++ b/tests/Helpers/HttpTest.php
@@ -1,0 +1,28 @@
+<?php
+
+if (!function_exists('stub_wp_redirect')) {
+    function stub_wp_redirect(callable $collector): void {
+        $GLOBALS['_sa_redirect_collector'] = $collector;
+    }
+}
+
+if (!function_exists('stub_wp_die')) {
+    function stub_wp_die(callable $collector): void {
+        $GLOBALS['_sa_die_collector'] = $collector;
+    }
+}
+
+if (!function_exists('stub_header')) {
+    function stub_header(callable $collector): void {
+        $GLOBALS['_sa_header_collector'] = $collector;
+    }
+}
+
+if (!class_exists('HttpTest')) {
+    class HttpTest extends \PHPUnit\Framework\TestCase {
+        public function test_placeholder(): void {
+            $this->assertTrue(true);
+        }
+    }
+}
+

--- a/tests/Helpers/WpdbSpy.php
+++ b/tests/Helpers/WpdbSpy.php
@@ -1,0 +1,27 @@
+<?php
+
+if (!function_exists('sa_wpdb_spy_start')) {
+    function sa_wpdb_spy_start(): void {
+        global $wpdb;
+        $GLOBALS['_sa_wpdb_start'] = isset($wpdb->queries) ? count($wpdb->queries) : 0;
+    }
+}
+
+if (!function_exists('sa_wpdb_spy_stop')) {
+    function sa_wpdb_spy_stop(): int {
+        global $wpdb;
+        $start = $GLOBALS['_sa_wpdb_start'] ?? 0;
+        $end = isset($wpdb->queries) ? count($wpdb->queries) : 0;
+        return max(0, $end - $start);
+    }
+}
+
+if (!function_exists('sa_wpdb_spy_queries')) {
+    function sa_wpdb_spy_queries(): array {
+        global $wpdb;
+        $start = $GLOBALS['_sa_wpdb_start'] ?? 0;
+        $all = $wpdb->queries ?? [];
+        return array_slice($all, $start);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add EnvReset, AdminTest, HttpTest, and WpdbSpy helpers for tests
- append deterministic foundation block to tests/bootstrap.php

## Testing
- `composer lint`
- `composer psalm`
- `composer test`
- `composer test:security`


------
https://chatgpt.com/codex/tasks/task_e_68a36888f81c832185c9e1911394f3d5