### PR TITLE
Add REST permission scanner and QA report integration

### DIFF
--- a/docs/QA_REPORT.md
+++ b/docs/QA_REPORT.md
@@ -1,6 +1,6 @@
 # QA Report
 
-The project includes a helper script for generating an overview of test status.
+The project includes helper scripts for generating an overview of test status and scanning REST permissions.
 
 ## Generating the report
 
@@ -12,6 +12,20 @@ php scripts/qa-report.php
 
 This writes `qa-report.json` and `qa-report.html` in the repository root. The script never exits with a non-zero status and notes missing artifacts such as code coverage.
 
+To scan REST routes for insecure or missing permission callbacks, run:
+
+```
+php scripts/scan-rest-permissions.php > rest-violations.json
+```
+
+The scanner prints a JSON array of files and always exits with code `0`.
+
+To automatically run the scan before pushing, install the sample pre-push hook:
+
+```
+ln -sf ../../scripts/git-hooks/pre-push.sample .git/hooks/pre-push
+```
+
 ## Interpreting the report
 
 `qa-report.json` contains:
@@ -19,6 +33,7 @@ This writes `qa-report.json` and `qa-report.html` in the repository root. The sc
 - `coverage_percent` – overall coverage percentage from `coverage-unit/index.xml` when available.
 - `env` – state of `RUN_SECURITY_TESTS`, `RUN_PERFORMANCE_TESTS` and `E2E` environment variables.
 - `test_files` – number of `*Test.php` files under `tests/`.
+- `rest_permission_violations` – count of insecure REST route permissions when the scanner is available.
 - `notes` – any warnings about missing data.
 
 The HTML version renders the same information in a simple right-to-left layout for RTL readers.

--- a/scripts/git-hooks/pre-push.sample
+++ b/scripts/git-hooks/pre-push.sample
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Scan REST permissions before pushing.
+# Install with:
+#   ln -sf ../../scripts/git-hooks/pre-push.sample .git/hooks/pre-push
+
+output="$(php scripts/scan-rest-permissions.php)"
+echo "$output" | jq .
+
+# Uncomment the next line to make this hook blocking on violations:
+# test "$(echo "$output" | jq 'length')" -eq 0 || exit 1
+
+exit 0

--- a/scripts/qa-report.php
+++ b/scripts/qa-report.php
@@ -36,10 +36,29 @@ foreach ($rii as $file) {
     }
 }
 
+$restViolations = null;
+$scanner = $root . '/scripts/scan-rest-permissions.php';
+if (is_file($scanner)) {
+    $json = @shell_exec('php ' . escapeshellarg($scanner));
+    if ($json !== null) {
+        $decoded = json_decode($json, true);
+        if (is_array($decoded)) {
+            $restViolations = count($decoded);
+        } else {
+            $notes[] = 'rest permission scan parse failed';
+        }
+    } else {
+        $notes[] = 'rest permission scan failed';
+    }
+} else {
+    $notes[] = 'rest permission scanner missing';
+}
+
 $data = [
     'coverage_percent' => $coverage,
     'env' => $env,
     'test_files' => $testFiles,
+    'rest_permission_violations' => $restViolations,
     'notes' => $notes,
 ];
 
@@ -49,6 +68,7 @@ $html  = '<!DOCTYPE html><html dir="rtl"><meta charset="utf-8"><title>QA Report<
 $html .= '<h1>QA Report</h1><ul>';
 $html .= '<li>Coverage: ' . ($coverage !== null ? $coverage . '%' : 'N/A') . '</li>';
 $html .= '<li>Test files: ' . $testFiles . '</li>';
+$html .= '<li>REST permission violations: ' . ($restViolations !== null ? $restViolations : 'N/A') . '</li>';
 $html .= '<li>Env toggles:<ul>';
 foreach ($env as $k => $v) {
     $html .= '<li>' . htmlspecialchars($k, ENT_QUOTES, 'UTF-8') . ': ' . ($v ? 'on' : 'off') . '</li>';

--- a/scripts/scan-rest-permissions.php
+++ b/scripts/scan-rest-permissions.php
@@ -1,0 +1,111 @@
+#!/usr/bin/env php
+<?php
+declare(strict_types=1);
+
+if (php_sapi_name() !== 'cli') {
+    echo "CLI only\n";
+    exit(0);
+}
+
+$options = getopt('', ['allowlist-tag:']);
+$allowTag = $options['allowlist-tag'] ?? '@security-ok-rest';
+
+$root = dirname(__DIR__);
+$files = collectPhpFiles($root);
+$routes = findRestRoutes($files);
+$violations = [];
+foreach ($routes as $file => $calls) {
+    $src = file_get_contents($file) ?: '';
+    if (strpos($src, $allowTag) !== false) {
+        continue;
+    }
+    foreach ($calls as $call) {
+        if (!hasSecurePermissionCallback($call)) {
+            $violations[] = $file;
+            break;
+        }
+    }
+}
+
+echo json_encode($violations, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . PHP_EOL;
+
+exit(0);
+
+function collectPhpFiles(string $root): array
+{
+    $rii = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($root));
+    $out = [];
+    foreach ($rii as $f) {
+        if (
+            $f->isFile() &&
+            substr($f->getFilename(), -4) === '.php' &&
+            strpos($f->getPathname(), '/tests/') === false &&
+            strpos($f->getPathname(), '/vendor/') === false
+        ) {
+            $out[] = $f->getPathname();
+        }
+    }
+    return $out;
+}
+
+/**
+ * @param array<string> $files
+ * @return array<string,array<int,string>>
+ */
+function findRestRoutes(array $files): array
+{
+    $out = [];
+    foreach ($files as $file) {
+        $src = file_get_contents($file) ?: '';
+        $offset = 0;
+        while (($pos = strpos($src, 'register_rest_route', $offset)) !== false) {
+            $call = extractCall($src, $pos);
+            if ($call !== null) {
+                $out[$file][] = $call;
+                $offset = $pos + 1;
+            } else {
+                break;
+            }
+        }
+    }
+    return $out;
+}
+
+function extractCall(string $src, int $start): ?string
+{
+    $open = strpos($src, '(', $start);
+    if ($open === false) {
+        return null;
+    }
+    $depth = 1;
+    $i = $open + 1;
+    $len = strlen($src);
+    while ($i < $len && $depth > 0) {
+        $ch = $src[$i];
+        if ($ch === '(') {
+            $depth++;
+        } elseif ($ch === ')') {
+            $depth--;
+        }
+        $i++;
+    }
+    if ($depth !== 0) {
+        return null;
+    }
+    return substr($src, $start, $i - $start);
+}
+
+function hasSecurePermissionCallback(string $call): bool
+{
+    if (strpos($call, 'permission_callback') === false) {
+        return false;
+    }
+    if (preg_match('/permission_callback\s*=>\s*([^,\)]+)/', $call, $m)) {
+        $val = strtolower(trim($m[1], " \t\n\r\"'"));
+        if ($val === '__return_true' || $val === 'true' || $val === '1') {
+            return false;
+        }
+        return true;
+    }
+    return false;
+}


### PR DESCRIPTION
## Summary
- add `scan-rest-permissions.php` CLI to find REST routes without secure permission callbacks
- sample `pre-push` git hook that runs the scanner
- QA report now counts REST permission violations

## Testing
- `composer test`
- `php scripts/scan-rest-permissions.php`
- `php scripts/qa-report.php`


------
https://chatgpt.com/codex/tasks/task_e_68a5bcadd55083218d221e8a3b33336f