### PR TITLE
Add packaging scripts and ops triage guide

### DIFF
--- a/docs/OPS_TRIAGE.md
+++ b/docs/OPS_TRIAGE.md
@@ -1,0 +1,54 @@
+# Ops / SRE Triage
+
+Quick reference for post-deploy verification and common production issues. See [POST_RELEASE.md](POST_RELEASE.md) for full procedures.
+
+## Verify Manifest & Signatures
+
+1. Navigate to `artifacts/dist/`.
+2. Ensure `manifest.json` exists.
+3. Verify checksum:
+   ```sh
+   openssl dgst -sha256 manifest.json
+   cat manifest.sha256
+   ```
+4. Verify signature when keys are available:
+   ```sh
+   openssl dgst -sha256 -verify pubkey.pem -signature manifest.sig manifest.json
+   gpg --verify manifest.asc manifest.json
+   ```
+
+## Health Endpoints
+
+- `GET /wp-json/smartalloc/v1/health` – returns `{ok, db, cache, version}`.
+- `GET /wp-json/smartalloc/v1/exports` – basic auth required; confirms exporter alive.
+
+## Breaker States
+
+Check option flags to see if circuits are open:
+
+```sh
+wp option get smartalloc_breaker_exports
+wp option get smartalloc_breaker_webhooks
+```
+
+`0` means closed/healthy, `1` means open (traffic stopped).
+
+## Common Runbooks
+
+### Exports Failing
+- Check queue: `wp smartalloc queue status`
+- Review logs for `ExportService` errors.
+- Retry with `wp smartalloc export --retry`.
+
+### Redis Down
+- Health endpoint `cache` will be false.
+- Restart service or failover to backup.
+- Clear object cache when restored.
+
+### Database Slow
+- Health endpoint `db` false or high latency.
+- Inspect `SHOW PROCESSLIST` and slow query logs.
+- Consider read replica or enabling query cache.
+
+---
+For more post-release tasks, see [POST_RELEASE.md](POST_RELEASE.md).

--- a/scripts/announce.php
+++ b/scripts/announce.php
@@ -1,0 +1,83 @@
+<?php
+declare(strict_types=1);
+
+$root = dirname(__DIR__);
+$dist = $root . '/artifacts/dist';
+if (!is_dir($dist)) {
+    mkdir($dist, 0777, true);
+}
+
+$changelog = $root . '/CHANGELOG.md';
+$releaseDraft = $dist . '/release-draft.md';
+$goFile = $root . '/artifacts/qa/go-no-go.json';
+$manifest = $dist . '/manifest.json';
+
+$version = '';
+$entry = '';
+if (is_file($changelog)) {
+    $lines = file($changelog, FILE_IGNORE_NEW_LINES);
+    for ($i=0; $i<count($lines); $i++) {
+        if (preg_match('/^##\s*(.+)$/', $lines[$i], $m)) {
+            $version = trim($m[1]);
+            $i++;
+            for (; $i<count($lines); $i++) {
+                if (preg_match('/^##\s*/', $lines[$i])) { break; }
+                $entry .= $lines[$i] . "\n";
+            }
+            $entry = trim($entry);
+            break;
+        }
+    }
+}
+
+$draftText = is_file($releaseDraft) ? trim((string)file_get_contents($releaseDraft)) : '';
+$go = is_file($goFile) ? json_decode((string)file_get_contents($goFile), true) : null;
+$checksums = [];
+if (is_file($manifest)) {
+    $m = json_decode((string)file_get_contents($manifest), true);
+    if (isset($m['files']) && is_array($m['files'])) {
+        foreach ($m['files'] as $f) {
+            $checksums[] = [$f['path'] ?? '', $f['sha256'] ?? '', $f['size'] ?? ''];
+        }
+    }
+}
+
+$slackLines = [];
+$slackLines[] = "*SmartAlloc $version*";
+if ($entry !== '') {
+    foreach (preg_split('/\n+/', $entry) as $line) {
+        $line = trim($line, " -*");
+        if ($line === '') { continue; }
+        $slackLines[] = "• " . $line;
+    }
+}
+if ($draftText !== '') {
+    $slackLines[] = $draftText;
+}
+file_put_contents($dist . '/announce-slack.md', implode("\n", $slackLines) . "\n");
+
+$email = "# SmartAlloc $version Release\n\n";
+if ($entry !== '') {
+    $email .= $entry . "\n\n";
+}
+if ($draftText !== '') {
+    $email .= $draftText . "\n\n";
+}
+if ($go !== null && isset($go['compatibility']) && is_array($go['compatibility'])) {
+    $email .= "## Compatibility\n\n| Component | Minimum | Maximum |\n| --- | --- | --- |\n";
+    foreach ($go['compatibility'] as $row) {
+        $email .= '| ' . ($row['component'] ?? '') . ' | ' . ($row['min'] ?? '') . ' | ' . ($row['max'] ?? '') . " |\n";
+    }
+    $email .= "\n";
+}
+if (!empty($checksums)) {
+    $email .= "## Checksums\n\n| File | SHA256 | Size |\n| --- | --- | --- |\n";
+    foreach ($checksums as $c) {
+        $email .= '| ' . $c[0] . ' | ' . $c[1] . ' | ' . $c[2] . " |\n";
+    }
+    $email .= "\n";
+}
+file_put_contents($dist . '/announce-email.md', $email);
+
+echo json_encode(['ok' => true]) . PHP_EOL;
+exit(0);

