### PR TITLE
Add i18n and WP.org advisory scripts

### DIFF
--- a/docs/I18N_CHECKLIST.md
+++ b/docs/I18N_CHECKLIST.md
@@ -1,0 +1,9 @@
+# I18N Checklist
+
+- [ ] Ensure all translation calls use the `smartalloc` text domain.
+- [ ] Verify printf-style placeholders are numbered and safe for translators.
+- [ ] Refresh `languages/smartalloc.pot` and review differences.
+- [ ] Audit RTL styles for visual regressions.
+- [ ] Review `.wordpress-org` assets (icons, banners, screenshots) for expected sizes.
+
+See [DEPLOY_WPORG.md](./DEPLOY_WPORG.md) and [RELEASE_GATE.md](./RELEASE_GATE.md) for full release guidance.

--- a/scripts/i18n-lint.php
+++ b/scripts/i18n-lint.php
@@ -1,0 +1,179 @@
+#!/usr/bin/env php
+<?php
+declare(strict_types=1);
+
+$root = dirname(__DIR__);
+$pluginFile = $root . '/smart-alloc.php';
+$expectedDomain = '';
+if (is_file($pluginFile)) {
+    $content = (string) file_get_contents($pluginFile);
+    if (preg_match('/Text Domain:\s*(\S+)/i', $content, $m)) {
+        $expectedDomain = trim($m[1]);
+    }
+}
+
+$files = collectPhpFiles($root);
+$result = [
+    'total_calls' => 0,
+    'wrong_domain' => [],
+    'placeholder_mismatch' => [],
+    'files_scanned' => count($files),
+];
+
+$functions = [
+    '__' => ['domain' => 1, 'strings' => [0]],
+    '_e' => ['domain' => 1, 'strings' => [0]],
+    '_x' => ['domain' => 2, 'strings' => [0]],
+    '_ex' => ['domain' => 2, 'strings' => [0]],
+    '_n' => ['domain' => 3, 'strings' => [0, 1]],
+    '_nx' => ['domain' => 4, 'strings' => [0, 1]],
+    'esc_html__' => ['domain' => 1, 'strings' => [0]],
+    'esc_html_e' => ['domain' => 1, 'strings' => [0]],
+    'esc_html_x' => ['domain' => 2, 'strings' => [0]],
+    'esc_attr__' => ['domain' => 1, 'strings' => [0]],
+    'esc_attr_e' => ['domain' => 1, 'strings' => [0]],
+    'esc_attr_x' => ['domain' => 2, 'strings' => [0]],
+];
+
+foreach ($files as $file) {
+    $src = (string) file_get_contents($file);
+    $tokens = token_get_all($src);
+    $count = count($tokens);
+    for ($i = 0; $i < $count; $i++) {
+        $t = $tokens[$i];
+        if (is_array($t) && $t[0] === T_STRING && isset($functions[$t[1]])) {
+            $call = extractCall($tokens, $i);
+            if ($call === null) {
+                continue;
+            }
+            $meta = $functions[$t[1]];
+            $args = splitArgs($call['args']);
+            $result['total_calls']++;
+            $domainIdx = $meta['domain'];
+            $domainArg = $args[$domainIdx] ?? null;
+            if ($domainArg && preg_match("/['\"]([^'\"]+)['\"]/", $domainArg, $dm)) {
+                $found = trim($dm[1]);
+                if ($expectedDomain !== '' && $found !== $expectedDomain) {
+                    $result['wrong_domain'][] = [
+                        'file' => $file,
+                        'line' => $call['line'],
+                        'found' => $found,
+                    ];
+                }
+            }
+            foreach ($meta['strings'] as $idx) {
+                $arg = $args[$idx] ?? null;
+                if ($arg && preg_match("/^['\"](.*)['\"]$/s", trim($arg), $sm)) {
+                    $str = stripcslashes($sm[1]);
+                    if (hasPlaceholderMismatch($str)) {
+                        $result['placeholder_mismatch'][] = [
+                            'file' => $file,
+                            'line' => $call['line'],
+                            'string' => $str,
+                        ];
+                    }
+                }
+            }
+        }
+    }
+}
+
+echo json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . PHP_EOL;
+exit(0);
+
+function collectPhpFiles(string $root): array
+{
+    $rii = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($root));
+    $out = [];
+    foreach ($rii as $f) {
+        if (
+            $f->isFile() &&
+            substr($f->getFilename(), -4) === '.php' &&
+            strpos($f->getPathname(), '/vendor/') === false &&
+            strpos($f->getPathname(), '/node_modules/') === false &&
+            strpos($f->getPathname(), '/tests/') === false &&
+            strpos($f->getPathname(), '/scripts/') === false
+        ) {
+            $out[] = $f->getPathname();
+        }
+    }
+    return $out;
+}
+
+function extractCall(array $tokens, int $idx): ?array
+{
+    $line = is_array($tokens[$idx]) ? $tokens[$idx][2] : 0;
+    $i = $idx + 1;
+    $count = count($tokens);
+    while ($i < $count && is_array($tokens[$i]) && $tokens[$i][0] === T_WHITESPACE) {
+        $i++;
+    }
+    if ($i >= $count || $tokens[$i] !== '(') {
+        return null;
+    }
+    $depth = 0;
+    $call = '';
+    for ($j = $i; $j < $count; $j++) {
+        $tok = $tokens[$j];
+        $call .= is_array($tok) ? $tok[1] : $tok;
+        if ($tok === '(') {
+            $depth++;
+        } elseif ($tok === ')') {
+            $depth--;
+            if ($depth === 0) {
+                break;
+            }
+        }
+    }
+    $inside = substr($call, 1, -1);
+    return ['args' => $inside, 'line' => $line];
+}
+
+function splitArgs(string $args): array
+{
+    $out = [];
+    $depth = 0;
+    $current = '';
+    $len = strlen($args);
+    for ($i = 0; $i < $len; $i++) {
+        $ch = $args[$i];
+        if ($ch === '(') {
+            $depth++;
+        } elseif ($ch === ')') {
+            $depth--;
+        } elseif ($ch === ',' && $depth === 0) {
+            $out[] = trim($current);
+            $current = '';
+            continue;
+        }
+        $current .= $ch;
+    }
+    if (trim($current) !== '') {
+        $out[] = trim($current);
+    }
+    return $out;
+}
+
+function hasPlaceholderMismatch(string $str): bool
+{
+    $count = preg_match_all('/%([0-9]+\$)?[bcdeEfFgGosuxX]/', $str, $m);
+    if ($count < 2) {
+        return false;
+    }
+    $numbers = array_filter($m[1], fn($v) => $v !== '');
+    $hasNumbered = !empty($numbers);
+    $hasUnnumbered = $count > count($numbers);
+    if ($hasNumbered && $hasUnnumbered) {
+        return true;
+    }
+    if ($hasNumbered) {
+        $nums = array_map('intval', $numbers);
+        sort($nums);
+        for ($i = 0; $i < count($nums); $i++) {
+            if ($nums[$i] !== $i + 1) {
+                return true;
+            }
+        }
+    }
+    return false;
+}

