### PR TITLE
Add admin security tests

### DIFF
--- a/tests/Helpers/AdminTest.php
+++ b/tests/Helpers/AdminTest.php
@@ -6,7 +6,13 @@ if (!function_exists('makeNonce')) {
     function makeNonce(string $action): string {
         Functions\when('check_admin_referer')->alias(function (string $expected = '-1', string $query_arg = '_wpnonce') use ($action) {
             $nonce = $_REQUEST[$query_arg] ?? '';
-            return $expected === $action && $nonce === 'sa-test-nonce';
+            if ($expected === $action && $nonce === 'sa-test-nonce') {
+                return true;
+            }
+            if (function_exists('wp_die')) {
+                wp_die('forbidden', '', ['response' => 403]);
+            }
+            return false;
         });
         return 'sa-test-nonce';
     }
@@ -52,7 +58,8 @@ if (!function_exists('runAdminPost')) {
 
         if (function_exists('do_action')) {
             do_action('admin_post_' . $action);
-        } elseif (function_exists($cb = 'admin_post_' . $action)) {
+        }
+        if (function_exists($cb = 'admin_post_' . $action)) {
             $cb();
         }
 

--- a/tests/Security/AdminEscapingTest.php
+++ b/tests/Security/AdminEscapingTest.php
@@ -1,13 +1,84 @@
 <?php
-
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+
+if (!class_exists('wpdb')) {
+    class wpdb {
+        public $prefix = 'wp_';
+        public function prepare($q, ...$a) { return $q; }
+        public function get_results($q, $o = 'OBJECT') { return []; }
+        public function get_var($q) { return null; }
+        public function insert($t, $d) { return true; }
+        public function query($q) { return true; }
+    }
+}
 
 final class AdminEscapingTest extends TestCase
 {
-    public function test_placeholder(): void
+    private $origWpdb;
+
+    protected function setUp(): void
     {
-        $this->markTestSkipped('Security escaping checks require full WP environment');
+        Monkey\setUp();
+        withCapability(true);
+
+        Functions\when('esc_html__')->alias(fn($v) => $v);
+        Functions\when('esc_html')->alias(fn($v) => htmlspecialchars((string) $v, ENT_QUOTES));
+        Functions\when('esc_attr')->alias(fn($v) => htmlspecialchars((string) $v, ENT_QUOTES));
+        Functions\when('__')->alias(fn($v) => $v);
+        Functions\when('esc_url')->alias(fn($v) => $v);
+        Functions\when('settings_fields')->alias(fn() => '');
+        Functions\when('submit_button')->alias(fn() => '');
+        Functions\when('selected')->alias(fn($a, $b, $echo = false) => $a === $b ? 'selected' : '');
+        Functions\when('checked')->alias(fn($a, $b, $echo = false) => $a === $b ? 'checked' : '');
+        Functions\when('admin_url')->alias(fn($p = '') => $p);
+        Functions\when('wp_nonce_field')->alias(fn() => '');
+        Functions\when('wp_nonce_url')->alias(fn($u) => $u);
+        Functions\when('wp_enqueue_script')->alias(fn() => null);
+        Functions\when('wp_enqueue_style')->alias(fn() => null);
+        Functions\when('plugins_url')->alias(fn($p, $f = null) => $p);
+        Functions\when('size_format')->alias(fn($v) => (string) $v);
+        Functions\when('sanitize_textarea_field')->alias(fn($v) => $v);
+        Functions\when('wp_die')->alias(fn() => '');
+
+        global $wpdb;
+        $wpdb = new wpdb();
+    }
+
+    protected function tearDown(): void
+    {
+        global $wpdb;
+        unset($wpdb);
+        Monkey\tearDown();
+    }
+
+    /**
+     * @dataProvider pagesProvider
+     */
+    public function test_page_outputs_are_escaped(callable $renderer): void
+    {
+        $payload = '<img src=x onerror=alert(1)><script>alert(1)</script>';
+        $level = ob_get_level();
+        $html = renderPage($renderer, ['q' => $payload], ['q' => $payload]);
+        while (ob_get_level() > $level) {
+            ob_end_clean();
+        }
+
+        $this->assertStringNotContainsString('<script', $html);
+        $this->assertStringNotContainsString('onerror=', $html);
+        $this->assertStringNotContainsString('<img src=x', $html);
+    }
+
+    public function pagesProvider(): array
+    {
+        return [
+            [[new \SmartAlloc\Admin\Pages\SettingsPage(), 'render']],
+            [[new \SmartAlloc\Admin\Pages\ExportPage(), 'render']],
+            [[new \SmartAlloc\Admin\Pages\ManualReviewPage(), 'render']],
+            [[new \SmartAlloc\Admin\Pages\ReportsPage(), 'render']],
+        ];
     }
 }

--- a/tests/Security/AdminNonceCapabilityTest.php
+++ b/tests/Security/AdminNonceCapabilityTest.php
@@ -1,13 +1,114 @@
 <?php
-
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
+use Brain\Monkey;
+use Brain\Monkey\Functions;
 
 final class AdminNonceCapabilityTest extends TestCase
 {
-    public function test_placeholder(): void
+    private $origWpdb;
+
+    protected function setUp(): void
     {
-        $this->markTestSkipped('Security checks require full WP environment');
+        Monkey\setUp();
+        
+        Functions\when('esc_html__')->alias(fn($v) => $v);
+        Functions\when('esc_html')->alias(fn($v) => $v);
+        Functions\when('esc_attr')->alias(fn($v) => $v);
+        Functions\when('__')->alias(fn($v) => $v);
+        Functions\when('esc_url')->alias(fn($v) => $v);
+        Functions\when('sanitize_textarea_field')->alias(fn($v) => $v);
+        Functions\when('wp_die')->alias(function ($message = '', $title = '', $args = []) {
+            $status = $args['response'] ?? 403;
+            if (isset($GLOBALS['_sa_die_collector'])) {
+                ($GLOBALS['_sa_die_collector'])($message, $title, ['response' => $status]);
+            }
+            return '';
+        });
+        Functions\when('add_query_arg')->alias(fn($a, $u) => $u);
+        Functions\when('admin_url')->alias(fn($p = '') => $p);
+        Functions\when('wp_safe_redirect')->alias(fn($loc, $code = 302) => wp_redirect($loc, $code));
+        Functions\when('wp_checkdate')->alias(fn($m, $d, $y, $t) => true);
+        Functions\when('nocache_headers')->alias(fn() => null);
+        Functions\when('size_format')->alias(fn($v) => (string) $v);
+
+        if (!function_exists('admin_post_smartalloc_reports_csv')) {
+            function admin_post_smartalloc_reports_csv(): void {
+                \SmartAlloc\Admin\Pages\ReportsPage::downloadCsv();
+            }
+        }
+
+        global $wpdb;
+        $this->origWpdb = $wpdb;
+        $wpdb = new class {
+            public $prefix = 'wp_';
+            public function prepare($q, ...$a) { return $q; }
+            public function query($q) { return true; }
+            public function get_results($q, $o = 'OBJECT') { return $GLOBALS['_sa_wpdb_results'] ?? []; }
+            public function get_row($q, $o = 'OBJECT') { return $GLOBALS['_sa_wpdb_row'] ?? null; }
+            public function get_var($q) { return $GLOBALS['_sa_wpdb_var'] ?? null; }
+            public function insert($t, $d) { return true; }
+            public function update($t, $d, $w) { return true; }
+            public function delete($t, $w) { return true; }
+            public function replace($t, $d) { return true; }
+            public function get_charset_collate() { return ''; }
+        };
+    }
+
+    protected function tearDown(): void
+    {
+        global $wpdb;
+        $wpdb = $this->origWpdb;
+        Monkey\tearDown();
+        unset($GLOBALS['_sa_wpdb_row'], $GLOBALS['_sa_wpdb_results'], $GLOBALS['_sa_wpdb_var']);
+    }
+
+    /**
+     * @dataProvider actionsProvider
+     */
+    public function test_rejects_when_nonce_invalid(string $action): void
+    {
+        withCapability(true);
+        $post = $get = [];
+        makeNonce('smartalloc_reports_csv');
+        $get = ['smartalloc_reports_nonce' => 'BAD'];
+        $res = runAdminPost($action, $post, $get);
+        $this->assertSame(403, $res['status']);
+    }
+
+    /**
+     * @dataProvider actionsProvider
+     */
+    public function test_rejects_when_capability_missing(string $action): void
+    {
+        withCapability(false);
+        $post = $get = [];
+        $nonce = makeNonce('smartalloc_reports_csv');
+        $get = ['smartalloc_reports_nonce' => $nonce];
+        $res = runAdminPost($action, $post, $get);
+        $this->assertSame(403, $res['status']);
+    }
+
+    /**
+     * @dataProvider actionsProvider
+     */
+    public function test_accepts_with_valid_nonce_and_capability(string $action): void
+    {
+        withCapability(true);
+        $post = $get = [];
+        $nonce = makeNonce('smartalloc_reports_csv');
+        $get = ['smartalloc_reports_nonce' => $nonce];
+        $GLOBALS['_sa_wpdb_results'] = [];
+        $GLOBALS['_sa_wpdb_var'] = 0;
+        $res = runAdminPost($action, $post, $get);
+        $this->assertContains($res['status'], [200, 302]);
+    }
+
+    public function actionsProvider(): array
+    {
+        return [
+            ['smartalloc_reports_csv'],
+        ];
     }
 }


### PR DESCRIPTION
## Summary
- add admin nonce/capability tests for reports CSV action
- add HTML escaping tests for key admin pages
- extend test helpers for nonce checking and admin_post harness

## Testing
- `composer lint`
- `composer psalm`
- `composer test`
- `composer test:security`


------
https://chatgpt.com/codex/tasks/task_e_68a36ba72a44832187910725cc9bc7a4