### PR TITLE
feat: add wp-env fallback for E2E

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,12 +185,20 @@ composer test
 vendor/bin/phpunit tests/DigitsNormalizerTest.php
 ```
 
-## E2E quick start
+## Docker or wp-env
 
-One-shot:
+Run E2E tests via Docker or wp-env.
+
+### Quick start (Docker)
 
 ```bash
 npm run e2e:install && npm run e2e:all
+```
+
+### Quick start (wp-env)
+
+```bash
+npm run e2e:install && npm run e2e:all:wpenv
 ```
 
 ### Troubleshooting

--- a/e2e/scripts/doctor.js
+++ b/e2e/scripts/doctor.js
@@ -10,8 +10,13 @@ function has(cmd) {
 }
 
 if (!has('docker version')) {
-  console.error(`Docker not found. Install Docker Desktop or use wp-env. Then run:
+  if (has('wp-env --version')) {
+    console.error(`Docker not found. wp-env detected. Run:
+npm run e2e:install && npm run e2e:all:wpenv`);
+  } else {
+    console.error(`Docker not found. Install Docker Desktop or wp-env. Then run:
 npm run e2e:install && npm run e2e:up && npm run e2e:wait && npm run e2e:seed && npm run test:e2e`);
+  }
   process.exit(1);
 }
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "e2e:wait": "node e2e/scripts/wait-for-wp.js",
     "test:e2e": "playwright test -c e2e/playwright.config.ts",
     "e2e:doctor": "node e2e/scripts/doctor.js",
-    "e2e:all": "node e2e/scripts/doctor.js && npm run e2e:up && npm run e2e:wait && npm run e2e:seed && npm run test:e2e"
+    "e2e:all": "node e2e/scripts/doctor.js && npm run e2e:up && npm run e2e:wait && npm run e2e:seed && npm run test:e2e",
+    "e2e:up:wpenv": "wp-env start",
+    "e2e:seed:wpenv": "WP_CLI='npx wp-env run cli wp' bash e2e/scripts/seed.sh",
+    "e2e:all:wpenv": "npm run e2e:up:wpenv && npm run e2e:seed:wpenv && npm run test:e2e"
   }
 }


### PR DESCRIPTION
## Summary
- add wp-env scripts for E2E testing without Docker
- guide doctor.js to suggest wp-env when Docker unavailable
- document Docker vs wp-env E2E quick starts

## Testing
- `composer lint`
- `composer psalm`
- `composer test`
- `composer test:security`
- `npm run e2e:install`
- `npm run e2e:all:wpenv` *(fails: wp-env not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a43086d7548321b5690e0547f60e2e