### PR TITLE
Add accessibility and editor E2E tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,10 +61,22 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
       - run: npm ci || npm install
       - run: npx playwright install --with-deps
       - run: npm run e2e:all || echo "Hint: WP healthcheck failed"
+      - name: Upload HTML report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report
+      - name: Upload test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-results
+          path: test-results

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,22 +7,23 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
-        with: { node-version: 20 }
+        with:
+          node-version: 20
       - name: Install deps
         run: npm ci
       - name: Install Playwright browsers
         run: npx playwright install --with-deps
-      - name: Doctor
-        run: node e2e/scripts/doctor.js || (echo "Hint: Docker not available" && exit 1)
-        env: { WP_BASE_URL: http://localhost:8080 }
-      - name: Start stack
-        run: docker compose up -d
-      - name: Wait for WP
-        run: node e2e/scripts/wait-for-wp.js || (echo "Hint: WP healthcheck failed" && exit 1)
-        env: { WP_BASE_URL: http://localhost:8080 }
-      - name: Seed data
-        run: bash e2e/scripts/seed.sh
-        env: { WP_BASE_URL: http://localhost:8080 }
-      - name: Run E2E tests
-        run: npm run test:e2e
-        env: { WP_BASE_URL: http://localhost:8080 }
+      - name: Run E2E tests (Playground)
+        run: npm run e2e:all
+      - name: Upload HTML report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report
+      - name: Upload test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-results
+          path: test-results

--- a/README.md
+++ b/README.md
@@ -187,33 +187,33 @@ vendor/bin/phpunit tests/DigitsNormalizerTest.php
 
 ## End-to-End Testing
 
-Run E2E tests using one of three paths:
+Run a11y and editor smoke tests via Playwright using one of three paths:
 
-### A) Docker Compose
+### A) Playground CLI (default)
 
 ```bash
 npm run e2e:install && npm run e2e:all
 ```
 
-### B) wp-env (Docker-based)
+### B) Docker Compose
+
+```bash
+npm run e2e:install && npm run e2e:all:docker
+```
+
+### C) wp-env (Docker-based)
 
 ```bash
 npm run e2e:install && npm run e2e:all:wpenv
 ```
 
-### C) Docker-free (Playground CLI)
-
-```bash
-npm run e2e:install && npm run e2e:all:playground
-```
-
-The Playground CLI mounts the current plugin automatically via `--auto-mount` and serves on port 9400 (configurable via `--port`).
+The Playground CLI mounts the current plugin automatically via `--auto-mount` and serves on port 9400 (override with `WP_BASE_URL`).
 
 ### Troubleshooting
 
-Common errors:
-
-- ECONNREFUSED → ensure the chosen path is running and `WP_BASE_URL` matches (9400 for Playground)
+- Offline? Playground download may fail → use Docker or wp-env paths
+- Port in use → set `WP_BASE_URL` accordingly (defaults to 9400)
+- ECONNREFUSED → ensure the chosen path is running and `WP_BASE_URL` matches
 - Node < 20 → upgrade Node for Playground CLI
 
 CI E2E is optional and won’t block merges.

--- a/e2e/blueprint.json
+++ b/e2e/blueprint.json
@@ -5,8 +5,8 @@
   "landingPage": "/wp-admin/",
   "steps": [
     { "step": "setSiteOptions", "options": { "blogname": "SmartAlloc E2E", "blogdescription": "Playground" } },
-    { "step": "wp-cli", "command": "wp user create reviewer reviewer@example.com --role=administrator --user_pass=reviewer123 || true" },
-    { "step": "wp-cli", "command": "wp user create editor1 editor1@example.com --role=editor --user_pass=editor123 || true" },
+    { "step": "wp-cli", "command": "wp user update admin --user_pass=admin" },
+    { "step": "wp-cli", "command": "wp user create editor editor@example.com --role=editor --user_pass=editor || true" },
     { "step": "wp-cli", "command": "wp plugin activate smartalloc || true" }
   ]
 }

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from '@playwright/test';
 
-// The Playground CLI path sets WP_BASE_URL to http://localhost:9400.
-const baseURL = process.env.WP_BASE_URL || 'http://localhost:8080';
+// Default to Playground port 9400; WP_BASE_URL overrides.
+const baseURL = process.env.WP_BASE_URL || 'http://localhost:9400';
 
 export default defineConfig({
   reporter: 'html',

--- a/e2e/scripts/doctor.js
+++ b/e2e/scripts/doctor.js
@@ -9,6 +9,10 @@ function has(cmd) {
   }
 }
 
+if (!has('npx @wp-playground/cli --version')) {
+  console.error('Playground CLI unavailable or offline. For Docker or wp-env paths run:\n npm run e2e:all:docker\n npm run e2e:all:wpenv');
+}
+
 if (!has('docker version')) {
   if (has('wp-env --version')) {
     console.error('wp-env still needs Docker; use Playground path instead.');
@@ -27,7 +31,7 @@ if (!has('docker version')) {
     }
   }
 
-  console.error('Docker not found. Run:\n npm run e2e:all:playground');
+  console.error('Docker not found. Run:\n npm run e2e:all');
   process.exit(1);
 }
 
@@ -36,7 +40,7 @@ if (!has('docker compose version')) {
   process.exit(1);
 }
 
-const url = process.env.WP_BASE_URL || 'http://localhost:8080';
+const url = process.env.WP_BASE_URL || 'http://localhost:9400';
 if (!process.env.WP_BASE_URL) {
   console.log(`WP_BASE_URL not set. Defaulting to ${url}`);
 } else {

--- a/e2e/scripts/wait-for-wp.js
+++ b/e2e/scripts/wait-for-wp.js
@@ -1,5 +1,5 @@
 const http = require('http');
-const url = process.env.WP_BASE_URL || 'http://localhost:8080';
+const url = process.env.WP_BASE_URL || 'http://localhost:9400';
 const deadline = Date.now() + 120000;
 
 function ping() {

--- a/e2e/tests/editor-smoke.spec.ts
+++ b/e2e/tests/editor-smoke.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '@playwright/test';
+
+const admin = { user: 'admin', pass: 'admin' };
+
+async function login(page, creds) {
+  await page.goto('/wp-login.php');
+  await page.fill('#user_login', creds.user);
+  await page.fill('#user_pass', creds.pass);
+  await page.click('#wp-submit');
+}
+
+async function assertCleanEditor(page, url: string) {
+  const messages: string[] = [];
+  page.on('console', msg => {
+    if ((msg.type() === 'error' || msg.type() === 'warning') && /smartalloc/i.test(msg.text())) {
+      messages.push(msg.text());
+    }
+  });
+
+  const resp = await page.goto(url);
+  if (!resp || resp.status() >= 400) {
+    test.skip(`TODO: Editor unavailable at ${url}`);
+  }
+
+  await expect(page.locator('link[href*="smart-alloc"], link[href*="smartalloc"]')).toHaveCount(0);
+  expect(messages).toEqual([]);
+}
+
+test.describe('@e2e-editor Gutenberg smoke', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.context().clearCookies();
+    await page.goto('/');
+    await page.evaluate(() => {
+      localStorage.clear();
+      sessionStorage.clear();
+    });
+    await login(page, admin);
+  });
+
+  test('Block Editor has no plugin leakage', async ({ page }) => {
+    await assertCleanEditor(page, '/wp-admin/post-new.php');
+  });
+
+  test('Site Editor has no plugin leakage', async ({ page }) => {
+    await assertCleanEditor(page, '/wp-admin/site-editor.php');
+  });
+});

--- a/e2e/tests/export.a11y.spec.ts
+++ b/e2e/tests/export.a11y.spec.ts
@@ -1,0 +1,28 @@
+import { test } from '@playwright/test';
+import { expectNoCriticalViolations } from '../utils/axe';
+
+const admin = { user: 'admin', pass: 'admin' };
+
+async function login(page, creds) {
+  await page.goto('/wp-login.php');
+  await page.fill('#user_login', creds.user);
+  await page.fill('#user_pass', creds.pass);
+  await page.click('#wp-submit');
+}
+
+test.describe('@e2e-a11y Export page accessibility', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.context().clearCookies();
+    await page.goto('/');
+    await page.evaluate(() => {
+      localStorage.clear();
+      sessionStorage.clear();
+    });
+  });
+
+  test('has no critical accessibility violations', async ({ page }) => {
+    await login(page, admin);
+    await page.goto('/wp-admin/admin.php?page=smartalloc-export');
+    await expectNoCriticalViolations(page);
+  });
+});

