### PR TITLE
Add release draft generator and rollback helpers

### DIFF
--- a/docs/POST_RELEASE.md
+++ b/docs/POST_RELEASE.md
@@ -1,5 +1,7 @@
 # Post-Release Monitoring & Operations (SmartAlloc)
 
+Run [`scripts/post-release-watch.sh`](../scripts/post-release-watch.sh) for an optional alerts checklist.
+
 ## Weekly
 - Patchstack scan & dependency review (record findings)
 - Review error logs & redaction samples (PII-free)
@@ -35,6 +37,8 @@
 ### Weekly Checks
 - Run Patchstack security scan.
 - Review DB health: indexes and table size trends.
+- Verify error rate < 0.1%.
+- Review LCP < 2.5s and CLS < 0.1 dashboards.
 - Smoke test: onboard one new student end-to-end.
 
 ### Examples

--- a/docs/ROLLBACK.md
+++ b/docs/ROLLBACK.md
@@ -1,0 +1,29 @@
+# Rollback Playbook
+
+## 1. Select Tag
+- List tags: `git tag --sort=-v:refname | head`
+- Choose prior GA tag (e.g., `v1.0.0`).
+
+## 2. Download & Verify
+- Fetch artifact:
+  ```bash
+  curl -LO https://downloads.wordpress.org/plugin/smart-alloc.<TAG>.zip
+  unzip -q smart-alloc.<TAG>.zip
+  ```
+- Verify checksums using manifest:
+  ```bash
+  sha256sum --check artifacts/dist/manifest.json
+  ```
+
+## 3. WordPress.org Revert Checklist
+- Update `readme.txt` stable tag to `<TAG>`.
+- Commit and push tag: `git tag -f <TAG> && git push origin <TAG> --force`.
+- Upload package via wp.org SVN.
+
+## 4. Data Safety
+- No database schema changes in this release; rollback is data-safe.
+
+## 5. Logs & Monitoring
+- Review error logs and APM dashboards.
+- Confirm circuit breaker state and export queue depth.
+- Link to dashboards as needed.

--- a/scripts/post-release-watch.sh
+++ b/scripts/post-release-watch.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Post-release watchers checklist. Reads optional QA artifacts and prints alert suggestions.
+# Always exits 0.
+
+set -u
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+GNG="$ROOT_DIR/artifacts/qa/go-no-go.json"
+QA_REPORT="$ROOT_DIR/artifacts/qa/qa-report.json"
+
+[ -f "$GNG" ] && echo "GO/NO-GO:" && cat "$GNG"
+[ -f "$QA_REPORT" ] && echo "QA Report:" && cat "$QA_REPORT"
+
+echo "Alerts checklist:"
+echo "- p95 response >2s"
+echo "- export errors >5/10m"
+echo "- breaker open"
+
+exit 0

