### PR TITLE
feat: add advisory coverage import and schema validation

### DIFF
--- a/docs/GA_ENFORCER.md
+++ b/docs/GA_ENFORCER.md
@@ -57,6 +57,28 @@ The `--junit` flag writes `artifacts/ga/GA_ENFORCER.junit.xml` with one
 `<testcase>` per signal and a `<failure>` node when that signal exceeds its
 threshold.
 
+## Coverage Import
+
+`scripts/coverage-import.php` normalizes coverage reports. It looks for
+`artifacts/coverage/clover.xml` first and falls back to an existing
+`coverage.json`. The importer emits a deterministic
+`artifacts/coverage/coverage.json` with totals, covered lines and percentage
+and is invoked automatically by the GA Enforcer when needed.
+
+## Schema Validation (Advisory)
+
+`scripts/validate-artifacts.php` inspects optional QA artifacts for basic
+shape and presence. Any mismatches are recorded as schema warnings and are
+advisory by default. When the validator script is missing the GA Enforcer
+skips this step.
+
+## Advisory CI Example
+
+`docs/examples/ga-enforcer-advisory.yml` shows a minimal GitHub Actions job
+that installs dependencies, imports coverage and runs the GA Enforcer in
+advisory mode. Teams can copy this into their own CI when ready. The enforcer
+continues to exit `0` unless `--enforce` or `RUN_ENFORCE=1` is supplied.
+
 ## QA Plan mapping
 
 | QA Plan stage | Artifact/Signal |

--- a/docs/examples/ga-enforcer-advisory.yml
+++ b/docs/examples/ga-enforcer-advisory.yml
@@ -1,0 +1,18 @@
+# Example GA Enforcer advisory job
+# Teams can copy this into their CI when ready.
+name: GA Enforcer Advisory
+
+on: [push]
+
+jobs:
+  ga-enforcer:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: composer install --no-interaction
+      - run: php scripts/coverage-import.php
+      - run: php scripts/ga-enforcer.php --profile=rc --junit
+      - uses: actions/upload-artifact@v3
+        with:
+          name: GA_ENFORCER.junit.xml
+          path: artifacts/ga/GA_ENFORCER.junit.xml

