### PR TITLE
Add optional security scans

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,3 +80,50 @@ jobs:
         with:
           name: playwright-results
           path: test-results
+
+  security-sast:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - run: composer install --no-interaction
+      - run: composer sec:semgrep
+      - name: Upload Semgrep report
+        if: hashFiles('semgrep.sarif') != ''
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: semgrep.sarif
+
+  security-sca:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm ci || true
+      - run: npm i -g snyk
+      - run: npm run sec:snyk
+      - name: Upload Snyk results
+        uses: actions/upload-artifact@v4
+        with:
+          name: snyk-results
+          path: ./.snyk*
+          if-no-files-found: ignore
+
+  security-wp:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+      - run: composer install --no-interaction
+      - run: composer sec:wp
+      - uses: actions/upload-artifact@v4
+        with:
+          name: patchstack-report
+          path: build/patchstack.json
+          if-no-files-found: ignore

--- a/README.md
+++ b/README.md
@@ -310,6 +310,16 @@ The plugin creates several tables with the prefix `wp_salloc_`:
 - Capability-based access control
 - Sensitive data masking in logs
 
+## Security Scans (Optional)
+
+Run additional security checks locally:
+
+- `composer sec:semgrep`
+- `npm run sec:snyk` (requires Snyk CLI)
+- `composer sec:wp`
+
+These jobs currently run in CI as non-blocking steps; enforcement may be added later.
+
 ## Support
 
 For support and documentation, please refer to the plugin documentation or contact the development team.

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
         "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
         "phpcompatibility/php-compatibility": "^9.3",
         "wp-phpunit/wp-phpunit": "^5.7",
-        "mikey179/vfsstream": "^1.6"
+        "mikey179/vfsstream": "^1.6",
+        "patchstack/security-scanner": "^1.0"
     },
     "autoload": {
         "psr-4": {
@@ -48,7 +49,9 @@
         "qa": "composer cs && composer psalm && composer test",
         "ci": "composer cs && composer test:security && composer coverage",
         "build": "rm -rf dist && mkdir dist && VERSION=$(php -r \"include 'smart-alloc.php'; echo SMARTALLOC_VERSION;\") && rsync -a . dist/smartalloc --exclude 'tests' --exclude 'stubs' --exclude 'docs' --exclude 'node_modules' --exclude '.github' --exclude 'dist' && cd dist && zip -r smartalloc-v$VERSION.zip smartalloc && rm -rf smartalloc",
-        "dist": "composer cs && composer test:security && composer test && composer build"
+        "dist": "composer cs && composer test:security && composer test && composer build",
+        "sec:semgrep": "docker run --rm -v $PWD:/src returntocorp/semgrep --config=auto --timeout 120 /src",
+        "sec:wp": "vendor/bin/patchstack scan --format=json --output build/patchstack.json || exit 0"
     },
     "config": {
         "allow-plugins": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "e2e:up:wpenv": "wp-env start",
     "e2e:seed:wpenv": "WP_CLI='npx wp-env run cli wp' bash e2e/scripts/seed.sh",
     "e2e:all:wpenv": "npm run e2e:up:wpenv && npm run e2e:seed:wpenv && npm run test:e2e",
-    "e2e:all": "npm run e2e:all:playground"
+    "e2e:all": "npm run e2e:all:playground",
+    "sec:snyk": "snyk test --severity-threshold=medium || exit 0"
   }
 }


### PR DESCRIPTION
## Summary
- add security scanning scripts for Semgrep, Snyk and Patchstack
- wire up non-blocking security jobs in CI with artifact uploads
- document optional security scans in README

## Testing
- `composer test`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a46b6fcbe08321a18d1dcfc0565643