### PR TITLE
feat: add profile-aware GA Enforcer with JUnit output

### DIFF
--- a/docs/GA_REHEARSAL.md
+++ b/docs/GA_REHEARSAL.md
@@ -13,6 +13,9 @@ RUN_GA_REHEARSAL=1 vendor/bin/phpunit --filter GARehearsalSmokeTest
 RUN_ENFORCE=1 php scripts/ga-enforcer.php --enforce
 ```
 
+> **Note:** After rehearsal you may run the Enforcer with `--profile=rc` for an
+> advisory check or `RUN_ENFORCE=1 --profile=ga --enforce` for a hard gate.
+
 ## Artifact map
 
 | QA Plan stage | Artifact/Action |

--- a/docs/RELEASE_FINAL.md
+++ b/docs/RELEASE_FINAL.md
@@ -18,3 +18,7 @@ missing. Outputs map to the GA checklist:
 
 Use the generated `GA_READY.txt` to review version, date, go/no-go summary and
 signal counts before performing the final tag dry run.
+
+> **Note:** After running the finalizer you may run the Enforcer with
+> `--profile=rc` for an advisory sweep or `RUN_ENFORCE=1 --profile=ga --enforce`
+> to enable a hard gate.

--- a/scripts/.ga-enforce.ga.json
+++ b/scripts/.ga-enforce.ga.json
@@ -1,0 +1,8 @@
+{
+  "rest_permission_violations": 0,
+  "coverage_min_lines_pct": 80,
+  "pot_min_entries": 10,
+  "dist_audit_max_errors": 0,
+  "wporg_lint_max_warnings": 0,
+  "version_mismatch_fatal": false
+}

--- a/scripts/.ga-enforce.rc.json
+++ b/scripts/.ga-enforce.rc.json
@@ -1,0 +1,8 @@
+{
+  "rest_permission_violations": 1,
+  "coverage_min_lines_pct": 50,
+  "pot_min_entries": 5,
+  "dist_audit_max_errors": 2,
+  "wporg_lint_max_warnings": 5,
+  "version_mismatch_fatal": false
+}

--- a/tests/unit/Release/GAEnforcerProfilesTest.php
+++ b/tests/unit/Release/GAEnforcerProfilesTest.php
@@ -1,0 +1,105 @@
+<?php
+declare(strict_types=1);
+
+namespace SmartAlloc\Tests\Release;
+
+use PHPUnit\Framework\TestCase;
+
+class GAEnforcerProfilesTest extends TestCase
+{
+    /** @var array<string> */
+    private array $files = [];
+
+    protected function setUp(): void
+    {
+        if (getenv('RUN_ENFORCE') !== '1') {
+            $this->markTestSkipped('RUN_ENFORCE not set');
+        }
+        @mkdir('artifacts/qa', 0777, true);
+        @mkdir('artifacts/i18n', 0777, true);
+        @mkdir('artifacts/dist', 0777, true);
+        @mkdir('artifacts/coverage', 0777, true);
+        @mkdir('artifacts/ga', 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (array_reverse($this->files) as $f) {
+            if (is_file($f)) {
+                unlink($f);
+            }
+        }
+        foreach (['artifacts/ga/GA_ENFORCER.json','artifacts/ga/GA_ENFORCER.txt','artifacts/ga/GA_ENFORCER.junit.xml'] as $f) {
+            @unlink($f);
+        }
+    }
+
+    private function write(string $path, string $content): void
+    {
+        $dir = \dirname($path);
+        if (!is_dir($dir)) {
+            mkdir($dir, 0777, true);
+        }
+        file_put_contents($path, $content);
+        $this->files[] = $path;
+    }
+
+    private function execEnforcer(array $args, ?int &$exit = null): void
+    {
+        $cmd = 'php scripts/ga-enforcer.php ' . implode(' ', array_map('escapeshellarg', $args));
+        $exit = null;
+        exec($cmd, $_, $exit);
+    }
+
+    public function testRcProfilePass(): void
+    {
+        $this->write('artifacts/qa/rest-violations.json', json_encode([]));
+        $this->write('artifacts/qa/sql-violations.json', json_encode([]));
+        $this->write('artifacts/qa/secrets.json', json_encode([]));
+        $this->write('artifacts/qa/licenses.json', json_encode(['summary'=>['denied'=>0]]));
+        $this->write('artifacts/qa/qa-report.json', json_encode([]));
+        $this->write('artifacts/qa/go-no-go.json', json_encode([]));
+        $this->write('artifacts/i18n/pot-refresh.json', json_encode(['pot_entries'=>5,'domain_mismatch'=>0]));
+        $this->write('artifacts/dist/manifest.json', '{}');
+        $this->write('artifacts/dist/sbom.json', '{}');
+        $this->write('artifacts/coverage/coverage.json', json_encode(['totals'=>['lines'=>['pct'=>100]]]));
+        $this->write('artifacts/dist/dist-audit.json', json_encode(['summary'=>['violations'=>0]]));
+        $this->write('artifacts/qa/wporg-lint.json', json_encode(['readme'=>['ok'=>true,'missing_headers'=>[], 'short_description'=>true,'sections'=>[]],'assets'=>['present'=>true,'files'=>[]]]));
+
+        $code = 0;
+        $this->execEnforcer(['--profile=rc','--enforce','--junit'], $code);
+        $this->assertSame(0, $code);
+        $this->assertFileExists('artifacts/ga/GA_ENFORCER.json');
+        $this->assertFileExists('artifacts/ga/GA_ENFORCER.txt');
+        $this->assertFileExists('artifacts/ga/GA_ENFORCER.junit.xml');
+    }
+
+    public function testGaProfileRestFail(): void
+    {
+        $this->write('artifacts/qa/rest-violations.json', json_encode(['v1']));
+        $this->write('artifacts/qa/sql-violations.json', json_encode([]));
+        $this->write('artifacts/qa/secrets.json', json_encode([]));
+        $this->write('artifacts/qa/licenses.json', json_encode(['summary'=>['denied'=>0]]));
+        $this->write('artifacts/qa/qa-report.json', json_encode([]));
+        $this->write('artifacts/qa/go-no-go.json', json_encode([]));
+        $this->write('artifacts/i18n/pot-refresh.json', json_encode(['pot_entries'=>10,'domain_mismatch'=>0]));
+        $this->write('artifacts/dist/manifest.json', '{}');
+        $this->write('artifacts/dist/sbom.json', '{}');
+        $this->write('artifacts/coverage/coverage.json', json_encode(['totals'=>['lines'=>['pct'=>100]]]));
+        $this->write('artifacts/dist/dist-audit.json', json_encode(['summary'=>['violations'=>0]]));
+        $this->write('artifacts/qa/wporg-lint.json', json_encode(['readme'=>['ok'=>true,'missing_headers'=>[], 'short_description'=>true,'sections'=>[]],'assets'=>['present'=>true,'files'=>[]]]));
+
+        $code = 0;
+        $this->execEnforcer(['--profile=ga','--enforce','--junit'], $code);
+        $this->assertSame(1, $code);
+        $xml = simplexml_load_file('artifacts/ga/GA_ENFORCER.junit.xml');
+        $found = false;
+        foreach ($xml->testcase as $tc) {
+            if ((string)$tc['name'] === 'REST' && isset($tc->failure)) {
+                $found = true;
+            }
+        }
+        $this->assertTrue($found, 'REST failure not found');
+    }
+}
+

--- a/tests/unit/Release/GAEnforcerTest.php
+++ b/tests/unit/Release/GAEnforcerTest.php
@@ -61,6 +61,8 @@ class GAEnforcerTest extends TestCase
             'require_manifest' => true,
             'require_sbom' => true,
             'version_mismatch_fatal' => false,
+            'dist_audit_max_errors' => 999,
+            'wporg_lint_max_warnings' => 999,
         ]));
         $this->write('artifacts/qa/qa-report.json', json_encode([
             'coverage_percent' => 100,
@@ -71,7 +73,7 @@ class GAEnforcerTest extends TestCase
         $this->write('artifacts/qa/sql-violations.json', json_encode([]));
         $this->write('artifacts/qa/secrets.json', json_encode([]));
         $this->write('artifacts/qa/licenses.json', json_encode(['summary' => ['denied' => 0]]));
-        $this->write('artifacts/i18n/pot-refresh.json', json_encode(['pot_entries' => 1, 'domain_mismatch' => 0]));
+        $this->write('artifacts/i18n/pot-refresh.json', json_encode(['pot_entries' => 10, 'domain_mismatch' => 0]));
         $this->write('artifacts/dist/manifest.json', '{}');
         $this->write('artifacts/dist/sbom.json', '{}');
 
@@ -92,6 +94,8 @@ class GAEnforcerTest extends TestCase
             'require_manifest' => true,
             'require_sbom' => true,
             'version_mismatch_fatal' => false,
+            'dist_audit_max_errors' => 999,
+            'wporg_lint_max_warnings' => 999,
         ]));
 
         $this->write('artifacts/qa/qa-report.json', json_encode([
@@ -103,7 +107,7 @@ class GAEnforcerTest extends TestCase
         $this->write('artifacts/qa/sql-violations.json', json_encode([]));
         $this->write('artifacts/qa/secrets.json', json_encode([]));
         $this->write('artifacts/qa/licenses.json', json_encode(['summary' => ['denied' => 0]]));
-        $this->write('artifacts/i18n/pot-refresh.json', json_encode(['pot_entries' => 1, 'domain_mismatch' => 0]));
+        $this->write('artifacts/i18n/pot-refresh.json', json_encode(['pot_entries' => 10, 'domain_mismatch' => 0]));
         $this->write('artifacts/dist/manifest.json', '{}');
         $this->write('artifacts/dist/sbom.json', '{}');
 


### PR DESCRIPTION
## Summary
- extend `ga-enforcer.php` with profile loading, dynamic thresholds, and optional JUnit reporting
- add RC and GA threshold profiles
- document advisory/enforce modes, profiles, and JUnit output
- add profile-focused unit tests

## Testing
- `composer test`
- `RUN_ENFORCE=1 composer test`


------
https://chatgpt.com/codex/tasks/task_e_68a6fbc2d3008321b941ea2c37610597