### PR TITLE
Add conflict marker guard test

### DIFF
--- a/tests/TEST_NOTES.md
+++ b/tests/TEST_NOTES.md
@@ -31,3 +31,9 @@ These tests do not modify runtime code. If a prerequisite such as Brain Monkey, 
 - Static analysis: PHPStan level 9 (`composer phpstan`) and Psalm
 - Deprecations fail tests by default (`SA_FAIL_ON_DEPRECATION=0` to allow)
 - Coverage gate: `composer coverage` enforces **MIN_COVERAGE=85** for ExporterService, Http/Rest and Compat namespaces (others TBD)
+
+## Conflict Cleanup & Discovery
+
+- `NoConflictMarkersTest` fails if merge conflict markers remain in the tree.
+- PHP 8.3 feature tests skip on older runtimes using `PHP_VERSION_ID`/`function_exists` guards.
+- PHPUnit discovery remains default; no additional paths were required.

--- a/tests/_tools/NoConflictMarkersTest.php
+++ b/tests/_tools/NoConflictMarkersTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SmartAlloc\Tests\Tools;
+
+use PHPUnit\Framework\TestCase;
+
+final class NoConflictMarkersTest extends TestCase
+{
+    public function test_no_conflict_markers_left(): void
+    {
+        $root = dirname(__DIR__, 2);
+        $it   = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($root, \FilesystemIterator::SKIP_DOTS)
+        );
+        $bad = [];
+        foreach ($it as $f) {
+            if (!$f->isFile()) {
+                continue;
+            }
+            $path = $f->getPathname();
+            if ($path === __FILE__) {
+                continue;
+            }
+            if (preg_match('~/(vendor|node_modules|dist|\.git)/~', $path)) {
+                continue;
+            }
+            $ext = pathinfo($path, PATHINFO_EXTENSION);
+            if (!in_array($ext, ['php', 'md', 'xml', 'yml', 'yaml', 'json', 'neon'], true)) {
+                continue;
+            }
+            $c = @file_get_contents($path);
+            if ($c === false) {
+                continue;
+            }
+            if (strpos($c, '<<<<<<<') !== false || strpos($c, '>>>>>>>') !== false || strpos($c, '=======') !== false) {
+                $bad[] = $path;
+            }
+        }
+        if ($bad !== []) {
+            $this->fail("Conflict markers found:\n - " . implode("\n - ", $bad));
+        }
+        $this->assertTrue(true);
+    }
+}


### PR DESCRIPTION
## Summary
- add NoConflictMarkersTest to fail fast if merge conflict markers are present
- document conflict cleanup and default test discovery in TEST_NOTES

## Testing
- `composer cs`
- `composer phpstan`
- `composer psalm`
- `composer test`
- `./vendor/bin/phpunit tests/Php83`
- `composer test:security`


------
https://chatgpt.com/codex/tasks/task_e_68a490f683e0832194b873ba2780ca5e