### PR TITLE
Enhance debug kit with breadcrumbs, query capture and secure admin UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,8 @@ An optional admin-only utility captures recent PHP errors and builds ready-to-co
 - Access the collected entries from the SmartAlloc Debug admin screen (requires `manage_smartalloc`).
 - Data is stored locally and redacted; no automatic outbound requests are made.
 - Stores up to 25 entries and throttles duplicates for five minutes.
+- Captures up to 10 recent logger breadcrumbs and, when `SAVEQUERIES` is enabled, up to 5 prepared SQL queries with arguments stripped.
+- Timestamps are normalised to UTC ISO-8601. Queries and breadcrumbs never include raw arguments or PII.
 
 ## Uninstall
 

--- a/src/Admin/DebugScreen.php
+++ b/src/Admin/DebugScreen.php
@@ -17,25 +17,47 @@ final class DebugScreen
         if (!current_user_can('manage_smartalloc')) {
             wp_die(esc_html__('Access denied', 'smartalloc'));
         }
+        $nonce = $_REQUEST['_wpnonce'] ?? '';
+        if (!wp_verify_nonce((string) $nonce, 'smartalloc_debug')) {
+            wp_die(esc_html__('Invalid nonce', 'smartalloc'));
+        }
+        $enabled = (bool) get_option('smartalloc_debug_enabled') && defined('WP_DEBUG') && WP_DEBUG;
         $entries = ErrorStore::all();
         $builder = new PromptBuilder();
-        echo '<div class="wrap"><h1>Debug</h1><table class="wp-list-table"><tbody>';
-        foreach ($entries as $i => $entry) {
+        echo '<div class="wrap"><h1>Debug</h1>';
+        if (!$enabled) {
+            echo '<div class="notice notice-warning"><p>' . esc_html__('Debug mode disabled', 'smartalloc') . '</p></div>';
+        }
+        echo '<table class="wp-list-table"><tbody>';
+        foreach ($entries as $entry) {
             $prompt = $builder->build($entry);
+            $issue = $builder->buildIssue($entry);
             $hash = md5((string) ($entry['message'] ?? '') . (string) ($entry['file'] ?? '') . (string) ($entry['line'] ?? ''));
-            $route = '';
-            if (isset($entry['context']) && is_array($entry['context']) && isset($entry['context']['route'])) {
-                $route = (string) $entry['context']['route'];
+            $route = (string) ($entry['context']['route'] ?? '');
+            $method = (string) ($entry['context']['method'] ?? '');
+            $preview = mb_substr($prompt, 0, 2000);
+            $truncated = mb_strlen($prompt) > 2000;
+            if ($truncated) {
+                $preview .= '…(truncated)';
             }
             echo '<tr>';
             echo '<td>' . esc_html($hash) . '</td>';
-            echo '<td>' . esc_html($route) . '</td>';
-            echo '<td><button class="copy-prompt" data-prompt="' . esc_attr($prompt) . '">' . esc_html__('Copy Prompt', 'smartalloc') . '</button></td>';
+            echo '<td>' . esc_html($method . ' ' . $route) . '</td>';
+            echo '<td>';
+            echo '<pre class="prompt" data-full="' . esc_attr($prompt) . '">' . esc_html($preview) . '</pre>';
+            if ($truncated) {
+                echo '<button class="show-more">' . esc_html__('Show more', 'smartalloc') . '</button> ';
+            }
+            echo '<button class="copy-prompt" data-clip="' . esc_attr($prompt) . '">' . esc_html__('Copy Prompt', 'smartalloc') . '</button> ';
+            echo '<button class="copy-issue" data-clip="' . esc_attr($issue) . '">' . esc_html__('Copy as GitHub Issue', 'smartalloc') . '</button>';
+            echo '</td>';
             echo '</tr>';
         }
         if (empty($entries)) {
             echo '<tr><td colspan="3">' . esc_html__('No errors', 'smartalloc') . '</td></tr>';
         }
-        echo '</tbody></table></div>';
+        echo '</tbody></table>';
+        echo '<script>document.querySelectorAll(".copy-prompt,.copy-issue").forEach(b=>b.addEventListener("click",()=>navigator.clipboard.writeText(b.dataset.clip)));document.querySelectorAll(".show-more").forEach(b=>b.addEventListener("click",()=>{const p=b.previousElementSibling;p.textContent=p.dataset.full;b.remove();}));</script>';
+        echo '</div>';
     }
 }