--- a/e2e/tests/manual-review.a11y.spec.ts
+++ b/e2e/tests/manual-review.a11y.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from '@playwright/test';
+import { expectNoCriticalViolations } from '../utils/axe';
+
+const admin = { user: 'admin', pass: 'admin' };
+
+async function login(page, creds) {
+  await page.goto('/wp-login.php');
+  await page.fill('#user_login', creds.user);
+  await page.fill('#user_pass', creds.pass);
+  await page.click('#wp-submit');
+}
+
+test.describe('@e2e-a11y Manual Review accessibility', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.context().clearCookies();
+    await page.goto('/');
+    await page.evaluate(() => {
+      localStorage.clear();
+      sessionStorage.clear();
+    });
+  });
+
+  test('page has no critical accessibility violations', async ({ page }) => {
+    await login(page, admin);
+    await page.goto('/wp-admin/admin.php?page=smartalloc-manual-review');
+    await expectNoCriticalViolations(page);
+  });
+
+  test('bulk buttons have aria-labels', async ({ page }) => {
+    await login(page, admin);
+    await page.goto('/wp-admin/admin.php?page=smartalloc-manual-review');
+    await expect(page.locator('#smartalloc-bulk-approve')).toHaveAttribute('aria-label', /Approve selected entries/i);
+    await expect(page.locator('#smartalloc-bulk-reject')).toHaveAttribute('aria-label', /Reject selected entries/i);
+    await expect(page.locator('#smartalloc-bulk-defer')).toHaveAttribute('aria-label', /Defer selected entries/i);
+  });
+});