--- a/scripts/release-draft.php
+++ b/scripts/release-draft.php
@@ -1,0 +1,149 @@
+<?php
+declare(strict_types=1);
+
+$root = dirname(__DIR__);
+$distDir = $root . '/artifacts/dist';
+if (!is_dir($distDir)) {
+    @mkdir($distDir, 0777, true);
+}
+$outFile = $distDir . '/release-draft.md';
+$lines = [];
+$lines[] = '<div dir="rtl">';
+$lines[] = '# Release Draft';
+$lines[] = '';
+$releaseNotesPath = $distDir . '/release-notes.md';
+$releaseNotes = is_file($releaseNotesPath) ? (string)file_get_contents($releaseNotesPath) : '';
+
+// Highlights from CHANGELOG
+$highlights = [];
+$changelog = $root . '/CHANGELOG.md';
+if (is_file($changelog)) {
+    $content = (string)file_get_contents($changelog);
+    if (preg_match('/^##\s*\[?([^\]\s]+)\]?\s*-\s*(\d{4}-\d{2}-\d{2})\s*\n(.*?)(?:\n##\s|\z)/s', $content, $m)) {
+        $body = trim($m[3]);
+        foreach (preg_split('/\r?\n/', $body) as $line) {
+            if (preg_match('/^\s*[-*]\s*(.+)/', $line, $lm)) {
+                $highlights[] = trim($lm[1]);
+            }
+        }
+    }
+}
+$lines[] = '## Highlights';
+if ($highlights) {
+    foreach ($highlights as $h) {
+        $lines[] = '- ' . $h;
+    }
+} else {
+    $lines[] = '_n/a_';
+}
+$lines[] = '';
+
+// QA Summary from go-no-go
+$qaPath = $root . '/artifacts/qa/go-no-go.json';
+$qaSummary = [];
+$reasons = [];
+if (is_file($qaPath)) {
+    $qa = json_decode((string)file_get_contents($qaPath), true);
+    if (is_array($qa)) {
+        $inputs = $qa['inputs'] ?? [];
+        $qaSummary['coverage'] = $inputs['qa']['coverage_percent'] ?? null;
+        $qaSummary['rest'] = $inputs['rest']['count'] ?? null;
+        $qaSummary['sql'] = $inputs['sql']['count'] ?? null;
+        $qaSummary['licenses'] = $inputs['licenses']['denied'] ?? null;
+        $qaSummary['secrets'] = $inputs['secrets']['count'] ?? null;
+        $qaSummary['verdict'] = $qa['summary']['go'] ?? null;
+        $reasons = $qa['summary']['reasons'] ?? [];
+    }
+}
+$lines[] = '## QA Summary';
+if ($qaSummary) {
+    $lines[] = '- Coverage: ' . ($qaSummary['coverage'] !== null ? $qaSummary['coverage'] . '%' : 'n/a');
+    $lines[] = '- REST violations: ' . ($qaSummary['rest'] ?? 'n/a');
+    $lines[] = '- SQL violations: ' . ($qaSummary['sql'] ?? 'n/a');
+    $lines[] = '- License denials: ' . ($qaSummary['licenses'] ?? 'n/a');
+    $lines[] = '- Secrets found: ' . ($qaSummary['secrets'] ?? 'n/a');
+    if ($qaSummary['verdict'] !== null) {
+        $lines[] = '- Verdict: ' . ($qaSummary['verdict'] ? 'GO' : 'NO-GO');
+    }
+} else {
+    $lines[] = '_n/a_';
+}
+$lines[] = '';
+
+// Artifacts from manifest and SBOM
+$lines[] = '## Artifacts';
+$manifestPath = $distDir . '/manifest.json';
+if (is_file($manifestPath)) {
+    $manifest = json_decode((string)file_get_contents($manifestPath), true);
+    if (isset($manifest['files']) && is_array($manifest['files'])) {
+        foreach ($manifest['files'] as $file) {
+            $path = $file['path'] ?? '';
+            $sha = $file['sha256'] ?? '';
+            if ($path !== '' && $sha !== '') {
+                $lines[] = '- `' . $path . '` `' . $sha . '`';
+            }
+        }
+    }
+} else {
+    $lines[] = '_n/a_';
+}
+$sbomPath = $distDir . '/sbom.json';
+if (is_file($sbomPath)) {
+    $sbom = json_decode((string)file_get_contents($sbomPath), true);
+    $count = is_array($sbom['components'] ?? null) ? count($sbom['components']) : 0;
+    $lines[] = ''; 
+    $lines[] = 'SBOM components: ' . $count;
+}
+$lines[] = '';
+
+// Upgrade & Compatibility matrix
+$lines[] = '## Upgrade & Compatibility';
+$pluginFile = $root . '/smart-alloc.php';
+$wpMin = $wpTested = $phpReq = $gfReq = 'n/a';
+if (is_file($pluginFile)) {
+    $contents = (string)file_get_contents($pluginFile);
+    if (preg_match('/Requires at least:\s*(.+)/i', $contents, $m)) {
+        $wpMin = trim($m[1]);
+    }
+    if (preg_match('/Tested up to:\s*(.+)/i', $contents, $m)) {
+        $wpTested = trim($m[1]);
+    }
+    if (preg_match('/Requires PHP:\s*(.+)/i', $contents, $m)) {
+        $phpReq = trim($m[1]);
+    }
+}
+// Attempt to detect Gravity Forms version from docs or readme
+$readme = $root . '/README.md';
+if (is_file($readme)) {
+    $rd = (string)file_get_contents($readme);
+    if (preg_match('/Gravity Forms[^\n\r]*?([0-9][0-9\.\+]*)/i', $rd, $m)) {
+        $gfReq = $m[1];
+    }
+}
+$lines[] = '| WordPress | Gravity Forms | PHP |';
+$lines[] = '| --- | --- | --- |';
+$lines[] = '| ' . $wpMin . '-' . $wpTested . ' | ' . $gfReq . ' | ' . $phpReq . ' |';
+$lines[] = '';
+
+// Known Issues / Skips
+$lines[] = '## Known Issues / Skips';
+if ($reasons) {
+    foreach ($reasons as $r) {
+        $type = $r['type'] ?? 'unknown';
+        $sev = $r['severity'] ?? 'info';
+        $lines[] = '- ' . $type . ' (' . $sev . ')';
+    }
+} elseif ($releaseNotes !== '' && preg_match('/##\s*Known Issues\s*\n(.*?)(?:\n##|\z)/s', $releaseNotes, $m)) {
+    foreach (preg_split('/\r?\n/', trim($m[1])) as $line) {
+        if ($line !== '') {
+            $lines[] = $line;
+        }
+    }
+} else {
+    $lines[] = '_n/a_';
+}
+$lines[] = '';
+$lines[] = '</div>';
+
+file_put_contents($outFile, implode("\n", $lines) . "\n");
+exit(0);

