### PR TITLE
chore: add e2e doctor and CI checks

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,6 +12,17 @@ jobs:
         run: npm ci
       - name: Install Playwright browsers
         run: npx playwright install --with-deps
-      - name: Run E2E (optional)
-        run: npm run e2e:all || echo "Hint: WP healthcheck failed"
+      - name: Doctor
+        run: node e2e/scripts/doctor.js || (echo "Hint: Docker not available" && exit 1)
+        env: { WP_BASE_URL: http://localhost:8080 }
+      - name: Start stack
+        run: docker compose up -d
+      - name: Wait for WP
+        run: node e2e/scripts/wait-for-wp.js || (echo "Hint: WP healthcheck failed" && exit 1)
+        env: { WP_BASE_URL: http://localhost:8080 }
+      - name: Seed data
+        run: bash e2e/scripts/seed.sh
+        env: { WP_BASE_URL: http://localhost:8080 }
+      - name: Run E2E tests
+        run: npm run test:e2e
         env: { WP_BASE_URL: http://localhost:8080 }

--- a/README.md
+++ b/README.md
@@ -187,18 +187,20 @@ vendor/bin/phpunit tests/DigitsNormalizerTest.php
 
 ## E2E quick start
 
-Playwright tests run in an optional CI job (`continue-on-error: true`). To run them locally:
+One-shot:
 
 ```bash
-npm run e2e:install # install browsers once
-npm run e2e:all
+npm run e2e:install && npm run e2e:all
 ```
 
-If tests fail with ECONNREFUSED, run:
+### Troubleshooting
 
-```bash
-npm run e2e:up && npm run e2e:wait && npm run e2e:seed
-```
+Common errors:
+
+- docker not found → install Docker or run via wp-env
+- ECONNREFUSED → run up→wait→seed or fix WP_BASE_URL
+
+CI E2E is optional and won’t block merges.
 
 ### Code Quality
 

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,11 +1,10 @@
 import { defineConfig } from '@playwright/test';
 
-const baseURL = process.env.WP_BASE_URL || 'http://localhost:8080';
-
 export default defineConfig({
+  reporter: 'html',
   retries: 1,
   use: {
-    baseURL,
+    baseURL: process.env.WP_BASE_URL || 'http://localhost:8080',
     actionTimeout: 15000,
     navigationTimeout: 30000,
     screenshot: 'only-on-failure',

--- a/e2e/scripts/doctor.js
+++ b/e2e/scripts/doctor.js
@@ -1,0 +1,28 @@
+const { execSync } = require('child_process');
+
+function has(cmd) {
+  try {
+    execSync(cmd, { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+if (!has('docker version')) {
+  console.error(`Docker not found. Install Docker Desktop or use wp-env. Then run:
+npm run e2e:install && npm run e2e:up && npm run e2e:wait && npm run e2e:seed && npm run test:e2e`);
+  process.exit(1);
+}
+
+if (!has('docker compose version')) {
+  console.error('Docker Compose not found. Install Docker Compose v2.');
+  process.exit(1);
+}
+
+const url = process.env.WP_BASE_URL || 'http://localhost:8080';
+if (!process.env.WP_BASE_URL) {
+  console.log(`WP_BASE_URL not set. Defaulting to ${url}`);
+} else {
+  console.log(`WP_BASE_URL=${url}`);
+}

--- a/e2e/scripts/wait-for-wp.js
+++ b/e2e/scripts/wait-for-wp.js
@@ -23,7 +23,7 @@ function retry() {
   if (Date.now() < deadline) {
     setTimeout(ping, 1500);
   } else {
-    console.error(`Timed out waiting for ${url}`);
+    console.error(`WordPress unreachable at ${url}. Did you run: npm run e2e:up ?`);
     process.exit(1);
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "e2e:seed": "bash e2e/scripts/seed.sh",
     "e2e:wait": "node e2e/scripts/wait-for-wp.js",
     "test:e2e": "playwright test -c e2e/playwright.config.ts",
-    "e2e:all": "npm run e2e:up && npm run e2e:wait && npm run e2e:seed && npm run test:e2e"
+    "e2e:doctor": "node e2e/scripts/doctor.js",
+    "e2e:all": "node e2e/scripts/doctor.js && npm run e2e:up && npm run e2e:wait && npm run e2e:seed && npm run test:e2e"
   }
 }


### PR DESCRIPTION
## Summary
- add doctor script to verify Docker and WP_BASE_URL
- refine Playwright config and wait hints
- expand optional E2E workflow steps

## Testing
- `composer lint`
- `composer psalm`
- `composer test`
- `composer test:security`
- `npm run e2e:install`
- `npm run e2e:all` *(fails: Docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a42d662ea08321a721c28f86b5d5ff