### PR TITLE
Add E2E environment and negative path coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,5 +66,5 @@ jobs:
         with:
           node-version: 18
       - run: npm ci || npm install
-      - run: npx playwright install --with-deps || true
+      - run: npm run e2e:install || true
       - run: npm run test:e2e || true

--- a/README.md
+++ b/README.md
@@ -187,11 +187,21 @@ vendor/bin/phpunit tests/DigitsNormalizerTest.php
 
 ### End-to-End Tests
 
-Playwright tests are optional in CI. To run them locally:
+Playwright tests run in an optional CI job (`continue-on-error: true`). To exercise them locally:
+
+1. Start a WordPress test stack and seed data:
 
 ```bash
-npm run e2e:install
-npm run test:e2e
+cd e2e
+docker compose up -d
+docker compose run --rm wordpress bash e2e/setup.sh
+```
+
+2. Install browsers and execute tests (override `BASE_URL` if needed):
+
+```bash
+BASE_URL=http://localhost:8080 npm run e2e:install
+BASE_URL=http://localhost:8080 npm run test:e2e
 ```
 
 ### Code Quality

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -1,0 +1,25 @@
+version: '3.9'
+services:
+  db:
+    image: mysql:8.0
+    restart: always
+    environment:
+      MYSQL_DATABASE: wordpress
+      MYSQL_USER: wordpress
+      MYSQL_PASSWORD: wordpress
+      MYSQL_ROOT_PASSWORD: root
+    command: --default-authentication-plugin=mysql_native_password
+  wordpress:
+    image: wordpress:6.3-php8.1
+    restart: always
+    depends_on:
+      - db
+    ports:
+      - "8080:80"
+    environment:
+      WORDPRESS_DB_HOST: db
+      WORDPRESS_DB_USER: wordpress
+      WORDPRESS_DB_PASSWORD: wordpress
+      WORDPRESS_DB_NAME: wordpress
+    volumes:
+      - ..:/var/www/html/wp-content/plugins/smart-alloc

--- a/e2e/seed.php
+++ b/e2e/seed.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Seed sample data for E2E manual review tests.
+ */
+
+global $wpdb;
+$candidates = json_encode([
+    ['mentor_id' => 1, 'used' => 0, 'capacity' => 1],
+]);
+$wpdb->query(
+    $wpdb->prepare(
+        "INSERT INTO {$wpdb->prefix}salloc_allocations (entry_id,status,candidates) VALUES (%d,%s,%s)",
+        1,
+        'manual',
+        $candidates
+    )
+);

--- a/e2e/setup.sh
+++ b/e2e/setup.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+# Wait for database to be ready
+until wp db check >/dev/null 2>&1; do
+  echo 'Waiting for database...'
+  sleep 3
+done
+
+wp core install \
+  --url="http://localhost:8080" \
+  --title="SmartAlloc Test" \
+  --admin_user=admin \
+  --admin_password=admin \
+  --admin_email=admin@example.com \
+  --skip-email
+
+wp user create editor editor@example.com --role=editor --user_pass=editor
+
+wp plugin activate smart-alloc
+wp smartalloc upgrade
+
+wp eval-file /var/www/html/wp-content/plugins/smart-alloc/e2e/seed.php

