### PR TITLE
Add release finalization helpers

### DIFF
--- a/docs/RELEASE_GATE.md
+++ b/docs/RELEASE_GATE.md
@@ -67,3 +67,15 @@ php scripts/tag-preflight.php
 `go-no-go.php` aggregates any existing QA artifacts and writes `artifacts/qa/go-no-go.html` for a quick RTL review. `changelog-guard.php` checks that the top `CHANGELOG.md` entry aligns with the plugin version and readme stable tag. `tag-preflight.php` prints a release note stub and reports SHA256 hashes for `artifacts/dist/manifest.json` and `artifacts/dist/sbom.json` if present.
 
 All outputs are advisory and non-blocking; missing files are skipped.
+
+## Finalization
+
+Generate release notes, snapshot the final checklist, and preview tagging:
+
+```bash
+php scripts/release-notes.php
+php scripts/final-checklist.php
+bash scripts/tag-dry-run.sh
+```
+
+All steps are advisory and non-blocking.

--- a/scripts/final-checklist.php
+++ b/scripts/final-checklist.php
@@ -1,0 +1,62 @@
+<?php
+declare(strict_types=1);
+
+$root = dirname(__DIR__);
+$items = [];
+
+$doc = $root . '/docs/RELEASE_GATE.md';
+if (is_file($doc)) {
+    $content = (string)file_get_contents($doc);
+    if (preg_match('/##\s*Checklist\s*\n(.*?)(?:\n##\s|\z)/s', $content, $m)) {
+        $lines = preg_split('/\r?\n/', trim($m[1]));
+        foreach ($lines as $line) {
+            $line = trim($line);
+            if ($line === '' || $line[0] !== '|') {
+                continue;
+            }
+            $cols = array_map('trim', explode('|', trim($line, '|')));
+            if (!isset($cols[0]) || $cols[0] === '' || stripos($cols[0], 'QA Plan') === 0 || $cols[0] === '---') {
+                continue;
+            }
+            $items[$cols[0]] = 'pass';
+        }
+    }
+}
+
+$map = [
+    'rest_violations' => 'REST guard',
+    'sql_violations' => 'SQL prepare guard',
+    'secrets_found' => 'Secrets scan',
+    'license_denied' => 'License audit',
+    'version_mismatch' => 'Version coherence & readme',
+    'coverage_below_threshold' => 'Coverage (optional)',
+];
+
+$files = glob($root . '/QA_REPORT/*go-no-go*.json') ?: [];
+foreach ($files as $file) {
+    $data = json_decode((string)file_get_contents($file), true);
+    if (!isset($data['summary']['reasons']) || !is_array($data['summary']['reasons'])) {
+        continue;
+    }
+    foreach ($data['summary']['reasons'] as $reason) {
+        $type = $reason['type'] ?? '';
+        $severity = strtolower((string)($reason['severity'] ?? ''));
+        if (!isset($map[$type])) {
+            continue;
+        }
+        $items[$map[$type]] = ($severity === 'high') ? 'fail' : 'warn';
+    }
+}
+
+$out = [];
+foreach ($items as $name => $status) {
+    $out[] = ['item' => $name, 'status' => $status];
+}
+
+$dir = $root . '/artifacts/qa';
+if (!is_dir($dir)) {
+    @mkdir($dir, 0777, true);
+}
+file_put_contents($dir . '/final-checklist.json', json_encode($out, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . PHP_EOL);
+
+exit(0);

--- a/scripts/release-notes.php
+++ b/scripts/release-notes.php
@@ -1,0 +1,116 @@
+<?php
+declare(strict_types=1);
+
+$root = dirname(__DIR__);
+
+$changelog = $root . '/CHANGELOG.md';
+$changelogBody = '';
+$version = '';
+if (is_file($changelog)) {
+    $content = (string)file_get_contents($changelog);
+    $content = preg_replace('/^#.*\n+/', '', $content, 1);
+    if (preg_match('/^##\s*([^\n]+)\n(.*?)(?=\n##\s|\z)/s', $content, $m)) {
+        $version = trim($m[1]);
+        $changelogBody = trim($m[2]);
+    }
+}
+
+$metrics = [
+    'coverage' => null,
+    'rest' => null,
+    'sql' => null,
+    'license' => null,
+    'secrets' => null,
+    'manifest' => [],
+];
+
+$goNoGoFile = null;
+$candidates = [
+    $root . '/QA_REPORT/go-no-go.json',
+    $root . '/QA_REPORT/GO-NO-GO.json',
+    $root . '/artifacts/qa/go-no-go.json',
+    $root . '/go-no-go.json',
+];
+foreach ($candidates as $c) {
+    if (is_file($c)) {
+        $goNoGoFile = $c;
+        break;
+    }
+}
+
+if ($goNoGoFile) {
+    $data = json_decode((string)file_get_contents($goNoGoFile), true);
+    if (is_array($data)) {
+        $inputs = $data['inputs'] ?? [];
+        $metrics['coverage'] = isset($inputs['qa']['coverage_percent']) ? (float)$inputs['qa']['coverage_percent'] : null;
+        $metrics['rest'] = isset($inputs['rest']['count']) ? (int)$inputs['rest']['count'] : null;
+        $metrics['sql'] = isset($inputs['sql']['count']) ? (int)$inputs['sql']['count'] : null;
+        $metrics['license'] = isset($inputs['licenses']['denied']) ? (int)$inputs['licenses']['denied'] : null;
+        $metrics['secrets'] = isset($inputs['secrets']['count']) ? (int)$inputs['secrets']['count'] : null;
+        if (isset($inputs['manifest']['files']) && is_array($inputs['manifest']['files'])) {
+            $metrics['manifest'] = $inputs['manifest']['files'];
+        }
+    }
+}
+
+$lines = [];
+$lines[] = '<div dir="rtl">';
+$lines[] = '# Release Notes' . ($version !== '' ? ' ' . $version : '');
+$lines[] = '';
+if ($changelogBody !== '') {
+    $lines[] = $changelogBody;
+    $lines[] = '';
+}
+
+$hasSignals = false;
+foreach (['coverage','rest','sql','license','secrets'] as $k) {
+    if ($metrics[$k] !== null) {
+        $hasSignals = true;
+        break;
+    }
+}
+
+if ($hasSignals || !empty($metrics['manifest'])) {
+    $lines[] = '## QA Signals';
+    if ($metrics['coverage'] !== null) {
+        $lines[] = '- Coverage: ' . $metrics['coverage'] . '%';
+    }
+    if ($metrics['rest'] !== null) {
+        $lines[] = '- REST violations: ' . $metrics['rest'];
+    }
+    if ($metrics['sql'] !== null) {
+        $lines[] = '- SQL violations: ' . $metrics['sql'];
+    }
+    if ($metrics['license'] !== null) {
+        $lines[] = '- License denials: ' . $metrics['license'];
+    }
+    if ($metrics['secrets'] !== null) {
+        $lines[] = '- Secrets found: ' . $metrics['secrets'];
+    }
+    $lines[] = '';
+    if (!empty($metrics['manifest'])) {
+        $lines[] = '### Manifest';
+        $files = array_slice($metrics['manifest'], 0, 5);
+        foreach ($files as $f) {
+            $path = $f['path'] ?? '';
+            $sha = $f['sha256'] ?? '';
+            $lines[] = '- ' . $path . ': ' . substr($sha, 0, 12);
+        }
+        $total = count($metrics['manifest']);
+        if ($total > count($files)) {
+            $lines[] = '- ... (' . $total . ' files)';
+        }
+        $lines[] = '';
+    }
+}
+
+$lines[] = '</div>';
+$markdown = implode("\n", $lines) . "\n";
+
+$dir = $root . '/artifacts/dist';
+if (!is_dir($dir)) {
+    @mkdir($dir, 0777, true);
+}
+file_put_contents($dir . '/release-notes.md', $markdown);
+
+exit(0);

--- a/scripts/tag-dry-run.sh
+++ b/scripts/tag-dry-run.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+plugin_version=$(php -r '@preg_match("/^\\s*Version:\\s*(.+)$/m", file_get_contents($argv[1] ?? ""), $m); echo $m[1] ?? "";' "$root/smart-alloc.php" 2>/dev/null)
+readme_tag=$(php -r '@preg_match("/^Stable tag:\\s*(.+)$/m", file_get_contents($argv[1] ?? ""), $m); echo $m[1] ?? "";' "$root/readme.txt" 2>/dev/null)
+
+tag="$plugin_version"
+if [ -n "$readme_tag" ] && [ "$plugin_version" != "$readme_tag" ]; then
+  tag="$plugin_version (plugin) / $readme_tag (readme)"
+fi
+
+date=$(date +%F)
+
+echo "Tag: $tag"
+echo "Date: $date"
+echo "Artifacts:"
+echo " - $root/artifacts/dist/manifest.json"
+echo " - $root/artifacts/dist/sbom.json"
+echo " - $root/artifacts/dist/release-notes.md"
+
+exit 0


### PR DESCRIPTION
## Summary
- add release notes generator that parses the top CHANGELOG entry and QA signals
- snapshot release gate and GO/NO-GO data into a final checklist
- provide a dry-run tag helper and document finalization steps

## Testing
- `composer test`
- `php scripts/release-notes.php`
- `php scripts/final-checklist.php`
- `bash scripts/tag-dry-run.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a6cf384b548321a7e56224c1318c7e