### PR TITLE
Repair duplicate allocations and add e2e tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,15 @@ composer test
 vendor/bin/phpunit tests/DigitsNormalizerTest.php
 ```
 
+### End-to-End Tests
+
+Playwright tests are optional in CI. To run them locally:
+
+```bash
+npm run e2e:install
+npm run test:e2e
+```
+
 ### Code Quality
 
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,76 @@
+{
+  "name": "SmartAlloc",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "@playwright/test": "^1.41.2",
+        "playwright": "^1.41.2"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.54.2.tgz",
+      "integrity": "sha512-A+znathYxPf+72riFd1r1ovOLqsIIB0jKIoPjyK2kqEIe30/6jF6BC7QNluHuwUmsD2tv1XZVugN8GqfTMOxsA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.54.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.54.2.tgz",
+      "integrity": "sha512-Hu/BMoA1NAdRUuulyvQC0pEqZ4vQbGfn8f7wPXcnqQmM+zct9UliKxsIkLNmz/ku7LElUNqmaiv1TG/aL5ACsw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.54.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.2.tgz",
+      "integrity": "sha512-n5r4HFbMmWsB4twG7tJLDN9gmBUeSPcsBZiWSE4DnYz9mJMAFqr2ID7+eGC9kpEnxExJ1epttwR59LEWCk8mtA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,9 +1,11 @@
 {
   "private": true,
   "devDependencies": {
-    "playwright": "^1.41.2"
+    "playwright": "^1.41.2",
+    "@playwright/test": "^1.41.2"
   },
   "scripts": {
-    "test:e2e": "playwright test"
+    "test:e2e": "playwright test -c e2e/playwright.config.ts",
+    "e2e:install": "npx playwright install --with-deps"
   }
 }

--- a/src/Http/RestController.php
+++ b/src/Http/RestController.php
@@ -253,6 +253,7 @@ final class RestController
                     'message' => 'Mentor capacity exceeded'
                 ], 409);
             }
+            $metrics->inc('review_duplicate_blocked');
             delete_transient('smartalloc_metrics_cache');
             return new WP_REST_Response([
                 'ok' => false,
@@ -366,6 +367,8 @@ final class RestController
         delete_transient($lockKey);
 
         if (!$ok) {
+            $metrics = $this->container->get(Metrics::class);
+            $metrics->inc('review_duplicate_blocked');
             delete_transient('smartalloc_metrics_cache');
             return new WP_REST_Response([
                 'ok' => false,

--- a/tests/Http/ManualReviewEndpointTest.php
+++ b/tests/Http/ManualReviewEndpointTest.php
@@ -119,7 +119,7 @@ final class ManualReviewEndpointTest extends BaseTestCase
         $res2 = $m->invoke($controller,$req);
         $this->assertSame(409,$res2->get_status());
         $this->assertSame('duplicate_allocation', $res2->get_data()['code']);
-        $this->assertSame(['review_defer_total'], $metrics->inc);
+        $this->assertSame(['review_defer_total','review_duplicate_blocked'], $metrics->inc);
     }
 
     public function test_lock_returns_409(): void
@@ -156,6 +156,7 @@ final class ManualReviewEndpointTest extends BaseTestCase
         $res = $m->invoke($controller,$req);
         $this->assertSame(409,$res->get_status());
         $this->assertSame('duplicate_allocation',$res->get_data()['code']);
+        $this->assertSame(['review_duplicate_blocked'], $metrics->inc);
     }
 }
 


### PR DESCRIPTION
## Summary
- pre-migrate cleanup removes duplicate rows before adding unique index
- expose duplicate allocation blocks via metrics and tests
- wire Playwright scripts for optional E2E runs and document usage

## Testing
- `composer lint`
- `composer psalm`
- `composer test:security`
- `composer test`
- `npm run test:e2e` *(fails: Executable doesn't exist at .../headless_shell; run npx playwright install)*

------
https://chatgpt.com/codex/tasks/task_e_68a41a8b0cdc83218eb16634ed7bfb02