### PR TITLE
Add reports and logs tests

### DIFF
--- a/tests/ReportsLogs/AdminReportTest.php
+++ b/tests/ReportsLogs/AdminReportTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SmartAlloc\Tests\ReportsLogs;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use SmartAlloc\Admin\Pages\ReportsPage;
+use SmartAlloc\Tests\BaseTestCase;
+
+final class AdminReportTest extends BaseTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        if (!class_exists(Monkey::class)) {
+            self::markTestSkipped('Brain Monkey not installed');
+        }
+        Monkey\setUp();
+        Functions\when('esc_html__')->alias(fn($v) => $v);
+        Functions\when('esc_html')->alias(fn($v) => $v);
+        Functions\when('esc_attr')->alias(fn($v) => $v);
+        Functions\when('esc_url')->alias(fn($v) => $v);
+        Functions\when('admin_url')->justReturn('/admin-post.php');
+        Functions\when('submit_button')->alias(fn($v) => $v);
+        Functions\when('current_user_can')->justReturn(true);
+        Functions\when('wp_nonce_url')->alias(fn($u) => $u);
+
+        $metrics = [
+            'rows' => [[
+                'date' => '2025-01-01',
+                'allocated' => 1,
+                'manual' => 0,
+                'reject' => 0,
+                'fuzzy_auto_rate' => 0,
+                'fuzzy_manual_rate' => 0,
+                'capacity_used' => 0,
+                'mobile' => '09123456789',
+                'national_id' => '12345678',
+                'postal_code' => '12345',
+            ]],
+            'total' => [
+                'allocated' => 1,
+                'manual' => 0,
+                'reject' => 0,
+                'fuzzy_auto_rate' => 0,
+                'fuzzy_manual_rate' => 0,
+                'capacity_used' => 0,
+            ],
+        ];
+        Functions\when('apply_filters')->alias(function ($hook, $value) use ($metrics) {
+            if ($hook === 'smartalloc_reports_metrics') {
+                return $metrics;
+            }
+            return $value;
+        });
+    }
+
+    protected function tearDown(): void
+    {
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    public function test_render_has_metrics_but_no_pii(): void
+    {
+        ob_start();
+        ReportsPage::render();
+        $html = ob_get_clean();
+
+        $this->assertStringContainsString('Allocated', $html);
+        $this->assertStringNotContainsString('09123456789', $html);
+        $this->assertStringNotContainsString('12345678', $html);
+        $this->assertStringNotContainsString('12345', $html);
+    }
+}

--- a/tests/ReportsLogs/CorrelationIdTest.php
+++ b/tests/ReportsLogs/CorrelationIdTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SmartAlloc\Tests\ReportsLogs;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use SmartAlloc\Infra\Logging\Logger;
+use SmartAlloc\Http\Rest\HealthController;
+use SmartAlloc\Tests\BaseTestCase;
+
+final class CorrelationIdTest extends BaseTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        if (!class_exists(Monkey::class)) {
+            self::markTestSkipped('Brain Monkey not installed');
+        }
+        Monkey\setUp();
+        Functions\when('get_option')->alias(fn() => '1.0.0');
+    }
+
+    protected function tearDown(): void
+    {
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    public function test_id_propagates_and_hashes(): void
+    {
+        $ref = new \ReflectionClass(Logger::class);
+        $prop = $ref->getProperty('requestId');
+        $prop->setAccessible(true);
+        $prop->setValue(null, 'deadbeefdeadbeef');
+
+        $logger = new Logger();
+        $logger->info('hello');
+        $record = $logger->records[0];
+        $this->assertSame('deadbeefdeadbeef', $record['correlation_id']);
+
+        global $wpdb;
+        $wpdb = new class {
+            public $prefix = 'wp_';
+            public function get_var($sql) { return 1; }
+            public function prepare($sql, $v = []) { return $sql; }
+        };
+
+        $controller = new HealthController();
+        $resp = $controller->handle(new \WP_REST_Request());
+        $data = $resp->get_data();
+        $expected = substr(hash('sha256', 'deadbeefdeadbeef'), 0, 8);
+        $this->assertSame($expected, $data['notes']['request']);
+    }
+}

