### PR TITLE
Add CSV and XLSX formula injection tests

### DIFF
--- a/tests/Security/CsvInjectionTest.php
+++ b/tests/Security/CsvInjectionTest.php
@@ -1,0 +1,181 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once dirname(__DIR__) . '/Support/DataProviders.php';
+
+final class CsvInjectionTest extends TestCase
+{
+    /**
+     * Run CSV export with given value.
+     */
+    private function runExport(string $value): array
+    {
+        withCapability(true);
+        $nonce = makeNonce('smartalloc_reports_csv');
+        if (!function_exists('admin_post_smartalloc_reports_csv')) {
+            function admin_post_smartalloc_reports_csv(): void
+            {
+                \SmartAlloc\Admin\Pages\ReportsPage::downloadCsv();
+            }
+        }
+        $row = [
+            'date' => $value,
+            'allocated' => 0,
+            'manual' => 0,
+            'reject' => 0,
+            'fuzzy_auto_rate' => 0,
+            'fuzzy_manual_rate' => 0,
+            'capacity_used' => 0,
+        ];
+        $hQuery = \Patchwork\replace('SmartAlloc\\Http\\Rest\\MetricsController::query', function (array $filters) use ($row) {
+            return ['rows' => [$row], 'total' => []];
+        });
+        $hHeader = \Patchwork\replace('header', function ($header) {
+            if (isset($GLOBALS['_sa_header_collector'])) {
+                ($GLOBALS['_sa_header_collector'])($header);
+            }
+        });
+        $res = runAdminPost('smartalloc_reports_csv', [], ['smartalloc_reports_nonce' => $nonce]);
+        \Patchwork\restore($hQuery);
+        \Patchwork\restore($hHeader);
+        return $res;
+    }
+
+    /**
+     * @dataProvider dangerousValuesProvider
+     */
+    public function test_csv_escapes_leading_formula_tokens_or_skip(string $input): void
+    {
+        $res = $this->runExport($input);
+        $headers = implode("\n", $res['headers']);
+        $this->assertStringContainsString('Content-Type: text/csv', $headers);
+        $this->assertStringContainsString('Content-Disposition: attachment', $headers);
+
+        $fh = fopen('php://memory', 'r+');
+        fwrite($fh, $res['body']);
+        rewind($fh);
+        fgetcsv($fh); // header
+        $data = fgetcsv($fh) ?: [];
+        fclose($fh);
+        $cell = $data[0] ?? '';
+        $trimmed = ltrim($cell, " \t\r\n");
+        $first = $trimmed[0] ?? '';
+        if (in_array($first, riskyLeadingTokens(), true)) {
+            $this->markTestSkipped('CSV formula-escaping not implemented yet — TODO: escape [=+ - @] incl. leading whitespace');
+        }
+        $this->assertFalse(in_array($first, riskyLeadingTokens(), true));
+    }
+
+    /**
+     * @return array<int,array{string}>
+     */
+    public static function dangerousValuesProvider(): array
+    {
+        return [
+            ['=1+1'],
+            ['+SUM(A1)'],
+            ['-1'],
+            ['@cmd'],
+            [' =1'],
+            ["\t+1"],
+            ["\n-1"],
+            ["\r@cmd"],
+        ];
+    }
+
+    /**
+     * @dataProvider safeValuesProvider
+     */
+    public function test_csv_preserves_plain_text_not_formulas(string $input): void
+    {
+        $res = $this->runExport($input);
+        $fh = fopen('php://memory', 'r+');
+        fwrite($fh, $res['body']);
+        rewind($fh);
+        fgetcsv($fh); // header
+        $data = fgetcsv($fh) ?: [];
+        fclose($fh);
+        $cell = $data[0] ?? '';
+        $this->assertSame($input, $cell);
+    }
+
+    /**
+     * @return array<int,array{string}>
+     */
+    public static function safeValuesProvider(): array
+    {
+        return array_map(fn(string $s) => [$s], safeTextSamples());
+    }
+
+    /**
+     * @dataProvider embeddedValuesProvider
+     */
+    public function test_csv_embedded_newlines_and_tabs_are_safely_quoted(string $input): void
+    {
+        $res = $this->runExport($input);
+        $fh = fopen('php://memory', 'r+');
+        fwrite($fh, $res['body']);
+        rewind($fh);
+        fgetcsv($fh); // header
+        $data = fgetcsv($fh);
+        $extra = fgetcsv($fh);
+        fclose($fh);
+        if ($extra !== false) {
+            $this->markTestSkipped('CSV formula-escaping not implemented yet — TODO: quote fields with embedded newlines/tabs');
+        }
+        $cell = $data[0] ?? '';
+        $trimmed = ltrim($cell, " \t\r\n");
+        if (in_array($trimmed[0] ?? '', riskyLeadingTokens(), true)) {
+            $this->markTestSkipped('CSV formula-escaping not implemented yet — TODO: escape [=+ - @] after embedded whitespace');
+        }
+        $this->assertSame($input, $cell);
+    }
+
+    /**
+     * @return array<int,array{string}>
+     */
+    public static function embeddedValuesProvider(): array
+    {
+        return [
+            ["line1\n=cmd"],
+            ["\t+SUM(A1)"],
+        ];
+    }
+
+    /**
+     * @dataProvider apostropheValuesProvider
+     */
+    public function test_csv_values_starting_with_apostrophe_are_not_double_escaped(string $input): void
+    {
+        $res = $this->runExport($input);
+        $fh = fopen('php://memory', 'r+');
+        fwrite($fh, $res['body']);
+        rewind($fh);
+        fgetcsv($fh); // header
+        $data = fgetcsv($fh) ?: [];
+        fclose($fh);
+        $cell = $data[0] ?? '';
+        $this->assertSame($input, $cell);
+    }
+
+    /**
+     * @return array<int,array{string}>
+     */
+    public static function apostropheValuesProvider(): array
+    {
+        return [
+            ["'=1+1"],
+            ["'normal"],
+        ];
+    }
+
+    public function test_csv_does_not_emit_user_controlled_sep_line(): void
+    {
+        $res = $this->runExport('sep=,');
+        $firstLine = strtok($res['body'], "\r\n");
+        $this->assertNotSame(0, strpos($firstLine, 'sep='));
+    }
+}
+

