### PR TITLE
Add REST permission guard and QA report tooling

### DIFF
--- a/docs/QA_REPORT.md
+++ b/docs/QA_REPORT.md
@@ -1,0 +1,24 @@
+# QA Report
+
+The project includes a helper script for generating an overview of test status.
+
+## Generating the report
+
+Run:
+
+```
+php scripts/qa-report.php
+```
+
+This writes `qa-report.json` and `qa-report.html` in the repository root. The script never exits with a non-zero status and notes missing artifacts such as code coverage.
+
+## Interpreting the report
+
+`qa-report.json` contains:
+
+- `coverage_percent` – overall coverage percentage from `coverage-unit/index.xml` when available.
+- `env` – state of `RUN_SECURITY_TESTS`, `RUN_PERFORMANCE_TESTS` and `E2E` environment variables.
+- `test_files` – number of `*Test.php` files under `tests/`.
+- `notes` – any warnings about missing data.
+
+The HTML version renders the same information in a simple right-to-left layout for RTL readers.

--- a/scripts/qa-report.php
+++ b/scripts/qa-report.php
@@ -1,0 +1,63 @@
+<?php
+declare(strict_types=1);
+
+if (php_sapi_name() !== 'cli') {
+    echo "CLI only\n";
+    exit(0);
+}
+
+$root = dirname(__DIR__);
+$coverageFile = $root . '/coverage-unit/index.xml';
+$coverage = null;
+$notes = [];
+
+if (is_file($coverageFile)) {
+    $xml = @simplexml_load_file($coverageFile);
+    if ($xml !== false && isset($xml['line-rate'])) {
+        $coverage = round(((float) $xml['line-rate']) * 100, 2);
+    } else {
+        $notes[] = 'coverage parse failed';
+    }
+} else {
+    $notes[] = 'coverage missing';
+}
+
+$env = [
+    'RUN_SECURITY_TESTS'    => getenv('RUN_SECURITY_TESTS') === '1',
+    'RUN_PERFORMANCE_TESTS' => getenv('RUN_PERFORMANCE_TESTS') === '1',
+    'E2E'                   => getenv('E2E') === '1',
+];
+
+$testFiles = 0;
+$rii = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($root . '/tests'));
+foreach ($rii as $file) {
+    if ($file->isFile() && substr($file->getFilename(), -8) === 'Test.php') {
+        $testFiles++;
+    }
+}
+
+$data = [
+    'coverage_percent' => $coverage,
+    'env' => $env,
+    'test_files' => $testFiles,
+    'notes' => $notes,
+];
+
+file_put_contents($root . '/qa-report.json', json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . PHP_EOL);
+
+$html  = '<!DOCTYPE html><html dir="rtl"><meta charset="utf-8"><title>QA Report</title><body>';
+$html .= '<h1>QA Report</h1><ul>';
+$html .= '<li>Coverage: ' . ($coverage !== null ? $coverage . '%' : 'N/A') . '</li>';
+$html .= '<li>Test files: ' . $testFiles . '</li>';
+$html .= '<li>Env toggles:<ul>';
+foreach ($env as $k => $v) {
+    $html .= '<li>' . htmlspecialchars($k, ENT_QUOTES, 'UTF-8') . ': ' . ($v ? 'on' : 'off') . '</li>';
+}
+$html .= '</ul></li>';
+if ($notes) {
+    $html .= '<li>Notes: ' . htmlspecialchars(implode(', ', $notes), ENT_QUOTES, 'UTF-8') . '</li>';
+}
+$html .= '</ul></body></html>';
+file_put_contents($root . '/qa-report.html', $html);
+
+exit(0);

--- a/tests/unit/Security/RestPermissionsTest.php
+++ b/tests/unit/Security/RestPermissionsTest.php
@@ -1,0 +1,110 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class RestPermissionsTest extends TestCase
+{
+    public function test_rest_routes_have_permissions(): void
+    {
+        if (getenv('RUN_SECURITY_TESTS') !== '1') {
+            $this->markTestSkipped('security tests opt-in');
+        }
+        $files = $this->collectPhpFiles(dirname(__DIR__, 3));
+        $routes = $this->findRestRoutes($files);
+        if (count($routes) === 0) {
+            $this->markTestSkipped('no routes found');
+        }
+        $violations = [];
+        foreach ($routes as $file => $calls) {
+            $src = file_get_contents($file) ?: '';
+            if (strpos($src, '@security-ok-rest') !== false) {
+                continue;
+            }
+            foreach ($calls as $call) {
+                if (!$this->hasSecurePermissionCallback($call)) {
+                    $violations[] = $file;
+                    break;
+                }
+            }
+        }
+        if (!empty($violations)) {
+            $this->fail('Insecure REST permissions in: ' . implode(', ', $violations));
+        }
+        $this->assertTrue(true);
+    }
+
+    private function collectPhpFiles(string $root): array
+    {
+        $rii = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($root));
+        $out = [];
+        foreach ($rii as $f) {
+            if ($f->isFile() && substr($f->getFilename(), -4) === '.php' && strpos($f->getPathname(), '/tests/') === false && strpos($f->getPathname(), '/vendor/') === false) {
+                $out[] = $f->getPathname();
+            }
+        }
+        return $out;
+    }
+
+    /**
+     * @param array<string> $files
+     * @return array<string,array<int,string>>
+     */
+    private function findRestRoutes(array $files): array
+    {
+        $out = [];
+        foreach ($files as $file) {
+            $src = file_get_contents($file) ?: '';
+            $offset = 0;
+            while (($pos = strpos($src, 'register_rest_route', $offset)) !== false) {
+                $call = $this->extractCall($src, $pos);
+                if ($call !== null) {
+                    $out[$file][] = $call;
+                    $offset = $pos + 1;
+                } else {
+                    break;
+                }
+            }
+        }
+        return $out;
+    }
+
+    private function extractCall(string $src, int $start): ?string
+    {
+        $open = strpos($src, '(', $start);
+        if ($open === false) {
+            return null;
+        }
+        $depth = 1;
+        $i = $open + 1;
+        $len = strlen($src);
+        while ($i < $len && $depth > 0) {
+            $ch = $src[$i];
+            if ($ch === '(') {
+                $depth++;
+            } elseif ($ch === ')') {
+                $depth--;
+            }
+            $i++;
+        }
+        if ($depth !== 0) {
+            return null;
+        }
+        return substr($src, $start, $i - $start);
+    }
+
+    private function hasSecurePermissionCallback(string $call): bool
+    {
+        if (strpos($call, 'permission_callback') === false) {
+            return false;
+        }
+        if (preg_match('/permission_callback\s*=>\s*([^,\)]+)/', $call, $m)) {
+            $val = strtolower(trim($m[1], " \t\n\r\"'"));
+            if ($val === '__return_true' || $val === 'true' || $val === '1') {
+                return false;
+            }
+            return true;
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
## Summary
- add static `RestPermissionsTest` that scans REST routes for real permission checks
- introduce `scripts/qa-report.php` to produce JSON/HTML QA reports
- document QA report usage

## Testing
- `composer test`
- `php scripts/qa-report.php`


------
https://chatgpt.com/codex/tasks/task_e_68a5b9d52bd483218e19a9b5b6199629