### PR TITLE
feat(logging): add redactor and correlation id

### DIFF
--- a/src/Http/Rest/HealthController.php
+++ b/src/Http/Rest/HealthController.php
@@ -54,13 +54,19 @@ final class HealthController
         $version        = (string) get_option('smartalloc_version');
         $last_migration = get_option('smartalloc_last_migration');
 
+        $notes = array();
+        if (class_exists('SmartAlloc\\Infra\\Logging\\Logger')) {
+            $req = \SmartAlloc\Infra\Logging\Logger::requestId();
+            $notes['request'] = substr(hash('sha256', $req), 0, 8);
+        }
+
         $response = array(
             'ok'             => $db_ok && $cache_ok,
             'version'        => $version ?: 'unknown',
             'db'             => $db_ok,
             'cache'          => $cache_ok,
             'last_migration' => $last_migration ?: null,
-            'notes'          => array(),
+            'notes'          => $notes,
         );
 
         return new WP_REST_Response($response, 200);

--- a/src/Infra/Logging/Logger.php
+++ b/src/Infra/Logging/Logger.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SmartAlloc\Infra\Logging;
+
+use Psr\Log\LoggerInterface;
+use Psr\Log\LoggerTrait;
+
+/**
+ * PSR-3 style logger that redacts context and adds correlation ids.
+ */
+final class Logger implements LoggerInterface
+{
+    use LoggerTrait;
+
+    /** @var callable */
+    private $writer;
+    private Redactor $redactor;
+
+    /** @var array<int,array<string,mixed>> Records for testing */
+    public array $records = [];
+
+    private static ?string $requestId = null;
+
+    public function __construct(?callable $writer = null, ?Redactor $redactor = null)
+    {
+        $this->writer = $writer ?? 'error_log';
+        $this->redactor = $redactor ?? new Redactor();
+    }
+
+    /**
+     * @param mixed $level
+     * @param string $message
+     * @param array<string,mixed> $context
+     */
+    public function log($level, $message, array $context = []): void
+    {
+        $context = $this->redactor->redact($context);
+        $level = strtoupper((string) $level);
+        $record = ['level' => $level, 'message' => $message, 'context' => $context];
+        $this->records[] = $record;
+        ($this->writer)(sprintf('[SmartAlloc][%s] %s %s', $level, $message, wp_json_encode($context)));
+    }
+
+    /**
+     * Return per-request correlation id.
+     */
+    public static function requestId(): string
+    {
+        if (self::$requestId === null) {
+            self::$requestId = bin2hex(random_bytes(8));
+        }
+        return self::$requestId;
+    }
+}

--- a/src/Infra/Logging/Redactor.php
+++ b/src/Infra/Logging/Redactor.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SmartAlloc\Infra\Logging;
+
+/**
+ * Utility to remove personally identifiable information from log context.
+ */
+final class Redactor
+{
+    /**
+     * Redact sensitive values and append correlation id.
+     *
+     * @param array<string,mixed> $context
+     * @return array<string,mixed>
+     */
+    public function redact(array $context): array
+    {
+        $allowed = ['entry_id','mentor_id','reviewer_id','status','count','counts','timing','duration_ms'];
+        $out = [];
+        foreach ($context as $key => $value) {
+            if (in_array($key, $allowed, true)) {
+                $out[$key] = $value;
+                continue;
+            }
+            if (in_array($key, ['mobile','national_id','postal_code'], true)) {
+                $out[$key] = $this->mask((string) $value);
+            }
+        }
+        $out['request_id'] = Logger::requestId();
+        return $out;
+    }
+
+    private function mask(string $value): string
+    {
+        $len = strlen($value);
+        if ($len <= 3) {
+            return str_repeat('*', $len);
+        }
+        return substr($value, 0, 3) . str_repeat('*', $len - 3);
+    }
+}

--- a/src/Services/Logging.php
+++ b/src/Services/Logging.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace SmartAlloc\Services;
 
 use SmartAlloc\Contracts\LoggerInterface;
+use SmartAlloc\Infra\Logging\Redactor;
 
 /**
  * Logging service with data masking for sensitive information
@@ -65,20 +66,8 @@ final class Logging implements LoggerInterface
      */
     private function maskSensitiveData(array $context): array
     {
-        $sensitiveKeys = ['national_id', 'phone', 'mobile', 'email', 'password'];
-        
-        foreach ($sensitiveKeys as $key) {
-            if (isset($context[$key])) {
-                $value = (string) $context[$key];
-                if (strlen($value) > 3) {
-                    $context[$key] = substr($value, 0, 3) . '***';
-                } else {
-                    $context[$key] = '***';
-                }
-            }
-        }
-        
-        return $context;
+        $redactor = new Redactor();
+        return $redactor->redact($context);
     }
 
     /**

--- a/tests/Http/HealthEndpointTest.php
+++ b/tests/Http/HealthEndpointTest.php
@@ -63,5 +63,7 @@ final class HealthEndpointTest extends BaseTestCase
         $this->assertTrue($data['cache']);
         $this->assertSame('1.2.3', $data['version']);
         $this->assertSame('2025-08-18T09:00:00Z', $data['last_migration']);
+        $this->assertArrayHasKey('request', $data['notes']);
+        $this->assertSame(8, strlen($data['notes']['request']));
     }
 }

--- a/tests/Infra/Logging/LoggerTest.php
+++ b/tests/Infra/Logging/LoggerTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use SmartAlloc\Infra\Log\LoggerWp;
+use SmartAlloc\Infra\Logging\Logger;
 use SmartAlloc\Tests\BaseTestCase;
 
 final class LoggerTest extends BaseTestCase
@@ -10,7 +10,7 @@ final class LoggerTest extends BaseTestCase
     public function test_redaction_and_level_routing(): void
     {
         $lines = [];
-        $logger = new LoggerWp(function (string $line) use (&$lines): void {
+        $logger = new Logger(function (string $line) use (&$lines): void {
             $lines[] = $line;
         });
 


### PR DESCRIPTION
## Summary
- add PSR-3 style logger with context redaction and request correlation ids
- expose hashed request id in health check notes
- cover logging and health correlation with tests

## Testing
- `composer lint`
- `composer test:security`
- `composer test`
- `composer ci`


------
https://chatgpt.com/codex/tasks/task_e_68a3d182865883218b6f2d36f7d4ec08