### PR TITLE
Add PHP 8.3 feature compatibility tests

### DIFF
--- a/tests/Php83/DynamicConstFetchTest.php
+++ b/tests/Php83/DynamicConstFetchTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SmartAlloc\Tests\Php83;
+
+use SmartAlloc\Tests\BaseTestCase;
+
+class DynamicConst
+{
+    public const VALUE = 'dynamic';
+}
+
+final class DynamicConstFetchTest extends BaseTestCase
+{
+    public function test_dynamic_class_constant_fetch(): void
+    {
+        if (PHP_VERSION_ID < 80300) {
+            self::markTestSkipped('Dynamic class-constant fetch requires PHP 8.3');
+        }
+
+        $const = 'VALUE';
+        $class = DynamicConst::class;
+        $this->assertSame('dynamic', $class::{$const});
+    }
+}

--- a/tests/Php83/JsonValidateTest.php
+++ b/tests/Php83/JsonValidateTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SmartAlloc\Tests\Php83;
+
+use SmartAlloc\Tests\BaseTestCase;
+
+final class JsonValidateTest extends BaseTestCase
+{
+    public function test_json_validate(): void
+    {
+        if (PHP_VERSION_ID < 80300) {
+            self::markTestSkipped('json_validate() requires PHP 8.3');
+        }
+
+        $valid = '{"a":1,"b":[2,3]}';
+        $invalid = '{"a":1';
+        $this->assertTrue(json_validate($valid));
+        $this->assertFalse(json_validate($invalid));
+    }
+}

--- a/tests/Php83/OverrideAttributeTest.php
+++ b/tests/Php83/OverrideAttributeTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SmartAlloc\Tests\Php83;
+
+use SmartAlloc\Tests\BaseTestCase;
+
+class OverrideBase
+{
+    public function run(): string
+    {
+        return 'base';
+    }
+}
+
+class OverrideChild extends OverrideBase
+{
+    #[\Override]
+    public function run(): string
+    {
+        return 'child';
+    }
+}
+
+final class OverrideAttributeTest extends BaseTestCase
+{
+    public function test_override_attribute(): void
+    {
+        if (PHP_VERSION_ID < 80300) {
+            self::markTestSkipped('Override attribute requires PHP 8.3');
+        }
+
+        $ref = new \ReflectionMethod(OverrideChild::class, 'run');
+        $attrs = $ref->getAttributes(\Override::class);
+        $this->assertCount(1, $attrs, '#[Override] attribute present');
+        $this->assertSame('child', (new OverrideChild())->run());
+    }
+}

--- a/tests/Php83/ReadonlyClassTest.php
+++ b/tests/Php83/ReadonlyClassTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SmartAlloc\Tests\Php83;
+
+use SmartAlloc\Tests\BaseTestCase;
+
+readonly class ReadonlyUser
+{
+    public function __construct(public string $name)
+    {
+    }
+}
+
+final class ReadonlyClassTest extends BaseTestCase
+{
+    public function test_readonly_class_properties_cannot_change(): void
+    {
+        if (PHP_VERSION_ID < 80200) {
+            self::markTestSkipped('Readonly classes require PHP 8.2');
+        }
+
+        $u = new ReadonlyUser('alice');
+        $this->assertSame('alice', $u->name);
+
+        try {
+            $u->name = 'bob';
+            $this->fail('Expected error when modifying readonly property');
+        } catch (\Error $e) {
+            $this->assertStringContainsString('readonly property', $e->getMessage());
+        }
+    }
+}

--- a/tests/Php83/TypedClassConstantsTest.php
+++ b/tests/Php83/TypedClassConstantsTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SmartAlloc\Tests\Php83;
+
+use SmartAlloc\Tests\BaseTestCase;
+
+class TypedConstants
+{
+    public const int INT_CONST = 42;
+    public const string STR_CONST = 'ok';
+}
+
+final class TypedClassConstantsTest extends BaseTestCase
+{
+    public function test_typed_class_constants_reflection(): void
+    {
+        if (PHP_VERSION_ID < 80300) {
+            self::markTestSkipped('Typed class constants require PHP 8.3');
+        }
+
+        $ref = new \ReflectionClass(TypedConstants::class);
+        $intConst = $ref->getReflectionConstant('INT_CONST');
+        $this->assertSame('int', $intConst->getType()?->getName());
+        $this->assertSame(42, $intConst->getValue());
+
+        $strConst = $ref->getReflectionConstant('STR_CONST');
+        $this->assertSame('string', $strConst->getType()?->getName());
+        $this->assertSame('ok', $strConst->getValue());
+    }
+}


### PR DESCRIPTION
## Summary
- add tests for PHP 8.3 features (#\[\Override], typed class constants, json_validate, readonly classes, dynamic const fetch)
- skip tests when running on older PHP versions

## Testing
- `composer cs`
- `composer phpstan`
- `composer psalm`
- `composer test`
- `composer test:security`


------
https://chatgpt.com/codex/tasks/task_e_68a47aee885883219def51e10aba9a84