### PR TITLE
Add QA orchestrator and release gate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,6 @@ artifacts/axe/
 artifacts/lighthouse/
 artifacts/qa/
 *.lhreport.html
+# allow committed artifact templates
+!scripts/templates/artifacts/
+!scripts/templates/artifacts/index.template.html

--- a/docs/RELEASE_GATE.md
+++ b/docs/RELEASE_GATE.md
@@ -1,0 +1,28 @@
+# Release Gate (Advisory)
+
+Run the QA helpers and review the generated artifacts before releasing. This gate is non-blocking and CI stays green by default.
+
+## Checklist
+
+| QA Plan (Critical/High) | Artifact | Notes |
+| --- | --- | --- |
+| REST guard | `rest-violations.json` | should be empty or allowlisted |
+| SQL prepare guard | `sql-violations.json` | review for unprepared queries |
+| Secrets scan | `secrets.json` | manual review |
+| License audit | `licenses.json` | denylist must be empty |
+| Coverage (optional) | `qa-report.json` | includes coverage% if available |
+| Perf opt-in | `AllocationPerformanceTest` | check p95/memory |
+
+## How to run
+
+```bash
+bash scripts/qa-orchestrator.sh
+```
+
+## What to upload
+
+```
+artifacts/qa/qa-bundle.zip
+```
+
+All steps are advisory and may be skipped; missing tools are ignored.

--- a/scripts/qa-index.php
+++ b/scripts/qa-index.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types=1);
+
+$root = dirname(__DIR__);
+$outDir = $root . '/artifacts/qa';
+if (!is_dir($outDir)) {
+    @mkdir($outDir, 0777, true);
+}
+
+$template = $root . '/scripts/templates/artifacts/index.template.html';
+$html = is_file($template) ? file_get_contents($template) : '<!DOCTYPE html><html dir="rtl"><meta charset="utf-8"><body><ul>{{items}}</ul></body></html>';
+
+$files = [
+    'qa-report.html',
+    'qa-report.json',
+    'rest-violations.json',
+    'sql-violations.json',
+    'secrets.json',
+    'licenses.json',
+];
+
+$items = [];
+foreach ($files as $file) {
+    $path = $root . '/' . $file;
+    if (is_file($path)) {
+        $rel = '../../' . $file;
+        $items[] = '<li><a href="' . htmlspecialchars($rel, ENT_QUOTES, 'UTF-8') . '">' . htmlspecialchars($file, ENT_QUOTES, 'UTF-8') . '</a></li>';
+    }
+}
+
+$bundle = $outDir . '/qa-bundle.zip';
+if (is_file($bundle)) {
+    $items[] = '<li><a href="' . htmlspecialchars('qa-bundle.zip', ENT_QUOTES, 'UTF-8') . '">qa-bundle.zip</a></li>';
+}
+
+if (!$items) {
+    $items[] = '<li>No artifacts found</li>';
+}
+
+$html = str_replace('{{items}}', implode(PHP_EOL, $items), $html);
+file_put_contents($outDir . '/index.html', $html);
+
+exit(0);

--- a/scripts/qa-orchestrator.sh
+++ b/scripts/qa-orchestrator.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# QA orchestrator: runs optional scanners/tests and collects artifacts.
+# All steps are non-blocking and the script always exits 0.
+
+set -u
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR" || exit 0
+
+summary=()
+
+run_step() {
+    local label="$1"; shift
+    local cmd="$*"
+    if eval "$cmd" >/dev/null 2>&1; then
+        summary+=("$label: ok")
+    else
+        summary+=("$label: skipped")
+    fi
+}
+
+# REST permissions scan
+if [ -f scripts/scan-rest-permissions.php ]; then
+    run_step "REST permissions" "php scripts/scan-rest-permissions.php > rest-violations.json"
+fi
+
+# SQL prepare scan
+if [ -f scripts/scan-sql-prepare.php ]; then
+    run_step "SQL prepare" "php scripts/scan-sql-prepare.php > sql-violations.json"
+fi
+
+# Secrets scan
+if [ -f scripts/scan-secrets.php ]; then
+    run_step "Secrets scan" "php scripts/scan-secrets.php > secrets.json"
+fi
+
+# License audit
+if [ -f scripts/license-audit.php ]; then
+    run_step "License audit" "php scripts/license-audit.php > licenses.json"
+fi
+
+# QA report regeneration
+if [ -f scripts/qa-report.php ]; then
+    run_step "QA report" "php scripts/qa-report.php"
+fi
+
+# HTML index (optional)
+if [ -f scripts/qa-index.php ]; then
+    run_step "QA index" "php scripts/qa-index.php"
+fi
+
+# QA bundle package
+if [ -f scripts/qa-bundle.php ]; then
+    run_step "QA bundle" "php scripts/qa-bundle.php"
+fi
+
+echo "QA Orchestrator Summary:"
+for line in "${summary[@]}"; do
+    echo " - $line"
+done
+echo "Done."
+
+exit 0

--- a/scripts/templates/artifacts/index.template.html
+++ b/scripts/templates/artifacts/index.template.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html dir="rtl">
+<meta charset="utf-8">
+<title>QA Artifacts</title>
+<body>
+<h1>QA Artifacts</h1>
+<ul>
+{{items}}
+</ul>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add bash QA orchestrator to run scanners and bundle artifacts
- document non-blocking release gate checklist
- build simple HTML index for QA artifacts and allow template tracking

## Testing
- `composer test`
- `bash scripts/qa-orchestrator.sh`
- `php scripts/qa-index.php`


------
https://chatgpt.com/codex/tasks/task_e_68a5cfcc9f248321b632fd29eb147363