### PR TITLE
Add release readiness helpers

### DIFF
--- a/docs/RELEASE_GATE.md
+++ b/docs/RELEASE_GATE.md
@@ -53,3 +53,17 @@ php scripts/sbom-from-composer.php
 ```
 
 Expect `artifacts/dist/sbom.json` to exist for GA.
+
+## GO/NO-GO & Tag Preflight
+
+Run final advisory helpers to summarize QA signals and preview tagging:
+
+```bash
+php scripts/go-no-go.php
+php scripts/changelog-guard.php
+php scripts/tag-preflight.php
+```
+
+`go-no-go.php` aggregates any existing QA artifacts and writes `artifacts/qa/go-no-go.html` for a quick RTL review. `changelog-guard.php` checks that the top `CHANGELOG.md` entry aligns with the plugin version and readme stable tag. `tag-preflight.php` prints a release note stub and reports SHA256 hashes for `artifacts/dist/manifest.json` and `artifacts/dist/sbom.json` if present.
+
+All outputs are advisory and non-blocking; missing files are skipped.

--- a/scripts/changelog-guard.php
+++ b/scripts/changelog-guard.php
@@ -1,0 +1,66 @@
+<?php
+declare(strict_types=1);
+
+$root = dirname(__DIR__);
+
+$pluginFile = null;
+foreach (glob($root . '/*.php') as $file) {
+    $chunk = (string)file_get_contents($file, false, null, 0, 8192);
+    if (preg_match('/Plugin Name\s*:/i', $chunk)) {
+        $pluginFile = $file;
+        break;
+    }
+}
+
+$pluginVersion = '';
+if ($pluginFile !== null && preg_match('/^Version:\s*(.+)$/mi', (string)file_get_contents($pluginFile), $m)) {
+    $pluginVersion = trim($m[1]);
+}
+
+$readmeVersion = '';
+$readme = $root . '/readme.txt';
+if (is_file($readme) && preg_match('/^Stable tag:\s*(.+)$/mi', (string)file_get_contents($readme), $m)) {
+    $readmeVersion = trim($m[1]);
+}
+
+$changelogVersion = '';
+$changelogDate = '';
+$changelog = $root . '/CHANGELOG.md';
+if (is_file($changelog)) {
+    $content = (string)file_get_contents($changelog);
+    if (preg_match('/^##\s*\[?([^\]\s]+)\]?\s*-\s*(\d{4}-\d{2}-\d{2})/m', $content, $m)) {
+        $changelogVersion = $m[1];
+        $changelogDate = $m[2];
+    }
+}
+
+$dateValid = false;
+if ($changelogDate !== '' && preg_match('/^(\d{4})-(\d{2})-(\d{2})$/', $changelogDate, $dm)) {
+    $dateValid = checkdate((int)$dm[2], (int)$dm[3], (int)$dm[1]);
+}
+
+$errors = [];
+if ($changelogVersion === '' || $pluginVersion === '' || $changelogVersion !== $pluginVersion) {
+    $errors[] = 'plugin_version_mismatch';
+}
+if ($changelogVersion === '' || $readmeVersion === '' || $changelogVersion !== $readmeVersion) {
+    $errors[] = 'readme_version_mismatch';
+}
+if (!$dateValid) {
+    $errors[] = 'invalid_date';
+}
+
+$result = [
+    'summary' => [
+        'ok' => empty($errors),
+        'plugin_version' => $pluginVersion,
+        'readme_version' => $readmeVersion,
+        'changelog_version' => $changelogVersion,
+        'changelog_date' => $changelogDate,
+        'date_valid' => $dateValid,
+        'errors' => $errors,
+    ],
+];
+
+echo json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . PHP_EOL;
+exit(0);

--- a/scripts/go-no-go.php
+++ b/scripts/go-no-go.php
@@ -1,0 +1,130 @@
+<?php
+declare(strict_types=1);
+
+$root = dirname(__DIR__);
+$files = [
+    'qa' => $root . '/qa-report.json',
+    'rest' => $root . '/rest-violations.json',
+    'sql' => $root . '/sql-violations.json',
+    'secrets' => $root . '/secrets.json',
+    'licenses' => $root . '/licenses.json',
+    'manifest' => $root . '/artifacts/dist/manifest.json',
+    'sbom' => $root . '/artifacts/dist/sbom.json',
+];
+
+$inputs = [];
+foreach ($files as $key => $path) {
+    if (is_file($path)) {
+        $decoded = json_decode((string)file_get_contents($path), true);
+        $inputs[$key] = $decoded;
+    }
+}
+
+$options = getopt('', ['coverage-min::']);
+$coverageMin = isset($options['coverage-min']) ? (float)$options['coverage-min'] : (float)(getenv('GNG_COVERAGE_MIN') ?: 85);
+
+$severity = static function(string $env, string $default): string {
+    $val = getenv($env);
+    if ($val === false || $val === '') {
+        return $default;
+    }
+    $val = strtolower($val);
+    return in_array($val, ['high','medium','low'], true) ? $val : $default;
+};
+
+$sevRest = $severity('GNG_REST_SEVERITY', 'high');
+$sevSql = $severity('GNG_SQL_SEVERITY', 'high');
+$sevLicense = $severity('GNG_LICENSE_SEVERITY', 'high');
+$sevSecrets = $severity('GNG_SECRETS_SEVERITY', 'medium');
+$sevCoverage = $severity('GNG_COVERAGE_SEVERITY', 'medium');
+$sevVersion = $severity('GNG_VERSION_MISMATCH_SEVERITY', 'high');
+
+$reasons = [];
+
+if (isset($inputs['rest']) && is_array($inputs['rest'])) {
+    $count = count($inputs['rest']);
+    $inputs['rest'] = ['count' => $count];
+    if ($count > 0) {
+        $reasons[] = ['type' => 'rest_violations', 'count' => $count, 'severity' => $sevRest];
+    }
+}
+
+if (isset($inputs['sql']) && is_array($inputs['sql'])) {
+    $count = count($inputs['sql']);
+    $inputs['sql'] = ['count' => $count];
+    if ($count > 0) {
+        $reasons[] = ['type' => 'sql_violations', 'count' => $count, 'severity' => $sevSql];
+    }
+}
+
+if (isset($inputs['licenses']['summary']['denied'])) {
+    $denied = (int)$inputs['licenses']['summary']['denied'];
+    $inputs['licenses'] = ['denied' => $denied];
+    if ($denied > 0) {
+        $reasons[] = ['type' => 'license_denied', 'count' => $denied, 'severity' => $sevLicense];
+    }
+}
+
+if (isset($inputs['secrets']) && is_array($inputs['secrets'])) {
+    $count = count($inputs['secrets']);
+    $inputs['secrets'] = ['count' => $count];
+    if ($count > 0) {
+        $reasons[] = ['type' => 'secrets_found', 'count' => $count, 'severity' => $sevSecrets];
+    }
+}
+
+if (isset($inputs['qa']['coverage_percent'])) {
+    $cov = (float)$inputs['qa']['coverage_percent'];
+    $inputs['qa'] = ['coverage_percent' => $cov];
+    if ($cov < $coverageMin) {
+        $reasons[] = ['type' => 'coverage_below_threshold', 'coverage' => $cov, 'threshold' => $coverageMin, 'severity' => $sevCoverage];
+    }
+}
+
+$vcScript = $root . '/scripts/version-coherence.php';
+if (is_file($vcScript)) {
+    $json = @shell_exec('php ' . escapeshellarg($vcScript));
+    $decoded = json_decode((string)$json, true);
+    $inputs['version_coherence'] = $decoded;
+    $mismatches = $decoded['summary']['mismatches'] ?? [];
+    if (!empty($mismatches)) {
+        $reasons[] = ['type' => 'version_mismatch', 'details' => $mismatches, 'severity' => $sevVersion];
+    }
+}
+
+$go = true;
+foreach ($reasons as $r) {
+    if (($r['severity'] ?? '') === 'high') {
+        $go = false;
+        break;
+    }
+}
+
+$result = [
+    'summary' => [
+        'go' => $go,
+        'reasons' => $reasons,
+    ],
+    'inputs' => $inputs,
+];
+
+echo json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . PHP_EOL;
+
+$dir = $root . '/artifacts/qa';
+if (!is_dir($dir)) {
+    @mkdir($dir, 0777, true);
+}
+$html = '<!DOCTYPE html><html dir="rtl"><meta charset="utf-8"><title>GO/NO-GO</title><body>';
+$html .= '<h1>' . ($go ? 'GO' : 'NO-GO') . '</h1>';
+if ($reasons) {
+    $html .= '<ul>';
+    foreach ($reasons as $r) {
+        $msg = htmlspecialchars($r['type'] . ' (' . $r['severity'] . ')', ENT_QUOTES, 'UTF-8');
+        $html .= '<li>' . $msg . '</li>';
+    }
+    $html .= '</ul>';
+}
+$html .= '</body></html>';
+file_put_contents($dir . '/go-no-go.html', $html);
+
+exit(0);

--- a/scripts/tag-preflight.php
+++ b/scripts/tag-preflight.php
@@ -1,0 +1,50 @@
+<?php
+declare(strict_types=1);
+
+$root = dirname(__DIR__);
+
+$changelog = $root . '/CHANGELOG.md';
+$version = '';
+$date = '';
+$highlights = [];
+if (is_file($changelog)) {
+    $content = (string)file_get_contents($changelog);
+    if (preg_match('/^##\s*\[?([^\]\s]+)\]?\s*-\s*(\d{4}-\d{2}-\d{2})\s*\n(.*?)(?:\n##\s|\z)/s', $content, $m)) {
+        $version = $m[1];
+        $date = $m[2];
+        $body = trim($m[3]);
+        foreach (preg_split('/\r?\n/', $body) as $line) {
+            if (preg_match('/^\s*[-*]\s*(.+)/', $line, $lm)) {
+                $highlights[] = trim($lm[1]);
+            }
+        }
+    }
+}
+
+$artifacts = [];
+$paths = [
+    'manifest' => $root . '/artifacts/dist/manifest.json',
+    'sbom' => $root . '/artifacts/dist/sbom.json',
+];
+foreach ($paths as $name => $path) {
+    if (is_file($path)) {
+        $artifacts[$name] = [
+            'present' => true,
+            'sha256' => hash_file('sha256', $path),
+        ];
+    } else {
+        $artifacts[$name] = [
+            'present' => false,
+        ];
+    }
+}
+
+$result = [
+    'version' => $version,
+    'date' => $date,
+    'highlights' => $highlights,
+    'artifacts' => $artifacts,
+];
+
+echo json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . PHP_EOL;
+exit(0);

--- a/tests/unit/Release/ChangelogGuardTest.php
+++ b/tests/unit/Release/ChangelogGuardTest.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class ChangelogGuardTest extends TestCase {
+    public function test_changelog_guard(): void {
+        if (getenv('RUN_RELEASE_GATES') !== '1') {
+            $this->markTestSkipped('release gates opt-in');
+        }
+        $root = dirname(__DIR__, 3);
+        $cmd = escapeshellcmd("php {$root}/scripts/changelog-guard.php");
+        $output = shell_exec($cmd);
+        $data = json_decode((string)$output, true);
+        $ok = $data['summary']['ok'] ?? false;
+        if (!$ok) {
+            $this->fail('changelog guard mismatches: ' . json_encode($data['summary']['errors'] ?? []));
+        }
+        $this->assertIsArray($data);
+    }
+}


### PR DESCRIPTION
## Summary
- Add GO/NO-GO aggregator to summarize QA artifacts and emit HTML overview
- Guard changelog coherence against plugin and readme versions
- Provide tag preflight helper for release notes and artifact hashes

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68a6c70c15648321b3fbd140dbb4ab2b