### PR TITLE
Add release finalizer orchestration

### DIFF
--- a/docs/RELEASE_FINAL.md
+++ b/docs/RELEASE_FINAL.md
@@ -1,0 +1,20 @@
+# Release Finalization
+
+Quick GA finalization flow:
+
+```bash
+bash scripts/release-finalizer.sh
+cat artifacts/ga/GA_READY.txt
+bash scripts/tag-dry-run.sh
+```
+
+The finalizer stitches existing distribution and QA helpers into a single advisory
+run. Each step is optional and the script never fails if a tool or artifact is
+missing. Outputs map to the GA checklist:
+
+- `artifacts/dist/manifest.json` and `artifacts/dist/sbom.json` provide release integrity.
+- `artifacts/qa/go-no-go.json` feeds `GA_READY.txt` with REST/SQL/license/secrets counts and coverage when available.
+- `artifacts/dist/release-notes.md` captures changelog excerpts and QA signals.
+
+Use the generated `GA_READY.txt` to review version, date, go/no-go summary and
+signal counts before performing the final tag dry run.

--- a/scripts/release-finalizer.sh
+++ b/scripts/release-finalizer.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+
+set +e
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+run_composer() {
+    local cmd="$1"
+    if command -v composer >/dev/null 2>&1 && [ -f "$ROOT/composer.json" ]; then
+        composer $cmd >/dev/null 2>&1 || true
+    fi
+}
+
+run_php() {
+    local script="$1"
+    if command -v php >/dev/null 2>&1 && [ -f "$ROOT/$script" ]; then
+        php "$ROOT/$script" "$2" >/dev/null 2>&1 || true
+    fi
+}
+
+# Step 1
+run_composer preflight
+run_composer dist
+
+# Step 2
+run_php scripts/dist-audit.php
+run_php scripts/dist-manifest.php
+
+# Step 3
+run_php scripts/version-coherence.php
+run_php scripts/validate-readme.php
+
+# Step 4
+run_php scripts/sbom-from-composer.php
+
+# Step 5
+if command -v php >/dev/null 2>&1; then
+    mkdir -p "$ROOT/artifacts/qa"
+    if [ -f "$ROOT/scripts/go-no-go.php" ]; then
+        php "$ROOT/scripts/go-no-go.php" > "$ROOT/artifacts/qa/go-no-go.json" 2>/dev/null || true
+    fi
+    run_php scripts/changelog-guard.php
+    run_php scripts/tag-preflight.php
+fi
+
+# Step 6
+run_php scripts/release-notes.php
+run_php scripts/final-checklist.php
+
+# Summary
+mkdir -p "$ROOT/artifacts/ga"
+version="$(php -r 'echo preg_match("/Version:\s*([^\n]+)/", file_get_contents("smart-alloc.php"), $m) ? trim($m[1]) : "";' 2>/dev/null)"
+[ -z "$version" ] && version="N/A"
+date="$(date -u +"%Y-%m-%d")"
+manifest="missing"
+[ -f "$ROOT/artifacts/dist/manifest.json" ] && manifest="present"
+sbom="missing"
+[ -f "$ROOT/artifacts/dist/sbom.json" ] && sbom="present"
+
+# go-no-go details
+go="N/A"; rest="N/A"; sql="N/A"; license="N/A"; secrets="N/A"; coverage="N/A"
+if command -v php >/dev/null 2>&1 && [ -f "$ROOT/artifacts/qa/go-no-go.json" ]; then
+    readarray -t gng < <(php -r '$j=json_decode(file_get_contents($argv[1]),true);echo ($j["summary"]["go"]??null)?"GO":"NO-GO";echo "\n";echo $j["inputs"]["rest"]["count"]??"N/A";echo "\n";echo $j["inputs"]["sql"]["count"]??"N/A";echo "\n";echo $j["inputs"]["licenses"]["denied"]??"N/A";echo "\n";echo $j["inputs"]["secrets"]["count"]??"N/A";echo "\n";echo $j["inputs"]["qa"]["coverage_percent"]??"";' "$ROOT/artifacts/qa/go-no-go.json")
+    go="${gng[0]}"
+    rest="${gng[1]}"
+    sql="${gng[2]}"
+    license="${gng[3]}"
+    secrets="${gng[4]}"
+    coverage="${gng[5]}"
+    [ -z "$coverage" ] && coverage="N/A"
+fi
+
+{
+    printf 'Version: %s\n' "$version"
+    printf 'Date: %s\n' "$date"
+    printf 'Manifest: %s\n' "$manifest"
+    printf 'SBOM: %s\n' "$sbom"
+    printf 'GO/NO-GO: %s\n' "$go"
+    printf 'REST: %s\n' "$rest"
+    printf 'SQL: %s\n' "$sql"
+    printf 'License: %s\n' "$license"
+    printf 'Secrets: %s\n' "$secrets"
+    [ "$coverage" != "N/A" ] && printf 'Coverage: %s\n' "$coverage" || true
+} > "$ROOT/artifacts/ga/GA_READY.txt"
+
+exit 0

--- a/tests/unit/Release/FinalizerSmokeTest.php
+++ b/tests/unit/Release/FinalizerSmokeTest.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class FinalizerSmokeTest extends TestCase {
+    public function test_release_finalizer_artifacts_exist(): void {
+        if (getenv('RUN_RELEASE_FINAL') !== '1') {
+            $this->markTestSkipped('release finalizer opt-in');
+        }
+        $root = dirname(__DIR__, 3);
+        $script = $root . '/scripts/release-finalizer.sh';
+        $this->assertFileExists($script);
+        $cmd = sprintf('bash %s', escapeshellarg($script));
+        exec($cmd, $_, $code);
+        $this->assertSame(0, $code, 'release-finalizer exited non-zero');
+        $dist = $root . '/artifacts/dist';
+        $this->assertFileExists($dist . '/manifest.json');
+        $this->assertFileExists($dist . '/sbom.json');
+        $this->assertFileExists($dist . '/release-notes.md');
+    }
+}


### PR DESCRIPTION
## Summary
- Add release-finalizer script that chains existing QA and dist helpers into a GA summary
- Provide optional smoke test verifying dist artifacts when finalizer runs
- Document finalization workflow and outputs

## Testing
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68a6d70b46bc83218c63ea823b88fe7f