--- a/e2e/utils/axe.ts
+++ b/e2e/utils/axe.ts
@@ -1,0 +1,22 @@
+import { Page, expect } from '@playwright/test';
+
+export async function injectAxe(page: Page) {
+  await page.addScriptTag({ path: require.resolve('axe-core') });
+}
+
+export async function getViolations(page: Page) {
+  await injectAxe(page);
+  const results = await page.evaluate(async () => {
+    // @ts-ignore
+    return await axe.run();
+  });
+  return results.violations.filter((v: any) => v.impact === 'critical');
+}
+
+export async function expectNoCriticalViolations(page: Page) {
+  const violations = await getViolations(page);
+  if (violations.length) {
+    console.error('Accessibility violations', JSON.stringify(violations, null, 2));
+  }
+  expect(violations).toEqual([]);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "devDependencies": {
         "@playwright/test": "^1.41.2",
+        "axe-core": "^4.10.0",
         "playwright": "^1.41.2",
         "start-server-and-test": "^2.0.3"
       }
@@ -80,6 +81,16 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/axe-core": {
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.3.tgz",
+      "integrity": "sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/axios": {
       "version": "1.11.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "devDependencies": {
     "playwright": "^1.41.2",
     "@playwright/test": "^1.41.2",
-    "start-server-and-test": "^2.0.3"
+    "start-server-and-test": "^2.0.3",
+    "axe-core": "^4.10.0"
   },
   "scripts": {
     "e2e:install": "npx playwright install --with-deps",
@@ -12,11 +13,12 @@
     "e2e:wait": "node e2e/scripts/wait-for-wp.js",
     "test:e2e": "playwright test -c e2e/playwright.config.ts",
     "e2e:doctor": "node e2e/scripts/doctor.js",
-    "e2e:all": "node e2e/scripts/doctor.js && npm run e2e:up && npm run e2e:wait && npm run e2e:seed && npm run test:e2e",
+    "e2e:all:docker": "node e2e/scripts/doctor.js && npm run e2e:up && npm run e2e:wait && npm run e2e:seed && npm run test:e2e",
     "e2e:up:playground": "npx @wp-playground/cli server --auto-mount --port=9400 --blueprint=e2e/blueprint.json",
     "e2e:all:playground": "WP_BASE_URL=http://localhost:9400 start-server-and-test \"npm run e2e:up:playground\" http://localhost:9400 \"npm run test:e2e\"",
     "e2e:up:wpenv": "wp-env start",
     "e2e:seed:wpenv": "WP_CLI='npx wp-env run cli wp' bash e2e/scripts/seed.sh",
-    "e2e:all:wpenv": "npm run e2e:up:wpenv && npm run e2e:seed:wpenv && npm run test:e2e"
+    "e2e:all:wpenv": "npm run e2e:up:wpenv && npm run e2e:seed:wpenv && npm run test:e2e",
+    "e2e:all": "npm run e2e:all:playground"
   }
 }


### PR DESCRIPTION
## Summary
- run axe-core accessibility scans on Export and Manual Review pages
- add Gutenberg and Site Editor smoke tests
- default E2E environment to Playground and document test paths

## Testing
- `composer lint`
- `composer psalm`
- `composer test`
- `composer test:security`
- `npm run e2e:all:playground` *(fails: fetch failed caused by connect ENETUNREACH 198.143.164.251:443 - Local (0.0.0.0:0))*

------
https://chatgpt.com/codex/tasks/task_e_68a43d932f708321a5ef998c852b1a0a