--- a/tests/ReportsLogs/RedactionTest.php
+++ b/tests/ReportsLogs/RedactionTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SmartAlloc\Tests\ReportsLogs;
+
+use SmartAlloc\Infra\Logging\Logger;
+use SmartAlloc\Tests\BaseTestCase;
+
+final class RedactionTest extends BaseTestCase
+{
+    public function test_logger_redacts_sensitive_fields(): void
+    {
+        if (!function_exists('wp_json_encode')) {
+            self::markTestSkipped('wp_json_encode missing');
+        }
+
+        $ref = new \ReflectionClass(Logger::class);
+        $prop = $ref->getProperty('requestId');
+        $prop->setAccessible(true);
+        $prop->setValue(null, 'fixedreqid12345');
+
+        $lines = [];
+        $logger = new Logger(function (string $line) use (&$lines): void {
+            $lines[] = $line;
+        });
+
+        $logger->info('msg', [
+            'mobile' => '09123456789',
+            'national_id' => '12345678',
+            'postal_code' => '12345',
+        ]);
+
+        $ctx = $logger->records[0]['context'];
+        $this->assertSame('091********', $ctx['mobile']);
+        $this->assertSame('123*****', $ctx['national_id']);
+        $this->assertSame('123**', $ctx['postal_code']);
+        $this->assertStringNotContainsString('"mobile":"09123456789"', $lines[0]);
+        $this->assertStringNotContainsString('"national_id":"12345678"', $lines[0]);
+        $this->assertStringNotContainsString('"postal_code":"12345"', $lines[0]);
+    }
+}

--- a/tests/TEST_NOTES.md
+++ b/tests/TEST_NOTES.md
@@ -18,6 +18,7 @@ Mapping to master checklist sections A–G and numerics 3.x & 8.x.
 | Exporter/Importer Path | `MappingTest`, `NormalizerTest`, `PriorityRulesTest`, `LegacySheetTest` verify Excel mappings, normalizers and priority rules (SKIP if PhpSpreadsheet/vfsStream missing). |
 | Prod-Risk A/B/C/D/E/G | `EnvLimitsTest`, `UnicodeAndCorruptionTest`, `ConcurrencyLiteTest` simulate env caps, unicode/corruption handling and idempotent locks (SKIP if env unknown or handlers absent). |
 | Debug Kit | `ErrorCollectorTest` verifies redaction, breadcrumbs and SAVEQUERIES behaviour; `DebugIntegrationTest` covers nonce/capability checks and prompt context; `DebugKitTest` guards against PII leakage and ensures only sanitized prepared SQL is surfaced. `ReproBuilderTest` scaffolds repros, `DebugBundleIntegrationTest` downloads bundles and `DebugBundleSecurityTest` scans for PII (requires `SAVEQUERIES` for SQL samples). |
+| Reports & Logs | `RedactionTest` masks mobile/national_id/postal_code; `CorrelationIdTest` checks request id propagation and health hashing; `AdminReportTest` renders metrics without leaking PII (SKIP if Brain Monkey/helpers missing). |
 | Chaos/Resilience | `ReproBuilderTest` and `DebugBundleIntegrationTest` validate reproducible scaffolds and admin/CLI flows. |
 | GF/i18n | Repro blueprints and tests remain locale-neutral and RTL-safe. |
 | Repro Hardening | Bundles stay under 1MB and PII-free; blueprint schema, nonce and capability checks are validated. |


### PR DESCRIPTION
## Summary
- cover logger redaction for mobile/national ID/postal code
- ensure correlation ID propagates and hashes into health notes
- render admin metrics snapshot without leaking PII

## Testing
- `composer cs`
- `composer phpstan`
- `composer psalm`
- `composer test`
- `composer test:security`


------
https://chatgpt.com/codex/tasks/task_e_68a48d99b7108321b51b3486f7c619f1