### PR TITLE
Add WP.org deploy dry-run toolkit

### DIFF
--- a/docs/DEPLOY_WPORG.md
+++ b/docs/DEPLOY_WPORG.md
@@ -1,0 +1,40 @@
+# WordPress.org Deploy (Dry-Run)
+
+The toolkit under `scripts/` prepares an offline SVN layout and supporting files. It does **not** perform any network operations.
+
+## Preparation
+
+1. Normalize your build and ensure dist artifacts exist (e.g. `artifacts/dist/SmartAlloc-normalized.zip`).
+2. Build the SVN tree:
+   ```bash
+   php scripts/wporg-svn-prepare.php artifacts/dist/SmartAlloc-normalized.zip 1.0.0
+   ```
+3. Truncate the changelog to the latest entries:
+   ```bash
+   php scripts/wporg-changelog-truncate.php 3
+   ```
+4. Generate the deployment checklist:
+   ```bash
+   php scripts/wporg-deploy-checklist.php
+   ```
+
+Artifacts are written to `artifacts/wporg/` and are safe to inspect offline.
+
+## Manual SVN Steps
+
+1. From a local checkout of the plugin SVN repository:
+   ```bash
+   svn cp trunk tags/1.0.0
+   ```
+2. Copy the prepared `trunk/`, `tags/1.0.0/`, and `assets/` from `artifacts/wporg/` into the SVN checkout.
+3. Upload assets and commit:
+   ```bash
+   svn add --force .
+   svn commit -m "Release 1.0.0"
+   ```
+4. Verify `readme.txt` and changelog using the truncated file.
+5. Compare checksums from `DEPLOY_CHECKLIST.md` before uploading the final ZIP.
+6. Consult [OPS_TRIAGE.md](OPS_TRIAGE.md) for any last-minute issues.
+7. After release, follow [POST_RELEASE.md](POST_RELEASE.md).
+
+The toolkit is advisory and intended for offline verification only.

--- a/scripts/wporg-changelog-truncate.php
+++ b/scripts/wporg-changelog-truncate.php
@@ -1,0 +1,73 @@
+<?php
+declare(strict_types=1);
+
+$root = dirname(__DIR__);
+$keep = isset($argv[1]) ? (int)$argv[1] : 3;
+$readme = $root . '/readme.txt';
+$outDir = $root . '/artifacts/wporg';
+@mkdir($outDir, 0777, true);
+$result = ['kept' => 0, 'removed' => 0, 'versions' => []];
+
+if (!is_file($readme)) {
+    $result['status'] = 'readme_missing';
+    echo json_encode($result, JSON_PRETTY_PRINT) . PHP_EOL;
+    exit(0);
+}
+
+$content = (string)file_get_contents($readme);
+$lines = preg_split('/\r?\n/', $content);
+$idx = null;
+for ($i = 0; $i < count($lines); $i++) {
+    if (trim($lines[$i]) === '== Changelog ==') {
+        $idx = $i;
+        break;
+    }
+}
+if ($idx === null) {
+    file_put_contents($outDir . '/readme-truncated.txt', $content);
+    $result['status'] = 'changelog_missing';
+    echo json_encode($result, JSON_PRETTY_PRINT) . PHP_EOL;
+    exit(0);
+}
+$header = array_slice($lines, 0, $idx + 1);
+$body = array_slice($lines, $idx + 1);
+$sections = [];
+$current = null;
+$currentLines = [];
+foreach ($body as $line) {
+    if (preg_match('/^=\s*([^=]+?)\s*=/', $line, $m)) {
+        if ($current !== null) {
+            $sections[] = ['version' => $current, 'lines' => $currentLines];
+        }
+        $current = trim($m[1]);
+        $currentLines = [];
+        continue;
+    }
+    if ($current !== null) {
+        $currentLines[] = $line;
+    }
+}
+if ($current !== null) {
+    $sections[] = ['version' => $current, 'lines' => $currentLines];
+}
+
+$kept = array_slice($sections, 0, $keep);
+$result['kept'] = count($kept);
+$result['removed'] = count($sections) - $result['kept'];
+$output = $header;
+foreach ($kept as $section) {
+    $linesCount = count($section['lines']);
+    $truncated = false;
+    if ($linesCount > 200) {
+        $section['lines'] = array_slice($section['lines'], 0, 200);
+        $truncated = true;
+    }
+    $result['versions'][$section['version']] = ['lines' => $linesCount, 'truncated' => $truncated];
+    $output[] = '= ' . $section['version'] . ' =';
+    $output = array_merge($output, $section['lines']);
+}
+$fileOut = implode("\n", $output);
+file_put_contents($outDir . '/readme-truncated.txt', $fileOut);
+
+echo json_encode($result, JSON_PRETTY_PRINT) . PHP_EOL;
+exit(0);

