### PR TITLE
Add composite E2E runner and CI hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,5 +66,5 @@ jobs:
         with:
           node-version: 18
       - run: npm ci || npm install
-      - run: npm run e2e:install || true
-      - run: npm run test:e2e || true
+      - run: npx playwright install --with-deps
+      - run: npm run e2e:all || echo "Hint: WP healthcheck failed"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,16 +10,8 @@ jobs:
         with: { node-version: 20 }
       - name: Install deps
         run: npm ci
-      - name: Start Docker stack
-        run: docker compose up -d
       - name: Install Playwright browsers
         run: npx playwright install --with-deps
-      - name: Wait for WordPress
-        run: node e2e/scripts/wait-for-wp.js
-        env: { WP_BASE_URL: http://localhost:8080 }
-      - name: Seed data
-        run: bash e2e/scripts/seed.sh
-        env: { WP_BASE_URL: http://localhost:8080 }
       - name: Run E2E (optional)
-        run: npm run test:e2e
+        run: npm run e2e:all || echo "Hint: WP healthcheck failed"
         env: { WP_BASE_URL: http://localhost:8080 }

--- a/README.md
+++ b/README.md
@@ -190,12 +190,14 @@ vendor/bin/phpunit tests/DigitsNormalizerTest.php
 Playwright tests run in an optional CI job (`continue-on-error: true`). To run them locally:
 
 ```bash
-npm run e2e:install
-npm run e2e:up
-export WP_BASE_URL=http://localhost:8080
-npm run e2e:wait
-npm run e2e:seed
-npm run test:e2e
+npm run e2e:install # install browsers once
+npm run e2e:all
+```
+
+If tests fail with ECONNREFUSED, run:
+
+```bash
+npm run e2e:up && npm run e2e:wait && npm run e2e:seed
 ```
 
 ### Code Quality

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,3 +1,15 @@
 import { defineConfig } from '@playwright/test';
+
 const baseURL = process.env.WP_BASE_URL || 'http://localhost:8080';
-export default defineConfig({ use: { baseURL }, timeout: 60000 });
+
+export default defineConfig({
+  retries: 1,
+  use: {
+    baseURL,
+    actionTimeout: 15000,
+    navigationTimeout: 30000,
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+    trace: 'on-first-retry',
+  },
+});

--- a/e2e/scripts/wait-for-wp.js
+++ b/e2e/scripts/wait-for-wp.js
@@ -1,8 +1,31 @@
 const http = require('http');
 const url = process.env.WP_BASE_URL || 'http://localhost:8080';
 const deadline = Date.now() + 120000;
-(function ping(){
-  http.get(url, res => res.statusCode === 200 ? process.exit(0)
-    : Date.now()<deadline ? setTimeout(ping, 1500) : process.exit(1))
-    .on('error', ()=> Date.now()<deadline ? setTimeout(ping,1500) : process.exit(1));
-})();
+
+function ping() {
+  http
+    .get(url, (res) => {
+      if (res.statusCode === 200) {
+        process.exit(0);
+      }
+      retry();
+    })
+    .on('error', (err) => {
+      if (['ENOTFOUND', 'ECONNREFUSED'].includes(err.code)) {
+        console.error(`Cannot reach ${url}: ${err.code}. Is the stack running?`);
+        process.exit(1);
+      }
+      retry();
+    });
+}
+
+function retry() {
+  if (Date.now() < deadline) {
+    setTimeout(ping, 1500);
+  } else {
+    console.error(`Timed out waiting for ${url}`);
+    process.exit(1);
+  }
+}
+
+ping();

--- a/e2e/tests/export.spec.ts
+++ b/e2e/tests/export.spec.ts
@@ -11,7 +11,15 @@ async function login(page, creds) {
   await page.click('#wp-submit');
 }
 
-test.describe('SmartAlloc Admin Export', () => {
+test.describe('@e2e-review SmartAlloc Admin Export', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.context().clearCookies();
+    await page.goto('/');
+    await page.evaluate(() => {
+      localStorage.clear();
+      sessionStorage.clear();
+    });
+  });
   test('happy path generates file', async ({ page }) => {
     await login(page, admin);
     await page.goto('/wp-admin/admin.php?page=smartalloc-export');

--- a/e2e/tests/manual-review.spec.ts
+++ b/e2e/tests/manual-review.spec.ts
@@ -10,7 +10,15 @@ async function login(page, creds) {
   await page.click('#wp-submit');
 }
 
-test.describe('SmartAlloc Manual Review', () => {
+test.describe('@e2e-review SmartAlloc Manual Review', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.context().clearCookies();
+    await page.goto('/');
+    await page.evaluate(() => {
+      localStorage.clear();
+      sessionStorage.clear();
+    });
+  });
   test('approve flow shows success', async ({ page }) => {
     await login(page, admin);
     await page.goto('/wp-admin/admin.php?page=smartalloc-manual-review');

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "e2e:up": "docker compose up -d",
     "e2e:seed": "bash e2e/scripts/seed.sh",
     "e2e:wait": "node e2e/scripts/wait-for-wp.js",
-    "test:e2e": "playwright test -c e2e/playwright.config.ts"
+    "test:e2e": "playwright test -c e2e/playwright.config.ts",
+    "e2e:all": "npm run e2e:up && npm run e2e:wait && npm run e2e:seed && npm run test:e2e"
   }
 }


### PR DESCRIPTION
## Summary
- bundle E2E bootstrap scripts under `npm run e2e:all`
- harden Playwright config for stability and diagnostics
- run E2E suite in CI with browser install and health check hint

## Testing
- `composer lint`
- `composer psalm`
- `composer test:security`
- `composer test`
- `npm run e2e:install`
- `npm run e2e:all` *(fails: docker: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a429bb6c188321b167e9ed00174b2e