--- a/scripts/pot-diff.php
+++ b/scripts/pot-diff.php
@@ -1,0 +1,185 @@
+#!/usr/bin/env php
+<?php
+declare(strict_types=1);
+
+$root = dirname(__DIR__);
+$pluginFile = $root . '/smart-alloc.php';
+$domain = '';
+if (is_file($pluginFile)) {
+    $content = (string) file_get_contents($pluginFile);
+    if (preg_match('/Text Domain:\s*(\S+)/i', $content, $m)) {
+        $domain = trim($m[1]);
+    }
+}
+$potFile = $root . '/languages/' . $domain . '.pot';
+
+if (!is_file($potFile)) {
+    echo json_encode(['pot_missing' => true], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . PHP_EOL;
+    exit(0);
+}
+
+$sourceStrings = collectStrings($root);
+$potStrings = parsePot($potFile);
+$missing = array_values(array_diff($sourceStrings, $potStrings));
+$extraneous = array_values(array_diff($potStrings, $sourceStrings));
+$result = [
+    'source_total' => count($sourceStrings),
+    'pot_total' => count($potStrings),
+    'missing' => $missing,
+    'extraneous' => $extraneous,
+];
+
+echo json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . PHP_EOL;
+
+$dir = $root . '/artifacts/i18n';
+@mkdir($dir, 0777, true);
+$md = "# POT Diff\n\n";
+$md .= 'Source strings: ' . count($sourceStrings) . "\n";
+$md .= 'POT strings: ' . count($potStrings) . "\n";
+if ($missing) {
+    $md .= "\n## Missing\n";
+    foreach ($missing as $s) { $md .= '- ' . $s . "\n"; }
+}
+if ($extraneous) {
+    $md .= "\n## Extraneous\n";
+    foreach ($extraneous as $s) { $md .= '- ' . $s . "\n"; }
+}
+@file_put_contents($dir . '/pot-diff.md', $md);
+
+exit(0);
+
+function collectStrings(string $root): array
+{
+    $files = collectPhpFiles($root);
+    $strings = [];
+    $map = [
+        '__' => ['strings' => [0]],
+        '_e' => ['strings' => [0]],
+        '_x' => ['strings' => [0]],
+        '_ex' => ['strings' => [0]],
+        '_n' => ['strings' => [0,1]],
+        '_nx' => ['strings' => [0,1]],
+        'esc_html__' => ['strings' => [0]],
+        'esc_html_e' => ['strings' => [0]],
+        'esc_html_x' => ['strings' => [0]],
+        'esc_attr__' => ['strings' => [0]],
+        'esc_attr_e' => ['strings' => [0]],
+        'esc_attr_x' => ['strings' => [0]],
+    ];
+    foreach ($files as $file) {
+        $src = (string) file_get_contents($file);
+        $tokens = token_get_all($src);
+        $count = count($tokens);
+        for ($i = 0; $i < $count; $i++) {
+            $t = $tokens[$i];
+            if (is_array($t) && $t[0] === T_STRING && isset($map[$t[1]])) {
+                $call = extractCall($tokens, $i);
+                if ($call === null) { continue; }
+                $args = splitArgs($call['args']);
+                foreach ($map[$t[1]]['strings'] as $idx) {
+                    $arg = $args[$idx] ?? null;
+                    if ($arg && preg_match("/^['\"](.*)['\"]$/s", trim($arg), $m)) {
+                        $strings[] = stripcslashes($m[1]);
+                    }
+                }
+            }
+        }
+    }
+    return array_values(array_unique($strings));
+}
+
+function parsePot(string $file): array
+{
+    $lines = file($file) ?: [];
+    $strings = [];
+    $collect = false;
+    $current = '';
+    foreach ($lines as $line) {
+        $line = rtrim($line, "\r\n");
+        if (strpos($line, 'msgid "') === 0) {
+            $collect = true;
+            $current = stripcslashes(substr($line, 7, -1));
+            continue;
+        }
+        if ($collect) {
+            if ($line !== '' && $line[0] === '"') {
+                $current .= stripcslashes(substr($line, 1, -1));
+            } else {
+                if ($current !== '') { $strings[] = $current; }
+                $collect = false;
+                $current = '';
+            }
+        }
+    }
+    if ($collect && $current !== '') { $strings[] = $current; }
+    return array_values(array_unique($strings));
+}
+
+function collectPhpFiles(string $root): array
+{
+    $rii = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($root));
+    $out = [];
+    foreach ($rii as $f) {
+        if (
+            $f->isFile() &&
+            substr($f->getFilename(), -4) === '.php' &&
+            strpos($f->getPathname(), '/vendor/') === false &&
+            strpos($f->getPathname(), '/node_modules/') === false &&
+            strpos($f->getPathname(), '/tests/') === false &&
+            strpos($f->getPathname(), '/scripts/') === false
+        ) {
+            $out[] = $f->getPathname();
+        }
+    }
+    return $out;
+}
+
+function extractCall(array $tokens, int $idx): ?array
+{
+    $i = $idx + 1;
+    $count = count($tokens);
+    while ($i < $count && is_array($tokens[$i]) && $tokens[$i][0] === T_WHITESPACE) {
+        $i++;
+    }
+    if ($i >= $count || $tokens[$i] !== '(') {
+        return null;
+    }
+    $depth = 0;
+    $call = '';
+    for ($j = $i; $j < $count; $j++) {
+        $tok = $tokens[$j];
+        $call .= is_array($tok) ? $tok[1] : $tok;
+        if ($tok === '(') {
+            $depth++;
+        } elseif ($tok === ')') {
+            $depth--;
+            if ($depth === 0) { break; }
+        }
+    }
+    return ['args' => substr($call, 1, -1)];
+}
+
+function splitArgs(string $args): array
+{
+    $out = [];
+    $depth = 0;
+    $current = '';
+    $len = strlen($args);
+    for ($i = 0; $i < $len; $i++) {
+        $ch = $args[$i];
+        if ($ch === '(') {
+            $depth++;
+        } elseif ($ch === ')') {
+            $depth--;
+        } elseif ($ch === ',' && $depth === 0) {
+            $out[] = trim($current);
+            $current = '';
+            continue;
+        }
+        $current .= $ch;
+    }
+    if (trim($current) !== '') {
+        $out[] = trim($current);
+    }
+    return $out;
+}