--- a/scripts/wporg-deploy-checklist.php
+++ b/scripts/wporg-deploy-checklist.php
@@ -1,0 +1,114 @@
+<?php
+declare(strict_types=1);
+
+$root = dirname(__DIR__);
+$outDir = $root . '/artifacts/wporg';
+@mkdir($outDir, 0777, true);
+$result = ['tag' => null, 'assets' => [], 'version' => [], 'checksums' => [], 'links' => []];
+
+$tagDir = $outDir . '/tags';
+if (is_dir($tagDir)) {
+    $entries = array_values(array_filter(scandir($tagDir) ?: [], static function ($n) {
+        return $n !== '.' && $n !== '..';
+    }));
+    $result['tag'] = $entries[0] ?? null;
+}
+
+$trunk = $outDir . '/trunk';
+$assetsDir = $outDir . '/assets';
+
+// Version coherence
+$pluginFile = null;
+if (is_dir($trunk)) {
+    foreach (glob($trunk . '/*.php') as $file) {
+        $content = (string)file_get_contents($file);
+        if (stripos($content, 'Plugin Name:') !== false) {
+            $pluginFile = $file;
+            break;
+        }
+    }
+}
+$pluginVersion = null;
+if ($pluginFile && is_file($pluginFile)) {
+    $data = (string)file_get_contents($pluginFile);
+    if (preg_match('/Version:\s*(.+)/i', $data, $m)) {
+        $pluginVersion = trim($m[1]);
+    }
+}
+$readmeFile = $trunk . '/readme.txt';
+$readmeVersion = null;
+if (is_file($readmeFile)) {
+    $content = (string)file_get_contents($readmeFile);
+    if (preg_match('/Stable tag:\s*(.+)/i', $content, $m)) {
+        $readmeVersion = trim($m[1]);
+    }
+}
+$result['version'] = ['plugin' => $pluginVersion, 'readme' => $readmeVersion, 'tag' => $result['tag']];
+
+// Assets
+if (is_dir($assetsDir)) {
+    $files = scandir($assetsDir) ?: [];
+    foreach ($files as $f) {
+        if ($f === '.' || $f === '..') { continue; }
+        $path = $assetsDir . '/' . $f;
+        if (is_file($path)) {
+            $result['assets'][$f] = filesize($path) ?: 0;
+        }
+    }
+}
+
+// Checksums
+$distZip = $root . '/artifacts/dist/SmartAlloc-normalized.zip';
+if (is_file($distZip)) {
+    $result['checksums']['SmartAlloc-normalized.zip'] = hash_file('sha256', $distZip);
+}
+$manifest = $root . '/artifacts/dist/manifest.json';
+if (is_file($manifest)) {
+    $result['checksums']['manifest.json'] = hash_file('sha256', $manifest);
+    $result['links'][] = 'artifacts/dist/manifest.json';
+}
+$sbom = $root . '/artifacts/dist/sbom.json';
+if (is_file($sbom)) {
+    $result['checksums']['sbom.json'] = hash_file('sha256', $sbom);
+    $result['links'][] = 'artifacts/dist/sbom.json';
+}
+$goNoGo = $root . '/artifacts/qa/go-no-go.json';
+if (is_file($goNoGo)) {
+    $result['links'][] = 'artifacts/qa/go-no-go.json';
+}
+$qaReport = $root . '/artifacts/qa/qa-report.json';
+if (is_file($qaReport)) {
+    $result['links'][] = 'artifacts/qa/qa-report.json';
+}
+$relNotes = $root . '/artifacts/dist/release-notes.md';
+if (is_file($relNotes)) {
+    $result['links'][] = 'artifacts/dist/release-notes.md';
+}
+$relDraft = $root . '/artifacts/dist/release-draft.md';
+if (is_file($relDraft)) {
+    $result['links'][] = 'artifacts/dist/release-draft.md';
+}
+
+// Build markdown
+$md = "# WP.org Deploy Checklist\n\n";
+$md .= "- [ ] Tag name: " . ($result['tag'] ?? 'n/a') . "\n";
+$md .= "- [ ] Assets present:" . (empty($result['assets']) ? ' none' : '') . "\n";
+foreach ($result['assets'] as $name => $size) {
+    $md .= "  - $name ($size bytes)\n";
+}
+$md .= "- [ ] Version coherence:\n";
+$md .= "  - Plugin header: " . ($pluginVersion ?? 'n/a') . "\n";
+$md .= "  - readme Stable tag: " . ($readmeVersion ?? 'n/a') . "\n";
+$md .= "  - Tag directory: " . ($result['tag'] ?? 'n/a') . "\n";
+$md .= "- [ ] Checksums:\n";
+foreach ($result['checksums'] as $file => $hash) {
+    $md .= "  - $file SHA256: $hash\n";
+}
+$md .= "- [ ] Preflight artifacts:\n";
+foreach ($result['links'] as $link) {
+    $md .= "  - $link\n";
+}
+file_put_contents($outDir . '/DEPLOY_CHECKLIST.md', $md);
+
+echo json_encode($result, JSON_PRETTY_PRINT) . PHP_EOL;
+exit(0);

