### PR TITLE
Add coverage gating and artifacts to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,20 +17,29 @@ jobs:
     env:
       WP_VERSION: ${{ matrix.wp }}
       SA_FAIL_ON_DEPRECATION: 1
+      SA_COVERAGE_OPTIONAL: 0
     steps:
       - uses: actions/checkout@v4
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
+          extensions: mbstring, json, dom, zip
           coverage: pcov
+          ini-values: pcov.enabled=1, pcov.directory=src
       - run: composer config platform.php ${{ matrix.php }}
       - run: composer update --no-interaction --prefer-dist --no-progress
       - run: composer cs
       - run: composer phpstan
       - run: composer psalm
-      - run: composer test
+      - run: vendor/bin/phpunit --coverage-clover build/coverage.xml
+      - run: php tools/coverage-check.php build/coverage.xml
+      - name: Upload coverage
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ matrix.php }}
+          path: build/coverage.xml
       - run: composer test:security
-      - run: composer coverage
       - run: |
           curl -L https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar -o wp
           chmod +x wp && sudo mv wp /usr/local/bin/wp

--- a/README.md
+++ b/README.md
@@ -234,11 +234,22 @@ composer cs:fix
 composer phpstan
 composer psalm
 
-# Run tests with coverage
-composer coverage
-
 # Allow deprecations locally
 SA_FAIL_ON_DEPRECATION=0 composer test
+```
+
+## Coverage
+
+Local runs skip coverage if no driver is available:
+
+```bash
+SA_COVERAGE_OPTIONAL=1 composer coverage
+```
+
+In CI the pcov extension is installed automatically and coverage for critical namespaces must stay above 85%. The generated `build/coverage.xml` is uploaded as a workflow artifact. Download it or generate an HTML report locally:
+
+```bash
+vendor/bin/phpunit --coverage-html build/coverage-html
 ```
 
 ## Architecture

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "test": "phpunit",
         "test:security": "phpunit --testsuite Security && psalm --no-cache --taint-analysis --show-info=false",
         "test:e2e": "phpunit --testsuite E2E",
-        "coverage": "phpunit --coverage-clover build/coverage.xml && php tools/coverage-check.php build/coverage.xml",
+        "coverage": "php tools/coverage.php",
         "qa": "composer cs && composer psalm && composer test",
         "ci": "composer cs && composer test:security && composer coverage",
         "build": "rm -rf dist && mkdir dist && VERSION=$(php -r \"include 'smart-alloc.php'; echo SMARTALLOC_VERSION;\") && rsync -a . dist/smartalloc --exclude 'tests' --exclude 'stubs' --exclude 'docs' --exclude 'node_modules' --exclude '.github' --exclude 'dist' && cd dist && zip -r smartalloc-v$VERSION.zip smartalloc && rm -rf smartalloc",

--- a/tools/coverage.php
+++ b/tools/coverage.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+$info = strtolower(shell_exec('php -i'));
+$hasDriver = str_contains($info, 'pcov') || str_contains($info, 'xdebug');
+$optionalEnv = getenv('SA_COVERAGE_OPTIONAL');
+$optional = $optionalEnv === false ? true : $optionalEnv !== '0';
+if (!$hasDriver) {
+    fwrite(STDERR, "No coverage driver (pcov or Xdebug) found.\n");
+    fwrite(STDERR, "Hint: install pcov or enable Xdebug. Set SA_COVERAGE_OPTIONAL=0 to require coverage.\n");
+    if ($optional) {
+        exit(0);
+    }
+    exit(1);
+}
+
+if (!is_dir('build')) {
+    mkdir('build', 0777, true);
+}
+
+passthru('vendor/bin/phpunit --coverage-clover build/coverage.xml', $code);
+if ($code !== 0) {
+    exit($code);
+}
+
+passthru('php tools/coverage-check.php build/coverage.xml', $code);
+exit($code);


### PR DESCRIPTION
## Summary
- enforce pcov-based coverage in CI with 85% gate on critical namespaces
- add `tools/coverage.php` script for optional local coverage runs
- document coverage workflow and artifact usage

## Testing
- `composer cs -v`
- `composer phpstan`
- `composer psalm`
- `composer test`
- `composer test:security`
- `composer coverage` *(driver absent; exits gracefully)*

------
https://chatgpt.com/codex/tasks/task_e_68a44ee4adec8321a08650167a6b5e25