--- a/scripts/dist-normalize.php
+++ b/scripts/dist-normalize.php
@@ -1,0 +1,97 @@
+<?php
+declare(strict_types=1);
+
+if (!function_exists('str_starts_with')) {
+    function str_starts_with(string $haystack, string $needle): bool {
+        return substr($haystack, 0, strlen($needle)) === $needle;
+    }
+}
+
+// Deterministic zip normalizer.
+// Usage: php scripts/dist-normalize.php <folder> [--outfile=path]
+
+$root = dirname(__DIR__);
+$input = $argv[1] ?? '';
+$outOpt = $argv[2] ?? '';
+$options = [];
+if (str_starts_with($outOpt, '--outfile=')) {
+    $options['outfile'] = substr($outOpt, 10);
+}
+
+$dir = $input !== '' ? realpath($input) : null;
+if ($dir === false || $dir === null || !is_dir($dir)) {
+    echo json_encode(['error' => 'invalid_input']) . PHP_EOL;
+    exit(0);
+}
+
+$base = basename($dir);
+$outFile = $options['outfile'] ?? ($root . '/artifacts/dist/' . $base . '-normalized.zip');
+$distDir = dirname($outFile);
+if (!is_dir($distDir)) {
+    mkdir($distDir, 0777, true);
+}
+
+$mtime = gmmktime(0, 0, 0, 1, 1, 2020);
+$items = [];
+$iter = new RecursiveIteratorIterator(
+    new RecursiveDirectoryIterator($dir, FilesystemIterator::SKIP_DOTS),
+    RecursiveIteratorIterator::SELF_FIRST
+);
+foreach ($iter as $info) {
+    $rel = substr($info->getPathname(), strlen($dir) + 1);
+    $rel = str_replace('\\', '/', $rel);
+    $items[] = ['path' => $rel, 'dir' => $info->isDir()];
+}
+
+usort($items, static function ($a, $b) {
+    return strcmp($a['path'], $b['path']);
+});
+
+$zip = new ZipArchive();
+$zip->open($outFile, ZipArchive::CREATE | ZipArchive::OVERWRITE);
+$fileCount = 0;
+foreach ($items as $item) {
+    $full = $dir . '/' . $item['path'];
+    if ($item['dir']) {
+        $zip->addEmptyDir($item['path']);
+        if (method_exists($zip, 'setMtimeName')) {
+            $zip->setMtimeName($item['path'], $mtime);
+        }
+        if (method_exists($zip, 'setExternalAttributesName')) {
+            $zip->setExternalAttributesName($item['path'], ZipArchive::OPSYS_UNIX, (040755 << 16));
+        }
+        continue;
+    }
+    $data = (string)file_get_contents($full);
+    if (isText($full)) {
+        $data = preg_replace("/\r\n?/,\n", $data);
+    }
+    $zip->addFromString($item['path'], $data);
+    if (method_exists($zip, 'setMtimeName')) {
+        $zip->setMtimeName($item['path'], $mtime);
+    }
+    if (method_exists($zip, 'setExternalAttributesName')) {
+        $zip->setExternalAttributesName($item['path'], ZipArchive::OPSYS_UNIX, (0100644 << 16));
+    }
+    $fileCount++;
+}
+$zip->close();
+
+$summary = [
+    'files' => $fileCount,
+    'size' => is_file($outFile) ? filesize($outFile) : 0,
+    'sha256' => is_file($outFile) ? hash_file('sha256', $outFile) : null,
+];
+
+echo json_encode($summary, JSON_PRETTY_PRINT) . PHP_EOL;
+exit(0);
+
+function isText(string $path): bool {
+    $fh = @fopen($path, 'rb');
+    if ($fh === false) {
+        return false;
+    }
+    $chunk = fread($fh, 512);
+    fclose($fh);
+    return $chunk !== false && strpos($chunk, "\0") === false;
+}

