### PR TITLE
chore: add release readiness docs and tooling

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+/tests export-ignore
+/docs export-ignore
+/build export-ignore
+/node_modules export-ignore
+/.github export-ignore
+/tools export-ignore
+/OBSERVABILITY.md export-ignore
+/ADMIN_GUIDE.md export-ignore
+/MIGRATION.md export-ignore

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,21 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+      - run: composer install --no-dev --no-interaction --prefer-dist --no-progress
+      - run: composer dist
+      - uses: actions/upload-artifact@v3
+        with:
+          name: smartalloc
+          path: build/smartalloc-*.zip

--- a/ADMIN_GUIDE.md
+++ b/ADMIN_GUIDE.md
@@ -1,0 +1,14 @@
+# Admin Guide
+
+This guide covers routine operational tasks for SmartAlloc.
+
+## Updating Export Config
+1. Upload the JSON config to `wp-content/uploads/SmartAlloc_Exporter_Config_v1.json`.
+2. Flush caches via `wp smartalloc cache flush`.
+
+## User Roles
+- `manage_smartalloc` capability grants access to all plugin features.
+
+## Logs and Health
+- View health status at `/wp-json/smartalloc/v1/health`.
+- Metrics are available via CLI: `wp smartalloc metrics`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.0.0-rc.1
+- Added release documentation and tooling.
+
 ## 1.0.0
 - Allocator: initial release.
 - GF hook: Gravity Forms integration.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,12 @@
+# Migration Guide
+
+Use this guide when upgrading SmartAlloc.
+
+## Database
+Run pending migrations after updating:
+```bash
+wp smartalloc upgrade
+```
+
+## Configuration
+Review new options in `wp smartalloc settings list` and update as needed.

--- a/OBSERVABILITY.md
+++ b/OBSERVABILITY.md
@@ -1,0 +1,10 @@
+# Observability
+
+SmartAlloc exposes health and metrics endpoints for monitoring.
+
+## Metrics
+- REST endpoint: `/wp-json/smartalloc/v1/metrics`
+- WP-CLI: `wp smartalloc metrics`
+
+## Logs
+Application logs are written using WordPress's logging facilities. Configure log retention via the Admin Guide.

--- a/README.md
+++ b/README.md
@@ -352,6 +352,14 @@ An optional admin-only utility captures recent PHP errors and builds ready-to-co
 
 Set the `purge_on_uninstall` option to true to remove SmartAlloc options and caches. By default only transient caches are cleared and allocation data remains.
 
+## Release
+
+Run `composer dist` to build a distributable zip. The artifact will be written to `build/smartalloc-<version>.zip`.
+
+## Preflight
+
+Run `composer preflight` to verify plugin headers and version alignment before tagging a release.
+
 ## License
 
 This plugin is licensed under the MIT License. See `LICENSE` for details.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,7 +1,11 @@
 # Security Policy
 
