### PR TITLE
Add release gate validators and SBOM generator

### DIFF
--- a/docs/RELEASE_GATE.md
+++ b/docs/RELEASE_GATE.md
@@ -10,6 +10,7 @@ Run the QA helpers and review the generated artifacts before releasing. This gat
 | SQL prepare guard | `sql-violations.json` | review for unprepared queries |
 | Secrets scan | `secrets.json` | manual review |
 | License audit | `licenses.json` | denylist must be empty |
+| Version coherence & readme | stdout | run validators; expect no mismatches |
 | Coverage (optional) | `qa-report.json` | includes coverage% if available |
 | Perf opt-in | `AllocationPerformanceTest` | check p95/memory |
 
@@ -17,7 +18,12 @@ Run the QA helpers and review the generated artifacts before releasing. This gat
 
 ```bash
 bash scripts/qa-orchestrator.sh
+php scripts/version-coherence.php
+php scripts/validate-readme.php
+php scripts/sbom-from-composer.php
 ```
+
+Validators should report no mismatches or warnings, and the SBOM file should be generated for GA.
 
 ## What to upload
 
@@ -37,3 +43,13 @@ php scripts/dist-manifest.php [path]
 ```
 
 `dist-audit` emits JSON with any violations (e.g., dev files or oversized assets). Review the list; minor warnings may pass for GA, but serious issues should be fixed before shipping. `dist-manifest` records checksums and sizes for auditing.
+
+## SBOM
+
+Generate a minimal SBOM from `composer.lock`:
+
+```bash
+php scripts/sbom-from-composer.php
+```
+
+Expect `artifacts/dist/sbom.json` to exist for GA.

--- a/scripts/sbom-from-composer.php
+++ b/scripts/sbom-from-composer.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+$root = dirname(__DIR__);
+$lockFile = $root . '/composer.lock';
+$packages = [];
+if (is_file($lockFile)) {
+    $data = json_decode((string)file_get_contents($lockFile), true);
+    foreach (['packages', 'packages-dev'] as $section) {
+        foreach ($data[$section] ?? [] as $pkg) {
+            $entry = [
+                'name' => $pkg['name'] ?? '',
+                'version' => $pkg['version'] ?? '',
+                'license' => $pkg['license'][0] ?? '',
+                'type' => 'composer',
+            ];
+            $sha = $pkg['dist']['sha256'] ?? ($pkg['dist']['shasum'] ?? '');
+            if ($sha !== '') {
+                $entry['checksum'] = ['algorithm' => 'sha256', 'hash' => $sha];
+            }
+            $packages[] = $entry;
+        }
+    }
+}
+$destDir = $root . '/artifacts/dist';
+if (!is_dir($destDir)) {
+    mkdir($destDir, 0777, true);
+}
+$sbomFile = $destDir . '/sbom.json';
+file_put_contents($sbomFile, json_encode(['packages' => $packages], JSON_PRETTY_PRINT) . PHP_EOL);
+$result = ['summary' => ['written' => is_file($sbomFile), 'count' => count($packages)]];
+echo json_encode($result, JSON_PRETTY_PRINT) . PHP_EOL;
+exit(0);

--- a/scripts/validate-readme.php
+++ b/scripts/validate-readme.php
@@ -1,0 +1,75 @@
+<?php
+declare(strict_types=1);
+
+$root = dirname(__DIR__);
+$file = $root . '/readme.txt';
+$warnings = [];
+
+if (!is_file($file)) {
+    $warnings[] = 'readme_missing';
+    $content = '';
+} else {
+    $content = (string)file_get_contents($file);
+    $lines = preg_split('/\r?\n/', $content);
+    $headers = [];
+    $idx = 1; // start after title
+    for (; $idx < count($lines); $idx++) {
+        $line = $lines[$idx];
+        if ($line === '') {
+            $idx++;
+            break;
+        }
+        if (strpos($line, ':') !== false) {
+            [$k, $v] = array_map('trim', explode(':', $line, 2));
+            $headers[$k] = $v;
+        }
+    }
+    $requiredHeaders = ['Contributors', 'Requires at least', 'Tested up to', 'Requires PHP', 'Stable tag'];
+    foreach ($requiredHeaders as $h) {
+        if (!isset($headers[$h])) {
+            $warnings[] = 'header_missing:' . $h;
+        }
+    }
+    if (($headers['Stable tag'] ?? '') === '') {
+        $warnings[] = 'stable_tag_missing';
+    }
+    $shortDesc = '';
+    for (; $idx < count($lines); $idx++) {
+        $line = trim($lines[$idx]);
+        if ($line !== '') {
+            $shortDesc = $line;
+            break;
+        }
+    }
+    if ($shortDesc === '') {
+        $warnings[] = 'short_description_missing';
+    } elseif (strlen($shortDesc) > 150) {
+        $warnings[] = 'short_description_long';
+    }
+    if (stripos($content, '== Description ==') === false) {
+        $warnings[] = 'description_section_missing';
+    }
+    if (stripos($content, '== Changelog ==') === false) {
+        $warnings[] = 'changelog_section_missing';
+    }
+    // oversized sections
+    if (preg_match_all('/^==\s*(.+?)\s*==/m', $content, $matches, PREG_SET_ORDER)) {
+        $positions = [];
+        foreach ($matches as $m) {
+            $positions[] = ['name' => $m[1], 'pos' => strpos($content, $m[0])];
+        }
+        for ($i = 0; $i < count($positions); $i++) {
+            $start = $positions[$i]['pos'] + strlen($positions[$i]['name']) + 4; // approx
+            $end = $positions[$i + 1]['pos'] ?? strlen($content);
+            $sectionLines = substr_count(substr($content, $start, $end - $start), "\n");
+            if ($sectionLines > 400) {
+                $warnings[] = 'section_oversized:' . $positions[$i]['name'];
+            }
+        }
+    }
+}
+
+$ok = empty($warnings);
+$result = ['summary' => ['ok' => $ok, 'warnings' => $warnings]];
+echo json_encode($result, JSON_PRETTY_PRINT) . PHP_EOL;
+exit(0);

--- a/scripts/version-coherence.php
+++ b/scripts/version-coherence.php
@@ -1,0 +1,75 @@
+<?php
+declare(strict_types=1);
+
+$root = dirname(__DIR__);
+$mismatches = [];
+
+$pluginFile = null;
+foreach (glob($root . '/*.php') as $file) {
+    $chunk = (string)file_get_contents($file, false, null, 0, 8192);
+    if (preg_match('/Plugin Name\s*:/i', $chunk)) {
+        $pluginFile = $file;
+        break;
+    }
+}
+
+$version = '';
+$textDomain = '';
+if ($pluginFile === null) {
+    $mismatches[] = ['type' => 'plugin_file_missing'];
+} else {
+    $header = (string)file_get_contents($pluginFile, false, null, 0, 8192);
+    $required = ['Plugin Name', 'Version', 'Requires at least', 'Tested up to', 'Requires PHP', 'Text Domain'];
+    foreach ($required as $name) {
+        if (!preg_match('/' . preg_quote($name, '/') . '\s*:\s*(.+)/i', $header, $m)) {
+            $mismatches[] = ['type' => 'header_missing', 'field' => $name];
+            continue;
+        }
+        $val = trim($m[1]);
+        if ($name === 'Version') {
+            $version = $val;
+        } elseif ($name === 'Text Domain') {
+            $textDomain = $val;
+            if ($textDomain === '') {
+                $mismatches[] = ['type' => 'text_domain_empty'];
+            }
+        }
+    }
+}
+
+$readme = $root . '/readme.txt';
+if (!is_file($readme)) {
+    $mismatches[] = ['type' => 'readme_missing'];
+    $stable = '';
+} else {
+    $content = (string)file_get_contents($readme);
+    if (stripos($content, '== Changelog ==') === false || stripos($content, '== Description ==') === false) {
+        $mismatches[] = ['type' => 'readme_sections'];
+    }
+    if (!preg_match('/^Stable tag:\s*(.+)$/mi', $content, $m)) {
+        $mismatches[] = ['type' => 'stable_tag_missing'];
+        $stable = '';
+    } else {
+        $stable = trim($m[1]);
+        if ($version !== '' && $version !== $stable) {
+            $mismatches[] = ['type' => 'version_mismatch', 'plugin' => $version, 'readme' => $stable];
+        }
+    }
+    if ($textDomain === '') {
+        // Already flagged empty, but ensure readme mentions same domain? Not required.
+    }
+}
+
+$changelog = $root . '/CHANGELOG.md';
+if (is_file($changelog) && $version !== '') {
+    $chContent = (string)file_get_contents($changelog);
+    if (preg_match('/^##\s*' . preg_quote($version, '/') . '\b/m', $chContent) === 0) {
+        $mismatches[] = ['type' => 'changelog_missing_entry', 'version' => $version];
+    }
+}
+
+$ok = empty($mismatches);
+$result = ['summary' => ['ok' => $ok, 'mismatches' => $mismatches]];
+
+echo json_encode($result, JSON_PRETTY_PRINT) . PHP_EOL;
+exit(0);

--- a/tests/unit/Packaging/VersionCoherenceTest.php
+++ b/tests/unit/Packaging/VersionCoherenceTest.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class VersionCoherenceTest extends TestCase {
+    public function test_version_coherence(): void {
+        if (getenv('RUN_RELEASE_GATES') !== '1') {
+            $this->markTestSkipped('release gates opt-in');
+        }
+        $root = dirname(__DIR__, 3);
+        $cmd = escapeshellcmd("php {$root}/scripts/version-coherence.php");
+        $output = shell_exec($cmd);
+        $data = json_decode((string)$output, true);
+        $mismatches = $data['summary']['mismatches'] ?? [];
+        if (!empty($mismatches)) {
+            $this->fail('version-coherence mismatches: ' . json_encode($mismatches));
+        }
+        $this->assertIsArray($data);
+    }
+}


### PR DESCRIPTION
## Summary
- add version coherence CLI to check plugin/readme/changelog alignment
- add readme validator and tiny composer SBOM generator
- document release gate steps and provide optional PHPUnit guard

## Testing
- `php scripts/version-coherence.php`
- `php scripts/validate-readme.php`
- `php scripts/sbom-from-composer.php`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68a63232753c8321ba1577aa653d9a3c