--- a/scripts/wporg-assets-verify.php
+++ b/scripts/wporg-assets-verify.php
@@ -1,0 +1,55 @@
+#!/usr/bin/env php
+<?php
+declare(strict_types=1);
+
+$root = dirname(__DIR__);
+$dir = $root . '/.wordpress-org';
+$result = ['assets' => [], 'warnings' => []];
+
+if (!is_dir($dir)) {
+    echo json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . PHP_EOL;
+    exit(0);
+}
+
+$types = ['icon' => [], 'banner' => [], 'screenshot' => [], 'other' => []];
+$entries = scandir($dir) ?: [];
+foreach ($entries as $file) {
+    if ($file === '.' || $file === '..') { continue; }
+    $path = $dir . '/' . $file;
+    if (!is_file($path)) { continue; }
+    $info = ['file' => $file, 'type' => 'other', 'bytes' => filesize($path) ?: 0];
+    if (function_exists('getimagesize')) {
+        $dim = @getimagesize($path);
+        if ($dim) { $info['width'] = $dim[0]; $info['height'] = $dim[1]; }
+    }
+    if (preg_match('/^icon-/i', $file)) { $info['type'] = 'icon'; }
+    elseif (preg_match('/^banner-/i', $file)) { $info['type'] = 'banner'; }
+    elseif (preg_match('/^screenshot-/i', $file)) { $info['type'] = 'screenshot'; }
+    $result['assets'][] = $info;
+    $types[$info['type']][$file] = $info;
+    if ($info['bytes'] > 1000000) { $result['warnings'][] = $file . ' is large'; }
+}
+
+if (count($types['icon']) > 0 && count($types['icon']) < 2) { $result['warnings'][] = 'icon missing variants'; }
+if (count($types['banner']) > 0 && count($types['banner']) < 2) { $result['warnings'][] = 'banner missing variants'; }
+if (empty($types['screenshot'])) { $result['warnings'][] = 'no screenshots found'; }
+
+$table = buildTable($result['assets']);
+if ($table !== '') {
+    echo $table . PHP_EOL;
+}
+
+echo json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . PHP_EOL;
+exit(0);
+
+function buildTable(array $assets): string
+{
+    if (empty($assets)) { return ''; }
+    $out = [];
+    $out[] = str_pad('file', 30) . str_pad('bytes', 10) . 'dimensions';
+    foreach ($assets as $a) {
+        $dim = isset($a['width']) ? $a['width'] . 'x' . $a['height'] : '?';
+        $out[] = str_pad($a['file'], 30) . str_pad((string) $a['bytes'], 10) . $dim;
+    }
+    return implode(PHP_EOL, $out);
+}


### PR DESCRIPTION
## Summary
- add script to lint text domains and placeholder usage
- add POT diff helper and WP.org asset verifier
- document i18n checklist for releases

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68a6e9ae8e748321957cb6384a5e6c60