-## Supported Versions
-- 1.0.x
+Supported versions follow [semantic versioning](https://semver.org/).
 
-## Reporting a Vulnerability
-Send reports to security@smartalloc.com.
+| Version | Supported |
+| ------- | --------- |
+| 1.x     | ✅ |
+
+### Reporting a Vulnerability
+
+Please email `security@smartalloc.com` with a clear description of the issue and steps to reproduce. We aim to respond within two business days.

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "smartalloc/wordpress-plugin",
     "description": "Event-driven student support allocation with Gravity Forms + Exporter",
     "type": "wordpress-plugin",
-    "version": "1.0.0",
+    "version": "1.0.0-rc.1",
     "license": "MIT",
     "authors": [
         {
@@ -50,8 +50,9 @@
         "coverage": "php tools/coverage.php",
         "qa": "composer cs && composer psalm && composer test",
         "ci": "composer cs && composer test:security && composer coverage",
-        "build": "rm -rf dist && mkdir dist && VERSION=$(php -r \"include 'smart-alloc.php'; echo SMARTALLOC_VERSION;\") && rsync -a . dist/smartalloc --exclude 'tests' --exclude 'stubs' --exclude 'docs' --exclude 'node_modules' --exclude '.github' --exclude 'dist' && cd dist && zip -r smartalloc-v$VERSION.zip smartalloc && rm -rf smartalloc",
-        "dist": "composer cs && composer test:security && composer test && composer build",
+        "preflight": "php tools/preflight.php",
+        "dist": "php tools/build-dist.php",
+        "release:check": "composer cs && composer phpstan && composer psalm && composer test && composer test:security && composer preflight",
         "sec:semgrep": "if command -v docker >/dev/null; then docker run --rm -v $PWD:/src returntocorp/semgrep --config=auto --timeout 120 --sarif --output semgrep.sarif /src; else echo 'Docker not installed, skipping Semgrep'; fi",
         "sec:wp": "if [ -x vendor/bin/patchstack ]; then vendor/bin/patchstack scan --format=json --output build/patchstack.json || true; else echo 'Patchstack unavailable'; fi",
         "post-install-cmd": [

--- a/smart-alloc.php
+++ b/smart-alloc.php
@@ -2,11 +2,12 @@
 /*
 Plugin Name: SmartAlloc
 Description: Event-driven student support allocation with Gravity Forms + Exporter.
-Version: 1.0.0
+Version: 1.0.0-rc.1
 Author: رضا هاشمی حسینی
 Text Domain: smartalloc
 Domain Path: /languages
 Requires at least: 6.3
+Tested up to: 6.4
 Requires PHP: 8.1
 Update URI: false
 */
@@ -22,7 +23,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Constants
-define('SMARTALLOC_VERSION', '1.0.0');
+define('SMARTALLOC_VERSION', '1.0.0-rc.1');
 define('SMARTALLOC_DB_VERSION', '1.0.0');
 define('SMARTALLOC_CAP', 'manage_smartalloc');
 define('SMARTALLOC_UPLOAD_DIR', 'smart-alloc');

--- a/tests/Tools/PreflightSmokeTest.php
+++ b/tests/Tools/PreflightSmokeTest.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+namespace SmartAlloc\Tests\Tools;
+
+use PHPUnit\Framework\TestCase;
+
+final class PreflightSmokeTest extends TestCase
+{
+    public function testPreflight(): void
+    {
+        if (!function_exists('exec')) {
+            $this->markTestSkipped('exec not available');
+        }
+        $script = __DIR__ . '/../../tools/preflight.php';
+        $cmd = escapeshellcmd(PHP_BINARY . ' ' . $script);
+        exec($cmd, $output, $exitCode);
+        $this->assertSame(0, $exitCode, implode("\n", $output));
+    }
+}

--- a/tools/build-dist.php
+++ b/tools/build-dist.php
@@ -1,0 +1,104 @@
+<?php
+declare(strict_types=1);
+
+$root = dirname(__DIR__);
+$pluginFile = $root . '/smart-alloc.php';
+$contents = file_get_contents($pluginFile);
+if ($contents === false) {
+    fwrite(STDERR, "Unable to read plugin file\n");
+    exit(1);
+}
+if (!preg_match('/^Version:\s*(.+)$/m', $contents, $m)) {
+    fwrite(STDERR, "Plugin version not found\n");
+    exit(1);
+}
+$version = trim($m[1]);
+
+$buildDir = $root . '/build';
+$tempDir = $buildDir . '/smartalloc';
+if (is_dir($tempDir)) {
+    $it = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($tempDir, RecursiveDirectoryIterator::SKIP_DOTS),
+        RecursiveIteratorIterator::CHILD_FIRST
+    );
+    foreach ($it as $file) {
+        $file->isDir() ? rmdir($file->getPathname()) : unlink($file->getPathname());
+    }
+    rmdir($tempDir);
+}
+if (!is_dir($buildDir) && !mkdir($buildDir) && !is_dir($buildDir)) {
+    fwrite(STDERR, "Unable to create build directory\n");
+    exit(1);
+}
+mkdir($tempDir);
+
+$files = [
+    'smart-alloc.php',
+    'readme.txt',
+    'README.md',
+    'SECURITY.md',
+    'CHANGELOG.md',
+    'LICENSE',
+];
+$dirs = ['src', 'assets', 'languages'];
+
+foreach ($files as $file) {
+    $src = $root . '/' . $file;
+    if (file_exists($src)) {
+        copy($src, $tempDir . '/' . $file);
+    }
+}
+foreach ($dirs as $dir) {
+    $srcDir = $root . '/' . $dir;
+    if (!is_dir($srcDir)) {
+        continue;
+    }
+    $destDir = $tempDir . '/' . $dir;
+    mkdir($destDir, 0777, true);
+    $it = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($srcDir, RecursiveDirectoryIterator::SKIP_DOTS),
+        RecursiveIteratorIterator::SELF_FIRST
+    );
+    foreach ($it as $item) {
+        $relative = substr($item->getPathname(), strlen($srcDir) + 1);
+        $destPath = $destDir . '/' . $relative;
+        if ($item->isDir()) {
+            if (!is_dir($destPath)) {
+                mkdir($destPath, 0777, true);
+            }
+        } else {
+            $dir = dirname($destPath);
+            if (!is_dir($dir)) {
+                mkdir($dir, 0777, true);
+            }
+            copy($item->getPathname(), $destPath);
+        }
+    }
+}
+
+$zipPath = $buildDir . '/smartalloc-' . $version . '.zip';
+$zip = new ZipArchive();
+if ($zip->open($zipPath, ZipArchive::CREATE | ZipArchive::OVERWRITE) !== true) {
+    fwrite(STDERR, "Unable to create zip\n");
+    exit(1);
+}
+$it = new RecursiveIteratorIterator(
+    new RecursiveDirectoryIterator($tempDir, RecursiveDirectoryIterator::SKIP_DOTS)
+);
+foreach ($it as $file) {
+    $path = substr($file->getPathname(), strlen($tempDir) + 1);
+    $zip->addFile($file->getPathname(), 'smartalloc/' . $path);
+}
+$zip->close();
+
+// cleanup temp directory
+$it = new RecursiveIteratorIterator(
+    new RecursiveDirectoryIterator($tempDir, RecursiveDirectoryIterator::SKIP_DOTS),
+    RecursiveIteratorIterator::CHILD_FIRST
+);
+foreach ($it as $file) {
+    $file->isDir() ? rmdir($file->getPathname()) : unlink($file->getPathname());
+}
+rmdir($tempDir);
+
+echo "Created dist: {$zipPath}\n";

--- a/tools/preflight.php
+++ b/tools/preflight.php
@@ -1,0 +1,77 @@
+<?php
+declare(strict_types=1);
+
+$root = dirname(__DIR__);
+$pluginFile = $root . '/smart-alloc.php';
+$composerFile = $root . '/composer.json';
+
+$headersRequired = [
+    'Plugin Name',
+    'Version',
+    'Text Domain',
+    'Requires at least',
+    'Tested up to',
+    'Requires PHP',
+];
+
+$contents = file_get_contents($pluginFile);
+if ($contents === false) {
+    fwrite(STDERR, "Unable to read plugin file\n");
+    exit(1);
+}
+
+foreach ($headersRequired as $header) {
+    if (!preg_match('/^' . preg_quote($header, '/') . ':.*$/m', $contents)) {
+        fwrite(STDERR, "Missing plugin header: {$header}\n");
+        exit(1);
+    }
+}
+
+if (!preg_match('/^Version:\s*(.+)$/m', $contents, $m)) {
+    fwrite(STDERR, "Unable to read plugin version\n");
+    exit(1);
+}
+$pluginVersion = trim($m[1]);
+
+$composer = json_decode((string) file_get_contents($composerFile), true);
+if (!is_array($composer) || empty($composer['version'])) {
+    fwrite(STDERR, "Unable to read composer version\n");
+    exit(1);
+}
+if ($composer['version'] !== $pluginVersion) {
+    fwrite(STDERR, "Version mismatch between plugin ({$pluginVersion}) and composer ({$composer['version']})\n");
+    exit(1);
+}
+
+if (strpos($contents, "load_plugin_textdomain('smartalloc'") === false) {
+    fwrite(STDERR, "Text domain not loaded correctly\n");
+    exit(1);
+}
+
+// Build dist and inspect
+$buildScript = $root . '/tools/build-dist.php';
+$cmd = escapeshellcmd(PHP_BINARY . ' ' . $buildScript);
+exec($cmd, $out, $exit); // build the zip
+if ($exit !== 0) {
+    fwrite(STDERR, "Failed to build dist\n");
+    exit(1);
+}
+
+$zipPath = $root . '/build/smartalloc-' . $pluginVersion . '.zip';
+$zip = new ZipArchive();
+if ($zip->open($zipPath) !== true) {
+    fwrite(STDERR, "Unable to open dist zip\n");
+    exit(1);
+}
+for ($i = 0; $i < $zip->numFiles; $i++) {
+    $name = $zip->getNameIndex($i);
+    if (preg_match('#/(?:vendor|tests|node_modules)/#', $name)) {
+        $zip->close();
+        fwrite(STDERR, "Dist contains disallowed paths: {$name}\n");
+        exit(1);
+    }
+}
+$zip->close();
+
+echo "Preflight checks passed\n";
+exit(0);


### PR DESCRIPTION
## Summary
- prepare plugin for 1.0.0-rc.1
- add release docs, preflight validator, and dist builder
- wire release workflow and smoke test

## Testing
- `composer release:check`
- `composer dist`
- `composer preflight`


------
https://chatgpt.com/codex/tasks/task_e_68a47c3f0e6883219db7cbb75213b2be