--- a/e2e/tests/manual-review.spec.ts
+++ b/e2e/tests/manual-review.spec.ts
@@ -38,31 +38,83 @@ test.describe('SmartAlloc Manual Review', () => {
   test('capacity full blocked', async ({ page }) => {
     await login(page, admin);
     await page.route('**/smartalloc/v1/review/*/approve', route => {
-      route.fulfill({ status:409, body: JSON.stringify({ ok:false, code:'capacity_exceeded', message:'Capacity exceeded' }) });
+      route.fulfill({
+        status: 409,
+        body: JSON.stringify({ ok: false, code: 'capacity_exceeded', message: 'Capacity exceeded' })
+      });
     });
     await page.goto('/wp-admin/admin.php?page=smartalloc-manual-review');
     page.on('dialog', d => d.accept());
     const btn = page.locator('.smartalloc-approve').first();
-    await btn.click();
+    const [resp] = await Promise.all([
+      page.waitForResponse(/smartalloc\/v1\/review\/.*\/approve/),
+      btn.click()
+    ]);
+    const data = await resp.json();
+    expect(data.ok).toBe(false);
+    expect(data.code).toBe('capacity_exceeded');
     await expect(page.locator('#smartalloc-notice')).toContainText('Capacity exceeded');
   });
 
   test('lock active blocked', async ({ page }) => {
     await login(page, admin);
     await page.route('**/smartalloc/v1/review/*/approve', route => {
-      route.fulfill({ status:409, body: JSON.stringify({ ok:false, code:'entry_locked', message:'Entry locked' }) });
+      route.fulfill({
+        status: 409,
+        body: JSON.stringify({ ok: false, code: 'entry_locked', message: 'Entry locked' })
+      });
     });
     await page.goto('/wp-admin/admin.php?page=smartalloc-manual-review');
     page.on('dialog', d => d.accept());
     const btn = page.locator('.smartalloc-approve').first();
-    await btn.click();
+    const [resp] = await Promise.all([
+      page.waitForResponse(/smartalloc\/v1\/review\/.*\/approve/),
+      btn.click()
+    ]);
+    const data = await resp.json();
+    expect(data.ok).toBe(false);
+    expect(data.code).toBe('entry_locked');
     await expect(page.locator('#smartalloc-notice')).toContainText('Entry locked');
+  });
+
+  test('duplicate allocation blocked', async ({ page }) => {
+    await login(page, admin);
+    await page.route('**/smartalloc/v1/review/*/approve', route => {
+      route.fulfill({
+        status: 409,
+        body: JSON.stringify({ ok: false, code: 'duplicate_allocation', message: 'Duplicate' })
+      });
+    });
+    await page.goto('/wp-admin/admin.php?page=smartalloc-manual-review');
+    page.on('dialog', d => d.accept());
+    const btn = page.locator('.smartalloc-approve').first();
+    const [resp] = await Promise.all([
+      page.waitForResponse(/smartalloc\/v1\/review\/.*\/approve/),
+      btn.click()
+    ]);
+    const data = await resp.json();
+    expect(data.ok).toBe(false);
+    expect(data.code).toBe('duplicate_allocation');
+    await expect(page.locator('#smartalloc-notice')).toContainText('Duplicate');
   });
 
   test('non-admin denied', async ({ page }) => {
     await login(page, editor);
     await page.goto('/wp-admin/admin.php?page=smartalloc-manual-review');
     await expect(page).toHaveURL(/denied/);
+    const res = await page.request.get('/wp-json/smartalloc/v1/review/1/approve');
+    expect(res.status()).toBe(403);
+  });
+
+  test('bulk buttons keyboard order', async ({ page }) => {
+    await login(page, admin);
+    await page.goto('/wp-admin/admin.php?page=smartalloc-manual-review');
+    await page.locator('#smartalloc-bulk-approve').focus();
+    await expect(page.locator('#smartalloc-bulk-approve')).toBeFocused();
+    await page.keyboard.press('Tab');
+    await expect(page.locator('#smartalloc-bulk-reject')).toBeFocused();
+    await page.keyboard.press('Tab');
+    await expect(page.locator('#smartalloc-bulk-defer')).toBeFocused();
   });
 });
 


### PR DESCRIPTION
## Summary
- provide docker-compose WordPress stack with seeded admin data for manual review
- exercise capacity, lock and duplicate allocation errors in Playwright with keyboard a11y smoke test
- document local E2E workflow and wire optional CI job to npm scripts

## Testing
- `composer lint`
- `composer psalm`
- `composer test:security`
- `composer test`
- `npm run test:e2e` *(fails: browsers not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68a420debbd08321b6f2875a11df0446