--- a/tests/Security/SpreadsheetInjectionTest.php
+++ b/tests/Security/SpreadsheetInjectionTest.php
@@ -1,0 +1,143 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use PhpOffice\PhpSpreadsheet\Cell\DataType;
+use PhpOffice\PhpSpreadsheet\IOFactory;
+use SmartAlloc\Infra\Export\ExcelExporter;
+use SmartAlloc\Infra\Export\CountersRepository;
+
+require_once dirname(__DIR__) . '/Support/DataProviders.php';
+
+final class SpreadsheetInjectionTest extends TestCase
+{
+    private function createExporter(): ExcelExporter
+    {
+        $wpdb = new class {
+            public $prefix = 'wp_';
+        };
+        $configPath = dirname(__DIR__, 2) . '/SmartAlloc_Exporter_Config_v1.json';
+        $repo = new class extends CountersRepository {
+            public function __construct() {}
+            public function getNextCounters(): array { return [1, 1]; }
+        };
+        return new ExcelExporter($wpdb, $configPath, sys_get_temp_dir(), $repo);
+    }
+
+    /**
+     * @dataProvider dangerousValuesProvider
+     */
+    public function test_xlsx_escapes_leading_formula_tokens_or_skip(string $input): void
+    {
+        if (!class_exists(\PhpOffice\PhpSpreadsheet\Spreadsheet::class)) {
+            $this->markTestSkipped('PhpSpreadsheet not installed');
+        }
+        $exporter = $this->createExporter();
+        $result = $exporter->exportFromRows([
+            ['id' => 1, 'status' => 'rejected', 'reason_code' => $input],
+        ]);
+        $path = $result['path'];
+        try {
+            $this->assertFileExists($path);
+            $this->assertGreaterThan(0, filesize($path));
+            $spreadsheet = IOFactory::load($path);
+            $sheet = $spreadsheet->getSheetByName('Errors');
+            $cell = $sheet?->getCell('C2');
+            $value = (string) $cell->getValue();
+            $trimmed = ltrim($value, " \t\r\n");
+            $first = $trimmed[0] ?? '';
+            if ($cell->getDataType() !== DataType::TYPE_STRING || in_array($first, riskyLeadingTokens(), true)) {
+                $this->markTestSkipped('XLSX formula-escaping verification not implemented yet — TODO: set explicit string type or prefix');
+            }
+            $this->assertSame(DataType::TYPE_STRING, $cell->getDataType());
+            $this->assertFalse(in_array($first, riskyLeadingTokens(), true));
+        } finally {
+            unlink($path);
+        }
+    }
+
+    /**
+     * @return array<int,array{string}>
+     */
+    public static function dangerousValuesProvider(): array
+    {
+        return [
+            ['=1+1'],
+            ['+SUM(A1)'],
+            ['-1'],
+            ['@cmd'],
+            [' =1'],
+            ["\t+1"],
+            ["\n-1"],
+            ["\r@cmd"],
+        ];
+    }
+
+    /**
+     * @dataProvider safeValuesProvider
+     */
+    public function test_xlsx_preserves_plain_text_not_formulas(string $input): void
+    {
+        if (!class_exists(\PhpOffice\PhpSpreadsheet\Spreadsheet::class)) {
+            $this->markTestSkipped('PhpSpreadsheet not installed');
+        }
+        $exporter = $this->createExporter();
+        $result = $exporter->exportFromRows([
+            ['id' => 1, 'status' => 'rejected', 'reason_code' => $input],
+        ]);
+        $path = $result['path'];
+        try {
+            $spreadsheet = IOFactory::load($path);
+            $sheet = $spreadsheet->getSheetByName('Errors');
+            $cell = $sheet?->getCell('C2');
+            $this->assertSame($input, (string) $cell->getValue());
+            $this->assertSame(DataType::TYPE_STRING, $cell->getDataType());
+        } finally {
+            unlink($path);
+        }
+    }
+
+    /**
+     * @return array<int,array{string}>
+     */
+    public static function safeValuesProvider(): array
+    {
+        return array_map(fn(string $s) => [$s], safeTextSamples());
+    }
+
+    /**
+     * @dataProvider apostropheValuesProvider
+     */
+    public function test_xlsx_apostrophe_inputs_not_double_escaped(string $input): void
+    {
+        if (!class_exists(\PhpOffice\PhpSpreadsheet\Spreadsheet::class)) {
+            $this->markTestSkipped('PhpSpreadsheet not installed');
+        }
+        $exporter = $this->createExporter();
+        $result = $exporter->exportFromRows([
+            ['id' => 1, 'status' => 'rejected', 'reason_code' => $input],
+        ]);
+        $path = $result['path'];
+        try {
+            $spreadsheet = IOFactory::load($path);
+            $sheet = $spreadsheet->getSheetByName('Errors');
+            $cell = $sheet?->getCell('C2');
+            $this->assertSame($input, (string) $cell->getValue());
+            $this->assertSame(DataType::TYPE_STRING, $cell->getDataType());
+        } finally {
+            unlink($path);
+        }
+    }
+
+    /**
+     * @return array<int,array{string}>
+     */
+    public static function apostropheValuesProvider(): array
+    {
+        return [
+            ["'=1+1"],
+            ["'normal"],
+        ];
+    }
+}
+

--- a/tests/Support/DataProviders.php
+++ b/tests/Support/DataProviders.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+if (!function_exists('riskyLeadingTokens')) {
+    function riskyLeadingTokens(): array {
+        return ['=', '+', '-', '@'];
+    }
+}
+
+if (!function_exists('leadingWhitespace')) {
+    function leadingWhitespace(): array {
+        return ['', ' ', "\t", "\n", "\r"];
+    }
+}
+
+if (!function_exists('safeTextSamples')) {
+    function safeTextSamples(): array {
+        return ['foo=bar', 'note -1 item', 'email@domain.com'];
+    }
+}
+


### PR DESCRIPTION
## Summary
- add helper data providers for common CSV/Excel injection scenarios
- cover CSV exports for formula injection, plain text preservation, and separators
- add XLSX tests verifying risky prefixes are escaped or skipped

## Testing
- `composer lint`
- `composer psalm`
- `composer test`
- `composer test:security`


------
https://chatgpt.com/codex/tasks/task_e_68a3ce4ce96c8321a8dbb1f21a019506