### PR TITLE
Add opt-in security and performance test scaffolding

### DIFF
--- a/docs/POST_RELEASE.md
+++ b/docs/POST_RELEASE.md
@@ -1,0 +1,22 @@
+# Post-Release Monitoring & Operations (SmartAlloc)
+
+## Weekly
+- Patchstack scan & dependency review (record findings)
+- Review error logs & redaction samples (PII-free)
+
+## Continuous Monitoring
+- Error rate < 0.1% (Sentry)
+- Web Vitals: LCP < 2.5s, CLS < 0.1 (Lighthouse/RUM)
+- Export latency and failure rate dashboards
+
+## Monthly
+- Performance benchmark (form render/export)
+- Review transient/options growth; retention jobs health
+
+## Quarterly
+- Compatibility matrix: PHP/WP/GF versions
+- Security posture review (Semgrep/Snyk/Patchstack)
+
+## Links
+- Dashboards (fill in URLs)
+- Playbooks & On-call (fill in)

--- a/tests/e2e/BlockEditorSmokeTest.php
+++ b/tests/e2e/BlockEditorSmokeTest.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class BlockEditorSmokeTest extends TestCase
+{
+    public function test_block_json_api_v3_or_skip(): void
+    {
+        $root = dirname(__DIR__, 2);
+        $it = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($root));
+        $blockJsons = [];
+        foreach ($it as $f) {
+            if ($f->isFile() && $f->getFilename() === 'block.json' && strpos($f->getPathname(), '/tests/') === false && strpos($f->getPathname(), '/vendor/') === false) {
+                $blockJsons[] = $f->getPathname();
+            }
+        }
+        if (empty($blockJsons)) {
+            $this->markTestSkipped('No custom block — API v3 compliance not applicable');
+        }
+        $ok = false;
+        foreach ($blockJsons as $p) {
+            $data = json_decode((string) file_get_contents($p), true);
+            if (isset($data['apiVersion']) && (int) $data['apiVersion'] === 3 && isset($data['name']) && isset($data['title']) && (isset($data['editorScript']) || isset($data['editorScriptModule'])) && (isset($data['style']) || isset($data['editorStyle']))) {
+                $ok = true;
+            }
+        }
+        $this->assertTrue($ok, 'Found block.json but apiVersion 3 missing');
+    }
+}

--- a/tests/integration/GFSecurityHooksTest.php
+++ b/tests/integration/GFSecurityHooksTest.php
@@ -1,0 +1,77 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class GFSecurityHooksTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!class_exists('\\Brain\\Monkey\\Functions')) {
+            $this->markTestSkipped('Brain Monkey not installed');
+        }
+        \Brain\Monkey\setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        if (class_exists('\\Brain\\Monkey')) {
+            \Brain\Monkey\tearDown();
+        }
+    }
+
+    public function test_gf_security_hooks_registered_or_skipped(): void
+    {
+        if (!function_exists('has_filter')) {
+            $this->markTestSkipped('WP not bootstrapped');
+        }
+
+        $hooks = [
+            'gform_form_post_get_meta',
+            'gform_field_validation',
+            'gform_pre_submission_filter',
+            'gform_post_submission',
+        ];
+
+        $container = $this->createStub(\SmartAlloc\Container::class);
+        $eventBus = $this->createStub(\SmartAlloc\Event\EventBus::class);
+        $logger = $this->createStub(\SmartAlloc\Contracts\LoggerInterface::class);
+
+        // Attempt to register hooks if class exists
+        if (class_exists(\SmartAlloc\Integration\GravityForms::class)) {
+            $gf = new \SmartAlloc\Integration\GravityForms($container, $eventBus, $logger);
+            $gf->register();
+        }
+
+        $found = 0;
+        foreach ($hooks as $hook) {
+            if (has_filter($hook)) {
+                $found++;
+                switch ($hook) {
+                    case 'gform_field_validation':
+                        $res = apply_filters($hook, ['is_valid' => true], 'value', ['id' => 1], ['id' => 1]);
+                        $this->assertArrayHasKey('is_valid', $res);
+                        break;
+                    case 'gform_pre_submission_filter':
+                        $form = apply_filters($hook, ['id' => 1], ['id' => 1]);
+                        $this->assertIsArray($form);
+                        break;
+                    case 'gform_form_post_get_meta':
+                        do_action($hook, ['id' => 1]);
+                        $this->assertTrue(true);
+                        break;
+                    case 'gform_post_submission':
+                        do_action($hook, ['id' => 1], ['id' => 1]);
+                        $this->assertTrue(true);
+                        break;
+                }
+            }
+        }
+
+        if ($found === 0) {
+            $this->markTestSkipped('no GF callbacks registered in this environment');
+        }
+
+        $this->assertGreaterThan(0, $found);
+    }
+}

