### PR TITLE
Add QA helper scripts and headers guard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,4 +74,5 @@ e2e/downloads/
 artifacts/
 artifacts/axe/
 artifacts/lighthouse/
+artifacts/qa/
 *.lhreport.html

--- a/docs/QA_REPORT.md
+++ b/docs/QA_REPORT.md
@@ -41,6 +41,30 @@ To automatically run the SQL scanner before committing, install the sample pre-c
 ln -sf ../../scripts/git-hooks/pre-commit.sample .git/hooks/pre-commit
 ```
 
+To scan for leaked secrets, run:
+
+```
+php scripts/scan-secrets.php > secrets.json
+```
+
+The tool emits a JSON array of findings with `file`, `line`, `type`, and `snippet` fields. Investigate any reported secrets and allowlist intentional ones with `@security-ok-secret`.
+
+To audit Composer licenses, run:
+
+```
+php scripts/license-audit.php > licenses.json
+```
+
+The audit prints JSON containing a `summary` (`total`, `unknown`, `denied`) and a detailed `packages` list. Review packages with unknown or denied licenses and resolve issues before release.
+
+To bundle QA artifacts, run:
+
+```
+php scripts/qa-bundle.php
+```
+
+This writes `artifacts/qa/qa-bundle.zip` with available reports and the latest Axe/Lighthouse outputs for easy sharing.
+
 ## Interpreting the report
 
 `qa-report.json` contains:

--- a/scripts/license-audit.php
+++ b/scripts/license-audit.php
@@ -1,0 +1,53 @@
+<?php
+declare(strict_types=1);
+
+$root = dirname(__DIR__);
+$denyList = [];
+foreach ($argv as $arg) {
+    if (str_starts_with($arg, '--deny=')) {
+        $denyList = array_filter(array_map('trim', explode(',', substr($arg, 7))));
+    }
+}
+
+$lockFile = $root . '/composer.lock';
+if (!is_file($lockFile)) {
+    echo json_encode(['error' => 'composer.lock not found']) . PHP_EOL;
+    exit(0);
+}
+
+$data = json_decode((string)file_get_contents($lockFile), true);
+$packages = [];
+foreach (['packages', 'packages-dev'] as $section) {
+    foreach ($data[$section] ?? [] as $pkg) {
+        $licenses = $pkg['license'] ?? [];
+        $licenses = is_array($licenses) ? $licenses : [$licenses];
+        $status = 'ok';
+        if (empty($licenses)) {
+            $status = 'unknown';
+        } elseif (!empty($denyList) && array_intersect($licenses, $denyList)) {
+            $status = 'denied';
+        }
+        $packages[] = [
+            'name' => $pkg['name'],
+            'version' => $pkg['version'] ?? '',
+            'licenses' => $licenses,
+            'status' => $status,
+        ];
+    }
+}
+
+$total = count($packages);
+$unknown = count(array_filter($packages, static fn($p) => $p['status'] === 'unknown'));
+$denied = count(array_filter($packages, static fn($p) => $p['status'] === 'denied'));
+
+$output = [
+    'summary' => [
+        'total' => $total,
+        'unknown' => $unknown,
+        'denied' => $denied,
+    ],
+    'packages' => $packages,
+];
+
+echo json_encode($output, JSON_PRETTY_PRINT) . PHP_EOL;
+exit(0);

--- a/scripts/qa-bundle.php
+++ b/scripts/qa-bundle.php
@@ -1,0 +1,65 @@
+<?php
+declare(strict_types=1);
+
+$root = dirname(__DIR__);
+$outDir = $root . '/artifacts/qa';
+if (!is_dir($outDir)) {
+    mkdir($outDir, 0777, true);
+}
+$outZip = $outDir . '/qa-bundle.zip';
+
+$files = [];
+$addIfExists = function (string $path) use (&$files) {
+    if (is_file($path)) {
+        $files[$path] = basename($path);
+    }
+};
+
+$addIfExists($root . '/qa-report.json');
+$addIfExists($root . '/qa-report.html');
+$addIfExists($root . '/rest-violations.json');
+$addIfExists($root . '/sql-violations.json');
+
+function latest_in_dir(string $dir): ?string {
+    if (!is_dir($dir)) {
+        return null;
+    }
+    $iterator = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($dir, FilesystemIterator::SKIP_DOTS)
+    );
+    $latest = null;
+    $mtime = 0;
+    foreach ($iterator as $file) {
+        if ($file->isFile()) {
+            $t = $file->getMTime();
+            if ($t > $mtime) {
+                $mtime = $t;
+                $latest = $file->getPathname();
+            }
+        }
+    }
+    return $latest;
+}
+
+$latestAxe = latest_in_dir($root . '/artifacts/axe');
+$latestLh = latest_in_dir($root . '/artifacts/lighthouse');
+if ($latestAxe) {
+    $files[$latestAxe] = basename($latestAxe);
+}
+if ($latestLh) {
+    $files[$latestLh] = basename($latestLh);
+}
+
+$zip = new ZipArchive();
+if ($zip->open($outZip, ZipArchive::CREATE | ZipArchive::OVERWRITE)) {
+    foreach ($files as $path => $local) {
+        $zip->addFile($path, $local);
+    }
+    $zip->close();
+}
+if (!file_exists($outZip)) {
+    touch($outZip);
+}
+
+echo $outZip . PHP_EOL;
+exit(0);

--- a/scripts/scan-secrets.php
+++ b/scripts/scan-secrets.php
@@ -1,0 +1,106 @@
+<?php
+declare(strict_types=1);
+
+function shannon_entropy(string $s): float {
+    $h = 0.0;
+    $len = strlen($s);
+    if ($len === 0) {
+        return 0.0;
+    }
+    $freq = count_chars($s, 1);
+    foreach ($freq as $count) {
+        $p = $count / $len;
+        $h -= $p * log($p, 2);
+    }
+    return $h;
+}
+
+function scan_secrets(string $root, string $allowTag): array {
+    $results = [];
+    $excludeDirs = ['vendor', 'node_modules', 'dist', '.git'];
+    $iterator = new RecursiveIteratorIterator(
+        new RecursiveCallbackFilterIterator(
+            new RecursiveDirectoryIterator($root, FilesystemIterator::SKIP_DOTS),
+            function ($current, $key, $iterator) use ($excludeDirs) {
+                if ($iterator->hasChildren()) {
+                    $basename = $current->getBasename();
+                    if (in_array($basename, $excludeDirs, true)) {
+                        return false;
+                    }
+                    if (strpos($current->getPathname(), 'tests' . DIRECTORY_SEPARATOR . 'artifacts') !== false) {
+                        return false;
+                    }
+                    return true;
+                }
+                return $current->isFile();
+            }
+        ),
+        RecursiveIteratorIterator::LEAVES_ONLY
+    );
+
+    $patterns = [
+        'aws_access_key' => '/AKIA[0-9A-Z]{16}/',
+        'aws_secret_key' => '/(?i)aws[^\n]{0,20}secret[^\n]{0,20}key[^\n]{0,20}[=:\s]\s*[\'\"][A-Za-z0-9\\/+]{40}[\'\"]/',
+        'gcp_service_account' => '/"type"\s*:\s*"service_account"/',
+        'slack_webhook' => '#https://hooks.slack.com/services/[^\s\"\']+#',
+        'bearer_token' => '/Bearer\s+[A-Za-z0-9\._\-]{20,}/',
+        'jwt' => '/[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}/',
+        'private_key' => '/-----BEGIN [A-Z ]*PRIVATE KEY-----/',
+    ];
+
+    foreach ($iterator as $fileInfo) {
+        $path = $fileInfo->getPathname();
+        if (basename($path) === 'scan-secrets.php') {
+            continue;
+        }
+        if ($fileInfo->getSize() > 5 * 1024 * 1024) {
+            continue; // skip huge files
+        }
+        $lines = @file($path);
+        if ($lines === false) {
+            continue;
+        }
+        foreach ($lines as $num => $line) {
+            if (strpos($line, $allowTag) !== false) {
+                continue;
+            }
+            foreach ($patterns as $type => $regex) {
+                if (preg_match($regex, $line)) {
+                    $results[] = [
+                        'file' => str_replace($root . DIRECTORY_SEPARATOR, '', $path),
+                        'line' => $num + 1,
+                        'type' => $type,
+                        'snippet' => trim($line),
+                    ];
+                    continue 2; // avoid duplicate entries for same line
+                }
+            }
+            if (preg_match_all('/(?:[A-Za-z0-9+\/]{32,}|[0-9a-fA-F]{32,})/', $line, $matches)) {
+                foreach ($matches[0] as $token) {
+                    if (shannon_entropy($token) >= 4.0) {
+                        $results[] = [
+                            'file' => str_replace($root . DIRECTORY_SEPARATOR, '', $path),
+                            'line' => $num + 1,
+                            'type' => 'high_entropy_string',
+                            'snippet' => trim($line),
+                        ];
+                        break;
+                    }
+                }
+            }
+        }
+    }
+    return $results;
+}
+
+$allowTag = '@security-ok-secret';
+foreach ($argv as $arg) {
+    if (str_starts_with($arg, '--allowlist-tag=')) {
+        $allowTag = substr($arg, strlen('--allowlist-tag='));
+    }
+}
+
+$root = dirname(__DIR__);
+$findings = scan_secrets($root, $allowTag);
+echo json_encode($findings, JSON_PRETTY_PRINT) . PHP_EOL;
+exit(0);

--- a/tests/unit/Security/HeadersGuardTest.php
+++ b/tests/unit/Security/HeadersGuardTest.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class HeadersGuardTest extends TestCase
+{
+    public function test_no_wildcard_cors_headers(): void
+    {
+        if (getenv('RUN_SECURITY_TESTS') !== '1') {
+            $this->markTestSkipped('security tests opt-in');
+        }
+
+        $root = dirname(__DIR__, 3);
+        $violations = [];
+        $allowTag = '@security-ok-header';
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveCallbackFilterIterator(
+                new RecursiveDirectoryIterator($root, FilesystemIterator::SKIP_DOTS),
+                static function ($current, $key, $iterator) {
+                    if ($iterator->hasChildren()) {
+                        $basename = $current->getBasename();
+                        $skip = ['vendor', 'node_modules', 'dist', '.git', 'tests'];
+                        return !in_array($basename, $skip, true);
+                    }
+                    return $current->isFile() && $current->getExtension() === 'php';
+                }
+            )
+        );
+
+        foreach ($iterator as $file) {
+            $path = $file->getPathname();
+            $lines = @file($path);
+            if ($lines === false) {
+                continue;
+            }
+            foreach ($lines as $num => $line) {
+                if (strpos($line, 'Access-Control-Allow-Origin: *') !== false
+                    && strpos($line, $allowTag) === false) {
+                    $violations[] = $path . ':' . ($num + 1);
+                }
+            }
+        }
+
+        if (!empty($violations)) {
+            $this->fail('Wildcard CORS headers found: ' . implode(', ', $violations));
+        }
+
+        $this->assertTrue(true);
+    }
+}


### PR DESCRIPTION
## Summary
- add pure-PHP secret scanner with entropy heuristic and allowlist tag
- add composer.lock license audit helper and QA bundle packer
- document helpers and add optional CORS header guard test

## Testing
- `php scripts/scan-secrets.php | head -n 20`
- `php scripts/license-audit.php | head -n 20`
- `php scripts/qa-bundle.php`
- `composer test >/tmp/test.log && tail -n 20 /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_68a5c93c06b48321849be5241d5edfd8