--- a/src/Debug/ErrorStore.php
+++ b/src/Debug/ErrorStore.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace SmartAlloc\Debug;
 
+use SmartAlloc\Infra\Metrics\MetricsCollector;
+
 /**
  * Ring buffer store for captured errors.
  */
@@ -33,6 +35,10 @@ final class ErrorStore
         $data = array_slice($data, 0, self::MAX_ENTRIES);
         /** @phpstan-ignore-next-line */
         update_option(self::OPTION, $data, false);
+
+        $metrics = new MetricsCollector();
+        $current = $metrics->all()['gauges']['debug_error_store_size'] ?? 0;
+        $metrics->gauge('debug_error_store_size', count($data) - (int) $current);
     }
 
     /**

--- a/src/Debug/RedactionAdapter.php
+++ b/src/Debug/RedactionAdapter.php
@@ -25,10 +25,29 @@ final class RedactionAdapter
     public function redact(array $context): array
     {
         if (isset($context['context']) && is_array($context['context'])) {
-            $context['context'] = $this->redactor->redact($context['context']);
-            if (isset($context['context']['route']) && is_string($context['context']['route'])) {
-                $context['context']['route'] = $this->stripQuery($context['context']['route']);
+            $ctx = $context['context'];
+            $route = $ctx['route'] ?? null;
+            $method = $ctx['method'] ?? null;
+            $userHash = $ctx['user_hash'] ?? null;
+            $correlation = $ctx['correlation_id'] ?? null;
+            $timestamp = $ctx['timestamp'] ?? null;
+            $ctx = $this->redactor->redact($ctx);
+            if ($route !== null && is_string($route)) {
+                $ctx['route'] = $this->stripQuery((string) $route);
             }
+            if ($method !== null) {
+                $ctx['method'] = $method;
+            }
+            if ($userHash !== null) {
+                $ctx['user_hash'] = $userHash;
+            }
+            if ($correlation !== null) {
+                $ctx['correlation_id'] = $correlation;
+            }
+            if ($timestamp !== null) {
+                $ctx['timestamp'] = $timestamp;
+            }
+            $context['context'] = $ctx;
         }
         if (isset($context['file']) && is_string($context['file'])) {
             $context['file'] = $this->shortenPath($context['file']);

--- a/src/Infra/Logging/Logger.php
+++ b/src/Infra/Logging/Logger.php
@@ -38,7 +38,13 @@ final class Logger implements LoggerInterface
     {
         $context = $this->redactor->redact($context);
         $level = strtoupper((string) $level);
-        $record = ['level' => $level, 'message' => $message, 'context' => $context];
+        $record = [
+            'timestamp' => gmdate('c'),
+            'correlation_id' => self::requestId(),
+            'level' => $level,
+            'message' => $message,
+            'context' => $context,
+        ];
         $this->records[] = $record;
         ($this->writer)(sprintf('[SmartAlloc][%s] %s %s', $level, $message, wp_json_encode($context)));
     }

--- a/tests/Integration/DebugIntegrationTest.php
+++ b/tests/Integration/DebugIntegrationTest.php
@@ -8,6 +8,7 @@ use Brain\Monkey;
 use Brain\Monkey\Functions;
 use SmartAlloc\Debug\ErrorCollector;
 use SmartAlloc\Debug\PromptBuilder;
+use SmartAlloc\Admin\DebugScreen;
 use SmartAlloc\Infra\Logging\Logger;
 use SmartAlloc\Tests\BaseTestCase;
 
@@ -30,6 +31,12 @@ final class DebugIntegrationTest extends BaseTestCase
         Functions\when('get_bloginfo')->alias(fn() => '6.0');
         Functions\when('wp_parse_url')->alias(fn($v) => parse_url($v));
         Functions\when('get_current_user_id')->alias(fn() => 1);
+        Functions\when('wp_verify_nonce')->alias(fn($n,$a) => $n === 'good' && $a === 'smartalloc_debug');
+        Functions\when('current_user_can')->alias(fn($c) => $c === 'manage_smartalloc');
+        Functions\when('esc_html__')->alias(fn($v) => $v);
+        Functions\when('esc_html')->alias(fn($v) => $v);
+        Functions\when('esc_attr')->alias(fn($v) => $v);
+        Functions\when('wp_die')->alias(fn($m) => throw new \RuntimeException($m));
         $GLOBALS['_SERVER']['REQUEST_URI'] = '/wp-json/foo';
         $GLOBALS['_SERVER']['REQUEST_METHOD'] = 'GET';
         $GLOBALS['sa_options']['smartalloc_debug_enabled'] = true;
@@ -58,6 +65,32 @@ final class DebugIntegrationTest extends BaseTestCase
         $this->assertNotEmpty($entries);
         $prompt = (new PromptBuilder())->build($entries[0]);
         $this->assertStringContainsString('/wp-json/foo', $prompt);
+        $this->assertStringContainsString('GET', $prompt);
         $this->assertStringContainsString('correlation_id', $prompt);
+
+        $_REQUEST['_wpnonce'] = 'good';
+        ob_start();
+        DebugScreen::render();
+        $html = ob_get_clean();
+        $this->assertStringContainsString('Copy Prompt', $html);
+
+        $_REQUEST['_wpnonce'] = 'bad';
+        ob_start();
+        $this->expectException(\RuntimeException::class);
+        try {
+            DebugScreen::render();
+        } finally {
+            ob_end_clean();
+        }
+
+        Functions\when('current_user_can')->alias(fn($c) => false);
+        $_REQUEST['_wpnonce'] = 'good';
+        ob_start();
+        $this->expectException(\RuntimeException::class);
+        try {
+            DebugScreen::render();
+        } finally {
+            ob_end_clean();
+        }
     }
 }

--- a/tests/Security/DebugKitTest.php
+++ b/tests/Security/DebugKitTest.php
@@ -35,8 +35,8 @@ final class DebugKitTest extends BaseTestCase
         $GLOBALS['sa_options']['smartalloc_debug_enabled'] = true;
         global $wpdb;
         $wpdb = (object) ['queries' => [
-            ['SELECT * FROM t WHERE id = %d', 1],
-            ['SELECT * FROM bad']
+            ['SELECT * FROM t WHERE id = 5', 0, 'wpdb->prepare'],
+            ['SELECT * FROM bad', 0, '']
         ]];
     }
 
@@ -64,6 +64,7 @@ final class DebugKitTest extends BaseTestCase
         $this->assertStringNotContainsString('user@example.com', $prompt);
         $this->assertStringNotContainsString('123456789', $prompt);
         $queries = $entry['queries'] ?? [];
+        $this->assertSame(['SELECT * FROM t WHERE id = ?'], $queries);
         $this->assertNotContains('SELECT * FROM bad', $queries);
         unlink($tmp);
     }

--- a/tests/TEST_NOTES.md
+++ b/tests/TEST_NOTES.md
@@ -14,7 +14,7 @@ Mapping to master checklist sections A–G and numerics 3.x & 8.x.
 | 3.x Gravity Forms | PHPUnit scaffolds `ComplexFormTest` and `FlowPerksIntegrationTest` (marked SKIP with TODO) cover nested conditionals, uploads, multipage sessions and Flow/Perks routing. |
 | 8.x Persian/RTL | `PersianRtlTest` and Playwright `@e2e-i18n` placeholders ensure RTL rendering, character handling and Jalali round-trip (SKIP with TODO). |
 | Third-Party Compatibility | `JalaliFilterBypassTest` and Playwright `@e2e-compat` protect against Jalali date filters and Persian GF admin styles. |
-| Debug Kit | `DebugIntegrationTest` exercises prompt building, throttling and redaction; `DebugKitTest` guards against PII leakage and unprepared SQL capture. |
+| Debug Kit | `ErrorCollectorTest` verifies redaction, breadcrumbs and SAVEQUERIES behaviour; `DebugIntegrationTest` covers nonce/capability checks and prompt context; `DebugKitTest` guards against PII leakage and ensures only sanitized prepared SQL is surfaced. |
 
 ## Quality Gates 2024
 


### PR DESCRIPTION
## Summary
- collect logger breadcrumbs and sanitized prepared SQL with ISO-8601 timestamps
- secure Debug screen with capability+nonce checks, copy actions and show-more UI
- record safety metrics for captured errors and prompts

## Testing
- `composer cs`
- `composer phpstan`
- `composer psalm`
- `composer test`
- `composer test:security`


------
https://chatgpt.com/codex/tasks/task_e_68a45931d3608321b38e53709fbb9c15