--- a/tests/integration/Performance/RequestBudgetTest.php
+++ b/tests/integration/Performance/RequestBudgetTest.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class RequestBudgetTest extends TestCase
+{
+    public function test_request_budget_opt_in(): void
+    {
+        if (getenv('RUN_PERFORMANCE_TESTS') !== '1') {
+            $this->markTestSkipped('performance tests opt-in');
+        }
+        if (!function_exists('get_num_queries')) {
+            $this->markTestSkipped('WP not bootstrapped / wp-browser missing');
+        }
+
+        $queries = function_exists('get_num_queries') ? get_num_queries() : -1;
+        if ($queries === -1) {
+            $this->markTestSkipped('SAVEQUERIES not enabled');
+        }
+
+        $mem = memory_get_peak_usage(true);
+        $this->assertLessThan(50, $queries, 'query budget exceeded');
+        $this->assertLessThan(32 * 1024 * 1024, $mem, 'memory budget exceeded');
+    }
+}

--- a/tests/unit/Security/NonceVerificationTest.php
+++ b/tests/unit/Security/NonceVerificationTest.php
@@ -1,0 +1,74 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class NonceVerificationTest extends TestCase
+{
+    public function test_nonce_usage_is_present_or_allowlisted(): void
+    {
+        if (getenv('RUN_SECURITY_TESTS') !== '1') {
+            $this->markTestSkipped('security tests opt-in');
+        }
+        if (!class_exists('\\Brain\\Monkey\\Functions')) {
+            $this->markTestSkipped('Brain Monkey not installed');
+        }
+        if (!function_exists('token_get_all')) {
+            $this->markTestSkipped('tokenizer missing');
+        }
+
+        $files = $this->collectPhpFiles(dirname(__DIR__, 3));
+        $handlers = $this->findSensitiveHandlers($files);
+
+        if (count($handlers) === 0) {
+            $this->markTestSkipped('no handlers found');
+        }
+
+        $violations = [];
+        foreach ($handlers as $file) {
+            $src = file_get_contents($file) ?: '';
+            $hasAllowlist = strpos($src, '@security-ok-nonce') !== false;
+            $hasNonce =
+                preg_match('/wp_verify_nonce\s*\(/', $src) ||
+                preg_match('/check_ajax_referer\s*\(/', $src) ||
+                preg_match('/wp_nonce_field\s*\(/', $src);
+
+            if (!$hasNonce && !$hasAllowlist) {
+                $violations[] = $file;
+            }
+        }
+
+        if (!empty($violations)) {
+            $this->fail('Missing nonce verification in: ' . implode(', ', $violations));
+        }
+
+        $this->assertTrue(true);
+    }
+
+    private function collectPhpFiles(string $root): array
+    {
+        $rii = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($root));
+        $out = [];
+        foreach ($rii as $f) {
+            if ($f->isFile() && substr($f->getFilename(), -4) === '.php' && strpos($f->getPathname(), '/tests/') === false && strpos($f->getPathname(), '/vendor/') === false) {
+                $out[] = $f->getPathname();
+            }
+        }
+        return $out;
+    }
+
+    private function findSensitiveHandlers(array $files): array
+    {
+        $hits = [];
+        foreach ($files as $file) {
+            $src = file_get_contents($file) ?: '';
+            if (
+                preg_match("/add_action\s*\(\s*['\"](wp_ajax_|admin_post_)/", $src) ||
+                strpos($src, 'rest_api_init') !== false
+            ) {
+                $hits[] = $file;
+            }
+        }
+        return $hits;
+    }
+}

