### PR TITLE
test: cover uninstall cleanup keys

### DIFF
--- a/docs/SECURITY_SCANS.md
+++ b/docs/SECURITY_SCANS.md
@@ -1,0 +1,23 @@
+# Security Scans
+
+This project can be scanned locally for known vulnerabilities. These checks are optional and are not wired into CI by default.
+
+## WPScan
+
+Run [WPScan](https://wpscan.com) against a local WordPress site to look for core, plugin, and theme issues:
+
+```bash
+wpscan --url http://localhost --api-token YOUR_TOKEN
+```
+
+## Patchstack, Semgrep, and Snyk
+
+These tools can run in a separate, non-blocking job to provide additional coverage:
+
+```bash
+composer sec:wp      # Patchstack scan (requires access to repo)
+composer sec:semgrep # Semgrep static analysis
+snyk test --file=composer.lock
+```
+
+Configure your CI to treat these scans as informative only. Failures should not block merges unless you decide to enforce them.

--- a/tests/fixtures/uninstall-expected.php
+++ b/tests/fixtures/uninstall-expected.php
@@ -2,9 +2,18 @@
 // Return an array of option/transient keys that uninstall.php is expected to delete.
 // Maintain as test-only truth; empty array means SKIP (keeps CI green until filled).
 return [
-    // Example keys (adjust by maintainers as needed):
-    // 'smartalloc_settings',
-    // 'smartalloc_export_retention_days',
-    // '_transient_smartalloc_export_lock',
+    'smartalloc_form_id',
+    'smartalloc_form_id_updated_at',
+    'smartalloc_settings',
+    'smartalloc_version',
+    'smartalloc_last_migration',
+    'smartalloc_debug_enabled',
+    'smartalloc_debug_errors',
+    'smartalloc_purge_on_uninstall',
+    'smartalloc_db_version',
+    'smartalloc_metrics',
+    'smartalloc_export_cb',
+    'export_rate_limit',
+    '_transient_smartalloc_metrics_cache',
 ];
 


### PR DESCRIPTION
## Summary
- list real option and transient keys for uninstall cleanup
- tighten uninstall test and note site-level deletions
- document optional security scan commands

## Testing
- `composer cs`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68a5aafa61248321ae89f8cd12c5968a