### PR TITLE
Add PHP 8.3 compatibility tests

### DIFF
--- a/tests/Php83/DynamicConstFetchTest.php
+++ b/tests/Php83/DynamicConstFetchTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SmartAlloc\Tests\Php83;
+
+use SmartAlloc\Tests\BaseTestCase;
+
+final class DynamicConstFetchTest extends BaseTestCase
+{
+    public function test_dynamic_class_constant_fetch(): void
+    {
+        if (PHP_VERSION_ID < 80300) {
+            self::markTestSkipped('Dynamic class constant fetch requires PHP 8.3+.');
+        }
+
+        eval(<<<'CODE'
+        class DynConst {
+            public const FOO = 'bar';
+        }
+        CODE);
+
+        $name = 'FOO';
+        eval('$value = \\DynConst::{$name};');
+        $this->assertSame('bar', $value);
+    }
+}

--- a/tests/Php83/JsonValidateTest.php
+++ b/tests/Php83/JsonValidateTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SmartAlloc\Tests\Php83;
+
+use SmartAlloc\Tests\BaseTestCase;
+
+final class JsonValidateTest extends BaseTestCase
+{
+    public function test_json_validate_function(): void
+    {
+        if (!function_exists('json_validate')) {
+            self::markTestSkipped('json_validate() requires PHP 8.3+.');
+        }
+
+        $valid   = '{"a":1}';
+        $invalid = '{"a":,}';
+
+        $this->assertTrue(json_validate($valid));
+        $this->assertFalse(json_validate($invalid));
+    }
+}

--- a/tests/Php83/OverrideAttributeTest.php
+++ b/tests/Php83/OverrideAttributeTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SmartAlloc\Tests\Php83;
+
+use SmartAlloc\Tests\BaseTestCase;
+
+final class OverrideAttributeTest extends BaseTestCase
+{
+    public function test_override_attribute_detected(): void
+    {
+        if (PHP_VERSION_ID < 80300) {
+            self::markTestSkipped('#[\\Override] requires PHP 8.3+.');
+        }
+
+        eval(<<<'CODE'
+        class OverrideBase {
+            public function foo(): int {
+                return 1;
+            }
+        }
+
+        class OverrideChild extends OverrideBase {
+            #[\Override]
+            public function foo(): int {
+                return 2;
+            }
+        }
+        CODE);
+
+        $ref = new \ReflectionMethod('OverrideChild', 'foo');
+        $this->assertCount(1, $ref->getAttributes(\Override::class));
+    }
+}

--- a/tests/Php83/ReadonlyClassTest.php
+++ b/tests/Php83/ReadonlyClassTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SmartAlloc\Tests\Php83;
+
+use SmartAlloc\Tests\BaseTestCase;
+
+final class ReadonlyClassTest extends BaseTestCase
+{
+    public function test_readonly_class_reflection(): void
+    {
+        if (PHP_VERSION_ID < 80200) {
+            self::markTestSkipped('readonly classes require PHP 8.2+.');
+        }
+
+        eval(<<<'CODE'
+        readonly class MyReadonly {
+            public int $id;
+            public function __construct(int $id) {
+                $this->id = $id;
+            }
+        }
+        CODE);
+
+        $ref = new \ReflectionClass('MyReadonly');
+        $this->assertTrue($ref->isReadOnly());
+        $obj = new \MyReadonly(42);
+        $this->assertSame(42, $obj->id);
+    }
+}

--- a/tests/Php83/TypedClassConstantsTest.php
+++ b/tests/Php83/TypedClassConstantsTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SmartAlloc\Tests\Php83;
+
+use SmartAlloc\Tests\BaseTestCase;
+
+final class TypedClassConstantsTest extends BaseTestCase
+{
+    public function test_typed_class_constant_has_type(): void
+    {
+        if (PHP_VERSION_ID < 80300) {
+            self::markTestSkipped('Typed class constants require PHP 8.3+.');
+        }
+
+        eval(<<<'CODE'
+        class TypedConstants {
+            public const string NAME = 'sa';
+        }
+        CODE);
+
+        $ref   = new \ReflectionClass('TypedConstants');
+        $const = $ref->getReflectionConstant('NAME');
+        $this->assertSame('string', $const->getType()->getName());
+        $this->assertSame('sa', $const->getValue());
+    }
+}


### PR DESCRIPTION
## Summary
- add tests for PHP 8.3 features including Override attribute, typed class constants, json_validate(), readonly classes, and dynamic class-constant fetch
- ensure each test skips when the feature is unavailable

## Testing
- `composer cs` *(fails: phpcs not found)*
- `composer phpstan` *(fails: phpstan not found)*
- `composer psalm` *(fails: psalm not found)*
- `composer test` *(fails: phpunit not found)*
- `composer test:security` *(fails: phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a478daca0c8321b8d7ecf5f9ff4afe