--- a/tests/unit/Security/SQLInjectionTest.php
+++ b/tests/unit/Security/SQLInjectionTest.php
@@ -1,0 +1,55 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class SQLInjectionTest extends TestCase
+{
+    public function test_wpdb_usage_is_prepared_or_allowlisted(): void
+    {
+        if (getenv('RUN_SECURITY_TESTS') !== '1') {
+            $this->markTestSkipped('security tests opt-in');
+        }
+
+        $files = $this->collectPhpFiles(dirname(__DIR__, 3));
+        $violations = [];
+        $found = false;
+
+        foreach ($files as $file) {
+            $src = file_get_contents($file) ?: '';
+            if (strpos($src, '@security-ok-sql') !== false) {
+                continue;
+            }
+            if (preg_match('/\$wpdb->(query|get_results|get_row|get_col|prepare)\s*\(/', $src)) {
+                $found = true;
+            }
+            $hasQuery = preg_match('/\$wpdb->(query|get_results|get_row|get_col)\s*\(/', $src);
+            $hasPrepareNearby = preg_match('/\$wpdb->prepare\s*\(/', $src);
+            if ($hasQuery && !$hasPrepareNearby) {
+                $violations[] = $file;
+            }
+        }
+
+        if (!$found) {
+            $this->markTestSkipped('no SQL usage found');
+        }
+
+        if (!empty($violations)) {
+            $this->fail('Unprepared $wpdb usage in: ' . implode(', ', $violations));
+        }
+
+        $this->assertTrue(true);
+    }
+
+    private function collectPhpFiles(string $root): array
+    {
+        $rii = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($root));
+        $out = [];
+        foreach ($rii as $f) {
+            if ($f->isFile() && substr($f->getFilename(), -4) === '.php' && strpos($f->getPathname(), '/tests/') === false && strpos($f->getPathname(), '/vendor/') === false) {
+                $out[] = $f->getPathname();
+            }
+        }
+        return $out;
+    }
+}

--- a/tests/unit/Validation/PersianValidatorTest.php
+++ b/tests/unit/Validation/PersianValidatorTest.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class PersianValidatorTest extends TestCase
+{
+    public function test_national_id_and_card_validation_or_skip(): void
+    {
+        if (!function_exists('smartalloc_validate_national_id') && !class_exists('\\SmartAlloc\\Validators')) {
+            $this->markTestSkipped('feature not implemented');
+        }
+
+        $this->assertTrue($this->isValidIranNationalId('0084575948'));
+        $this->assertFalse($this->isValidIranNationalId('1111111111'));
+        $this->assertTrue($this->luhn('6274129000001234'));
+        $this->assertFalse($this->luhn('6274129000001235'));
+    }
+
+    private function luhn(string $s): bool
+    {
+        $sum = 0; $alt = false;
+        for ($i = strlen($s) - 1; $i >= 0; $i--) {
+            $n = (int) $s[$i];
+            if ($alt) { $n *= 2; if ($n > 9) { $n -= 9; } }
+            $sum += $n; $alt = !$alt;
+        }
+        return $sum % 10 === 0;
+    }
+
+    private function isValidIranNationalId(string $nid): bool
+    {
+        if (!preg_match('/^\d{10}$/', $nid)) { return false; }
+        if (preg_match('/^(\d)\1{9}$/', $nid)) { return false; }
+        $c = (int) $nid[9];
+        $sum = 0;
+        for ($i = 0; $i < 9; $i++) { $sum += (int) $nid[$i] * (10 - $i); }
+        $r = $sum % 11;
+        return ($r < 2 && $c == $r) || ($r >= 2 && $c + $r == 11);
+    }
+}


### PR DESCRIPTION
## Summary
- add nonce and SQL scan tests gated by RUN_SECURITY_TESTS
- add Gravity Forms hook coverage, block.json smoke, and Persian validators
- document post-release monitoring steps

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68a595b983488321ac9888a96e2894fd