--- a/scripts/sign-manifest.sh
+++ b/scripts/sign-manifest.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set +e
+MANIFEST="$(dirname "$(dirname "$0")")/artifacts/dist/manifest.json"
+DIST_DIR="$(dirname "$MANIFEST")"
+KEY="${MANIFEST_SIGN_KEY:-}"
+
+if [ ! -f "$MANIFEST" ]; then
+  echo "manifest.json not found; skipping" >&2
+  exit 0
+fi
+
+if ! command -v openssl >/dev/null 2>&1; then
+  echo "openssl not available; skipping" >&2
+  exit 0
+fi
+
+HASH_FILE="$DIST_DIR/manifest.sha256"
+SIG_FILE="$DIST_DIR/manifest.sig"
+ASC_FILE="$DIST_DIR/manifest.asc"
+
+hash=$(openssl dgst -sha256 -r "$MANIFEST" 2>/dev/null | awk '{print $1}')
+if [ -n "$hash" ]; then
+  echo "$hash" > "$HASH_FILE"
+fi
+
+if [ -n "$KEY" ] && [ -f "$KEY" ]; then
+  openssl dgst -sha256 -sign "$KEY" -out "$SIG_FILE" "$MANIFEST" 2>/dev/null
+  if command -v gpg >/dev/null 2>&1; then
+    gpg --batch --yes --armor --detach-sign -o "$ASC_FILE" "$MANIFEST" 2>/dev/null || true
+  else
+    echo "gpg not available; skipping ascii signature" >&2
+  fi
+else
+  echo "signing key missing; skipping signatures" >&2
+fi
+
+exit 0

--- a/scripts/wporg-lint.php
+++ b/scripts/wporg-lint.php
@@ -1,0 +1,90 @@
+<?php
+declare(strict_types=1);
+
+$root = dirname(__DIR__);
+$result = ['readme' => [], 'assets' => []];
+
+$readmeFile = $root . '/readme.txt';
+$readme = [
+    'missing_headers' => [],
+    'short_description' => true,
+    'sections' => [],
+    'ok' => true,
+];
+if (!is_file($readmeFile)) {
+    $readme['ok'] = false;
+    $readme['missing'] = true;
+} else {
+    $content = (string)file_get_contents($readmeFile);
+    $lines = preg_split('/\r?\n/', $content);
+    $headers = [];
+    $idx = 1; // skip title
+    for (; $idx < count($lines); $idx++) {
+        $line = $lines[$idx];
+        if ($line === '') { $idx++; break; }
+        if (strpos($line, ':') !== false) {
+            [$k, $v] = array_map('trim', explode(':', $line, 2));
+            $headers[$k] = $v;
+        }
+    }
+    $req = ['Requires at least','Tested up to','Stable tag','Requires PHP'];
+    foreach ($req as $h) { if (!isset($headers[$h]) || $headers[$h] === '') { $readme['missing_headers'][] = $h; } }
+    $short = '';
+    for (; $idx < count($lines); $idx++) {
+        $line = trim($lines[$idx]);
+        if ($line !== '') { $short = $line; break; }
+    }
+    if ($short === '' || strlen($short) > 150) {
+        $readme['short_description'] = false;
+    }
+    if (preg_match_all('/^==\s*(.+?)\s*==/m', $content, $matches, PREG_SET_ORDER)) {
+        $positions = [];
+        foreach ($matches as $m) {
+            $positions[] = ['name' => $m[1], 'pos' => strpos($content, $m[0])];
+        }
+        for ($i=0; $i<count($positions); $i++) {
+            $start = $positions[$i]['pos'] + strlen($positions[$i]['name']) + 4;
+            $end = $positions[$i+1]['pos'] ?? strlen($content);
+            $linesCount = substr_count(substr($content, $start, $end-$start), "\n");
+            $readme['sections'][$positions[$i]['name']] = $linesCount;
+            if ($linesCount > 400) {
+                $readme['ok'] = false;
+            }
+        }
+    }
+    if ($readme['missing_headers'] || !$readme['short_description']) {
+        $readme['ok'] = false;
+    }
+}
+$result['readme'] = $readme;
+
+$assetsDir = $root . '/.wordpress-org';
+$assets = ['present' => false];
+if (is_dir($assetsDir)) {
+    $assets['present'] = true;
+    $required = [
+        'banner-772x250' => 1000000,
+        'banner-1544x500' => 1500000,
+        'icon-128x128' => 100000,
+        'icon-256x256' => 200000,
+    ];
+    foreach ($required as $base => $max) {
+        $found = false;
+        foreach (['.png','.jpg','.jpeg','.svg'] as $ext) {
+            $path = "$assetsDir/$base$ext";
+            if (is_file($path)) {
+                $size = filesize($path);
+                $assets['files'][$base.$ext] = ['size' => $size, 'ok' => $size <= $max];
+                $found = true;
+                break;
+            }
+        }
+        if (!$found) {
+            $assets['files'][$base] = ['missing' => true];
+        }
+    }
+}
+$result['assets'] = $assets;
+
+echo json_encode($result, JSON_PRETTY_PRINT) . PHP_EOL;
+exit(0);


### PR DESCRIPTION
## Summary
- add deterministic dist-normalize utility
- include optional manifest signing helper
- lint WP.org readme/assets and generate announcement kit
- document ops triage steps

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68a6dfca6cb083219c5269cfcd6f8ab9