--- a/scripts/rollback-check.php
+++ b/scripts/rollback-check.php
@@ -1,0 +1,60 @@
+<?php
+declare(strict_types=1);
+
+$root = dirname(__DIR__);
+$manifestPath = $root . '/artifacts/dist/manifest.json';
+$pluginFile = $root . '/smart-alloc.php';
+
+$manifest = [];
+if (is_file($manifestPath)) {
+    $manifest = json_decode((string)file_get_contents($manifestPath), true);
+}
+
+$version = null;
+if (is_file($pluginFile)) {
+    $contents = (string)file_get_contents($pluginFile);
+    if (preg_match('/^\s*Version:\s*(.+)$/mi', $contents, $m)) {
+        $version = trim($m[1]);
+    }
+}
+
+$prev = null;
+if ($version !== null) {
+    $base = preg_replace('/-.*/', '', $version);
+    $parts = explode('.', $base);
+    if (count($parts) === 3) {
+        $parts[2] = (string)max(0, ((int)$parts[2]) - 1);
+        $prev = implode('.', $parts);
+    }
+}
+
+$lines = [];
+$lines[] = '# Rollback Check';
+if ($version !== null) {
+    $lines[] = 'Current version: ' . $version;
+}
+if ($prev !== null) {
+    $artifact = 'smart-alloc-' . $prev . '.zip';
+    $lines[] = 'Fetch previous GA artifact:';
+    $lines[] = 'curl -LO https://downloads.wordpress.org/plugin/smart-alloc.' . $prev . '.zip';
+    $lines[] = 'unzip -q smart-alloc.' . $prev . '.zip -d rollback-' . $prev;
+    if (!empty($manifest['files'])) {
+        $lines[] = 'cd rollback-' . $prev; 
+        $lines[] = 'sha256sum --check <<\'EOF\'';
+        foreach ($manifest['files'] as $f) {
+            $path = $f['path'] ?? '';
+            $sha = $f['sha256'] ?? '';
+            if ($path !== '' && $sha !== '') {
+                $lines[] = $sha . '  ' . $path;
+            }
+        }
+        $lines[] = 'EOF';
+    } else {
+        $lines[] = '# manifest.json missing or empty';
+    }
+} else {
+    $lines[] = 'Plugin version not detected.';
+}
+
+echo implode("\n", $lines) . "\n";
+exit(0);


### PR DESCRIPTION
## Summary
- generate release-draft markdown with highlights, QA summary, artifacts, compatibility matrix and known issues
- add rollback kit including playbook and command generator
- add post-release watchers script and docs updates

## Testing
- `composer test`
- `php scripts/release-draft.php`
- `php scripts/rollback-check.php`
- `bash scripts/post-release-watch.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a6dcf946e483218bb45f71950cc890