--- a/scripts/wporg-svn-prepare.php
+++ b/scripts/wporg-svn-prepare.php
@@ -1,0 +1,175 @@
+<?php
+declare(strict_types=1);
+
+$root = dirname(__DIR__);
+$distPath = $argv[1] ?? '';
+$version = $argv[2] ?? '';
+$outDir = $root . '/artifacts/wporg';
+@mkdir($outDir, 0777, true);
+$result = [
+    'input' => ['dist' => $distPath, 'version' => $version],
+    'output' => ['dir' => $outDir],
+    'validation' => [
+        'plugin_header' => [],
+        'readme' => [],
+        'assets' => [],
+    ],
+    'status' => 'ok',
+];
+
+if ($distPath === '' || $version === '') {
+    $result['status'] = 'missing_args';
+    echo json_encode($result, JSON_PRETTY_PRINT) . PHP_EOL;
+    exit(0);
+}
+
+$tmp = $outDir . '/tmp-dist';
+if (is_dir($tmp)) {
+    deleteDir($tmp);
+}
+@mkdir($tmp, 0777, true);
+
+$distReal = realpath($distPath);
+if ($distReal === false) {
+    $result['status'] = 'dist_missing';
+} elseif (is_file($distReal) && preg_match('/\.zip$/i', $distReal)) {
+    if (class_exists('ZipArchive')) {
+        $zip = new ZipArchive();
+        if ($zip->open($distReal) === true) {
+            $zip->extractTo($tmp);
+            $zip->close();
+        } else {
+            $result['status'] = 'zip_open_failed';
+        }
+    } else {
+        $result['status'] = 'zip_extension_missing';
+    }
+} elseif (is_dir($distReal)) {
+    copyDir($distReal, $tmp);
+} else {
+    $result['status'] = 'dist_invalid';
+}
+
+$trunk = $outDir . '/trunk';
+$tag = $outDir . '/tags/' . $version;
+$assetsOut = $outDir . '/assets';
+@mkdir($outDir . '/tags', 0777, true);
+
+if (is_dir($tmp)) {
+    copyDir($tmp, $trunk);
+    copyDir($tmp, $tag);
+}
+
+$assetsSrc = $root . '/.wordpress-org';
+if (is_dir($assetsSrc)) {
+    copyDir($assetsSrc, $assetsOut);
+}
+
+// Plugin header validation
+$pluginFile = null;
+if (is_dir($tmp)) {
+    foreach (glob($tmp . '/*.php') as $file) {
+        $content = (string)file_get_contents($file);
+        if (stripos($content, 'Plugin Name:') !== false) {
+            $pluginFile = $file;
+            break;
+        }
+    }
+}
+$header = ['name' => null, 'version' => null, 'text_domain' => null, 'ok' => false];
+if ($pluginFile && is_file($pluginFile)) {
+    $data = (string)file_get_contents($pluginFile);
+    if (preg_match('/Plugin Name:\s*(.+)/i', $data, $m)) {
+        $header['name'] = trim($m[1]);
+    }
+    if (preg_match('/Version:\s*(.+)/i', $data, $m)) {
+        $header['version'] = trim($m[1]);
+    }
+    if (preg_match('/Text Domain:\s*(.+)/i', $data, $m)) {
+        $header['text_domain'] = trim($m[1]);
+    }
+    $header['ok'] = $header['name'] && $header['version'] && $header['text_domain'] && ($header['version'] === $version);
+}
+$result['validation']['plugin_header'] = $header;
+
+// readme stable tag
+$readmeFile = $tmp . '/readme.txt';
+$readme = ['stable_tag' => null, 'ok' => false];
+if (is_file($readmeFile)) {
+    $content = (string)file_get_contents($readmeFile);
+    if (preg_match('/Stable tag:\s*(.+)/i', $content, $m)) {
+        $readme['stable_tag'] = trim($m[1]);
+    }
+    $readme['ok'] = $readme['stable_tag'] === $version && $header['version'] === $version;
+}
+$result['validation']['readme'] = $readme;
+
+// assets sanity
+$assets = ['files' => [], 'ok' => true];
+if (is_dir($assetsSrc)) {
+    $required = [
+        'banner-772x250' => 1000000,
+        'banner-1544x500' => 1500000,
+        'icon-128x128' => 100000,
+        'icon-256x256' => 200000,
+    ];
+    foreach ($required as $base => $max) {
+        $found = false;
+        foreach (['.png','.jpg','.jpeg','.svg'] as $ext) {
+            $path = "$assetsSrc/$base$ext";
+            if (is_file($path)) {
+                $size = filesize($path) ?: 0;
+                $assets['files'][$base.$ext] = ['size' => $size, 'ok' => $size <= $max];
+                if ($size > $max) { $assets['ok'] = false; }
+                $found = true;
+                break;
+            }
+        }
+        if (!$found) {
+            $assets['files'][$base] = ['missing' => true];
+            $assets['ok'] = false;
+        }
+    }
+} else {
+    $assets['ok'] = false;
+}
+$result['validation']['assets'] = $assets;
+
+deleteDir($tmp);
+
+echo json_encode($result, JSON_PRETTY_PRINT) . PHP_EOL;
+exit(0);
+
+function copyDir(string $src, string $dst): void {
+    if (!is_dir($src)) { return; }
+    @mkdir($dst, 0777, true);
+    $iter = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($src, FilesystemIterator::SKIP_DOTS),
+        RecursiveIteratorIterator::SELF_FIRST
+    );
+    foreach ($iter as $info) {
+        $rel = substr($info->getPathname(), strlen($src) + 1);
+        $target = $dst . '/' . $rel;
+        if ($info->isDir()) {
+            if (!is_dir($target)) { @mkdir($target, 0777, true); }
+        } else {
+            @copy($info->getPathname(), $target);
+        }
+    }
+}
+
+function deleteDir(string $dir): void {
+    if (!is_dir($dir)) { return; }
+    $iter = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($dir, FilesystemIterator::SKIP_DOTS),
+        RecursiveIteratorIterator::CHILD_FIRST
+    );
+    foreach ($iter as $info) {
+        if ($info->isDir()) {
+            @rmdir($info->getPathname());
+        } else {
+            @unlink($info->getPathname());
+        }
+    }
+    @rmdir($dir);
+}


### PR DESCRIPTION
## Summary
- add `wporg-svn-prepare.php` to build WordPress.org-style SVN trees and validate headers/assets
- add `wporg-changelog-truncate.php` to shrink readme changelog
- add `wporg-deploy-checklist.php` to produce offline deploy checklists
- document manual deployment workflow in `DEPLOY_WPORG.md`

## Testing
- `composer test`
- `php scripts/wporg-svn-prepare.php`
- `php scripts/wporg-changelog-truncate.php`
- `php scripts/wporg-deploy-checklist.php`


------
https://chatgpt.com/codex/tasks/task_e_68a6e604a68483219de4ddbe9c88849b