--- a/scripts/coverage-import.php
+++ b/scripts/coverage-import.php
@@ -1,0 +1,58 @@
+#!/usr/bin/env php
+<?php
+declare(strict_types=1);
+
+if (PHP_SAPI !== 'cli') {
+    exit(0);
+}
+
+$root = dirname(__DIR__);
+$dir  = $root . '/artifacts/coverage';
+if (!is_dir($dir)) {
+    mkdir($dir, 0777, true);
+}
+$outFile = $dir . '/coverage.json';
+
+$clover   = $dir . '/clover.xml';
+$existing = $dir . '/coverage.json';
+$source   = null;
+$linesTotal = 0;
+$linesCovered = 0;
+$linesPct = null;
+
+if (is_file($clover)) {
+    $xml = @simplexml_load_file($clover);
+    if ($xml !== false && isset($xml->project->metrics['statements'], $xml->project->metrics['coveredstatements'])) {
+        $linesTotal   = (int)$xml->project->metrics['statements'];
+        $linesCovered = (int)$xml->project->metrics['coveredstatements'];
+        $linesPct     = $linesTotal > 0 ? round(($linesCovered / $linesTotal) * 100, 2) : 0.0;
+        $source       = 'clover.xml';
+    }
+} elseif (is_file($existing)) {
+    $data = json_decode((string)file_get_contents($existing), true);
+    if (is_array($data)) {
+        $linesTotal   = (int)($data['lines_total'] ?? 0);
+        $linesCovered = (int)($data['lines_covered'] ?? 0);
+        if (isset($data['lines_pct']) && $data['lines_pct'] !== null) {
+            $linesPct = (float)$data['lines_pct'];
+        } elseif ($linesTotal > 0) {
+            $linesPct = round(($linesCovered / $linesTotal) * 100, 2);
+        }
+        $source = 'coverage.json';
+    }
+}
+
+$result = [
+    'generated_at'  => gmdate('Y-m-d\TH:i:s\Z'),
+    'lines_covered' => $linesCovered,
+    'lines_pct'     => $linesPct,
+    'lines_total'   => $linesTotal,
+    'source'        => $source,
+];
+ksort($result);
+file_put_contents($outFile, json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n");
+
+$summary = 'coverage ' . ($linesPct === null ? 'null' : $linesPct . '%') . ' from ' . ($source ?? 'none');
+echo $summary . "\n";
+
+exit(0);

--- a/scripts/validate-artifacts.php
+++ b/scripts/validate-artifacts.php
@@ -1,0 +1,104 @@
+#!/usr/bin/env php
+<?php
+declare(strict_types=1);
+
+if (PHP_SAPI !== 'cli') {
+    exit(0);
+}
+
+$root = dirname(__DIR__);
+$results = [];
+
+$defs = [
+    ['artifacts/qa/qa-report.json', function ($data) {
+        if (!is_array($data)) {
+            return ['not object'];
+        }
+        foreach ($data as $k => $v) {
+            if (!is_int($v) && !is_float($v)) {
+                return [$k . ' not numeric'];
+            }
+        }
+        return [];
+    }],
+    ['artifacts/qa/go-no-go.json', function ($data) {
+        return (is_array($data) && array_key_exists('verdict', $data)) ? [] : ['missing verdict'];
+    }],
+    ['artifacts/dist/manifest.json', function ($data) {
+        if (!is_array($data)) {
+            return ['not array'];
+        }
+        foreach ($data as $i => $row) {
+            if (!is_array($row) || !isset($row['path'], $row['size'], $row['sha256']) || !is_string($row['path']) || !is_string($row['sha256']) || !is_int($row['size'])) {
+                return ['invalid entry at ' . $i];
+            }
+        }
+        return [];
+    }],
+    ['artifacts/dist/sbom.json', function ($data) {
+        if (!is_array($data)) {
+            return ['not array'];
+        }
+        foreach ($data as $i => $row) {
+            if (!is_array($row) || !isset($row['name'], $row['version']) || !is_string($row['name']) || !is_string($row['version'])) {
+                return ['invalid entry at ' . $i];
+            }
+            if (isset($row['license']) && !is_string($row['license'])) {
+                return ['invalid license at ' . $i];
+            }
+        }
+        return [];
+    }],
+    ['artifacts/i18n/pot-refresh.json', function ($data) {
+        if (!is_array($data)) {
+            return ['not object'];
+        }
+        if (!isset($data['pot_entries']) || !is_int($data['pot_entries'])) {
+            return ['pot_entries missing'];
+        }
+        if (!isset($data['domain_mismatches']) || !is_int($data['domain_mismatches'])) {
+            return ['domain_mismatches missing'];
+        }
+        return [];
+    }],
+];
+
+foreach ($defs as [$rel, $validator]) {
+    $path = $root . '/' . $rel;
+    $entry = ['file' => $rel, 'ok' => false, 'errors' => []];
+    if (!is_file($path)) {
+        $entry['errors'][] = 'missing';
+    } else {
+        $data = json_decode((string)file_get_contents($path), true);
+        if ($data === null && json_last_error() !== JSON_ERROR_NONE) {
+            $entry['errors'][] = 'parse error';
+        } else {
+            $errs = $validator($data);
+            if ($errs) {
+                $entry['errors'] = $errs;
+            } else {
+                $entry['ok'] = true;
+            }
+        }
+    }
+    ksort($entry);
+    $results[] = $entry;
+}
+
+usort($results, fn($a, $b) => strcmp($a['file'], $b['file']));
+
+$outDir = $root . '/artifacts/qa';
+if (!is_dir($outDir)) {
+    mkdir($outDir, 0777, true);
+}
+file_put_contents($outDir . '/schema-validate.json', json_encode($results, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n");
+
+$warn = 0;
+foreach ($results as $r) {
+    if (!$r['ok']) {
+        $warn++;
+    }
+}
+echo 'schema warnings: ' . $warn . "\n";
+
+exit(0);

--- a/tests/unit/Release/CoverageImportTest.php
+++ b/tests/unit/Release/CoverageImportTest.php
@@ -1,0 +1,55 @@
+<?php
+declare(strict_types=1);
+
+namespace SmartAlloc\Tests\Release;
+
+use PHPUnit\Framework\TestCase;
+
+class CoverageImportTest extends TestCase
+{
+    /** @var array<string> */
+    private array $files = [];
+
+    protected function setUp(): void
+    {
+        if (getenv('RUN_ENFORCE') !== '1') {
+            $this->markTestSkipped('RUN_ENFORCE not set');
+        }
+        @mkdir('artifacts/coverage', 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (array_reverse($this->files) as $f) {
+            if (is_file($f)) {
+                unlink($f);
+            }
+        }
+    }
+
+    private function write(string $path, string $content): void
+    {
+        $dir = \dirname($path);
+        if (!is_dir($dir)) {
+            mkdir($dir, 0777, true);
+        }
+        file_put_contents($path, $content);
+        $this->files[] = $path;
+    }
+
+    public function testCloverImport(): void
+    {
+        $xml = '<coverage><project><metrics statements="10" coveredstatements="7"/></project></coverage>';
+        $this->write('artifacts/coverage/clover.xml', $xml);
+
+        $code = 0;
+        exec('php scripts/coverage-import.php', $_, $code);
+        $this->assertSame(0, $code);
+        $this->assertFileExists('artifacts/coverage/coverage.json');
+        $data = json_decode((string)file_get_contents('artifacts/coverage/coverage.json'), true);
+        $this->assertSame(10, $data['lines_total']);
+        $this->assertSame(7, $data['lines_covered']);
+        $this->assertSame(70.0, (float)$data['lines_pct']);
+        $this->assertSame('clover.xml', $data['source']);
+    }
+}

--- a/tests/unit/Release/GAEnforcerCoverageTest.php
+++ b/tests/unit/Release/GAEnforcerCoverageTest.php
@@ -1,0 +1,110 @@
+<?php
+declare(strict_types=1);
+
+namespace SmartAlloc\Tests\Release;
+
+use PHPUnit\Framework\TestCase;
+
+class GAEnforcerCoverageTest extends TestCase
+{
+    /** @var array<string> */
+    private array $files = [];
+
+    protected function setUp(): void
+    {
+        if (getenv('RUN_ENFORCE') !== '1') {
+            $this->markTestSkipped('RUN_ENFORCE not set');
+        }
+        @mkdir('artifacts/qa', 0777, true);
+        @mkdir('artifacts/i18n', 0777, true);
+        @mkdir('artifacts/dist', 0777, true);
+        @mkdir('artifacts/coverage', 0777, true);
+        @mkdir('artifacts/ga', 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (array_reverse($this->files) as $f) {
+            if (is_file($f)) {
+                unlink($f);
+            }
+        }
+        foreach (['artifacts/ga/GA_ENFORCER.json','artifacts/ga/GA_ENFORCER.txt','artifacts/ga/GA_ENFORCER.junit.xml'] as $f) {
+            @unlink($f);
+        }
+    }
+
+    private function write(string $path, string $content): void
+    {
+        $dir = \dirname($path);
+        if (!is_dir($dir)) {
+            mkdir($dir, 0777, true);
+        }
+        file_put_contents($path, $content);
+        $this->files[] = $path;
+    }
+
+    private function execEnforcer(array $args, ?int &$exit = null): void
+    {
+        $cmd = 'php scripts/ga-enforcer.php ' . implode(' ', array_map('escapeshellarg', $args));
+        $exit = null;
+        exec($cmd, $_, $exit);
+    }
+
+    private function writeCommonArtifacts(): void
+    {
+        $this->write('artifacts/qa/rest-violations.json', json_encode([]));
+        $this->write('artifacts/qa/sql-violations.json', json_encode([]));
+        $this->write('artifacts/qa/secrets.json', json_encode([]));
+        $this->write('artifacts/qa/licenses.json', json_encode(['summary'=>['denied'=>0]]));
+        $this->write('artifacts/qa/qa-report.json', json_encode([]));
+        $this->write('artifacts/qa/go-no-go.json', json_encode(['verdict'=>'go']));
+        $this->write('artifacts/i18n/pot-refresh.json', json_encode(['pot_entries'=>10,'domain_mismatches'=>0]));
+        $this->write('artifacts/dist/manifest.json', json_encode([['path'=>'a','size'=>1,'sha256'=>'x']]));
+        $this->write('artifacts/dist/sbom.json', json_encode([['name'=>'a','version'=>'1']]));
+        $this->write('artifacts/dist/dist-audit.json', json_encode(['summary'=>['violations'=>0]]));
+        $this->write('artifacts/qa/wporg-lint.json', json_encode([
+            'readme'=>['missing'=>false,'missing_headers'=>[],'short_description'=>true,'sections'=>[]],
+            'assets'=>['present'=>true,'files'=>[]]
+        ]));
+    }
+
+    public function testCoveragePass(): void
+    {
+        $this->writeCommonArtifacts();
+        $this->write('artifacts/coverage/coverage.json', json_encode([
+            'lines_total'=>10,
+            'lines_covered'=>6,
+            'lines_pct'=>60,
+            'source'=>'unit'
+        ]));
+
+        $code = 0;
+        $this->execEnforcer(['--profile=rc','--enforce','--junit'], $code);
+        $this->assertSame(0, $code);
+        $this->assertFileExists('artifacts/ga/GA_ENFORCER.junit.xml');
+    }
+
+    public function testCoverageFail(): void
+    {
+        $this->writeCommonArtifacts();
+        $this->write('artifacts/coverage/coverage.json', json_encode([
+            'lines_total'=>10,
+            'lines_covered'=>5,
+            'lines_pct'=>50,
+            'source'=>'unit'
+        ]));
+
+        $code = 0;
+        $this->execEnforcer(['--profile=ga','--enforce','--junit'], $code);
+        $this->assertSame(1, $code);
+        $xml = simplexml_load_file('artifacts/ga/GA_ENFORCER.junit.xml');
+        $found = false;
+        foreach ($xml->testcase as $tc) {
+            if ((string)$tc['name'] === 'Coverage' && isset($tc->failure)) {
+                $found = true;
+            }
+        }
+        $this->assertTrue($found, 'Coverage failure not found');
+    }
+}


### PR DESCRIPTION
## Summary
- add `scripts/coverage-import.php` to normalize clover or existing coverage and emit deterministic `coverage.json`
- add `scripts/validate-artifacts.php` to advisory-check common artifact shapes
- integrate importer and validator into GA Enforcer with schema warnings and JUnit test case
- document coverage import, schema validation, and provide an advisory CI YAML example
- add opt-in unit tests for coverage import and coverage enforcement

## Testing
- `composer test`
- `RUN_ENFORCE=1 vendor/bin/phpunit tests/unit/Release/CoverageImportTest.php tests/unit/Release/GAEnforcerCoverageTest.php`
- `php scripts/coverage-import.php`
- `php scripts/ga-enforcer.php --profile=rc --junit`
- `RUN_ENFORCE=1 php scripts/ga-enforcer.php --profile=ga --enforce --junit`

------
https://chatgpt.com/codex/tasks/task_e_68a6ff94a8f08321b98122c08682f4fe