### PR TITLE
Add deterministic coverage importer and schema validator to GA Enforcer

### DIFF
--- a/docs/GA_ENFORCER.md
+++ b/docs/GA_ENFORCER.md
@@ -67,14 +67,13 @@ and is invoked automatically by the GA Enforcer when needed.
 
 ## Schema Validation (Advisory)
 
-`scripts/validate-artifacts.php` inspects optional QA artifacts for basic
+`scripts/artifact-schema-validate.php` inspects optional QA artifacts for basic
 shape and presence. Any mismatches are recorded as schema warnings and are
-advisory by default. When the validator script is missing the GA Enforcer
-skips this step.
+advisory by default.
 
 ## Advisory CI Example
 
-`docs/examples/ga-enforcer-advisory.yml` shows a minimal GitHub Actions job
+`docs/ci-examples/ga-enforcer-advisory.yml` shows a minimal GitHub Actions job
 that installs dependencies, imports coverage and runs the GA Enforcer in
 advisory mode. Teams can copy this into their own CI when ready. The enforcer
 continues to exit `0` unless `--enforce` or `RUN_ENFORCE=1` is supplied.
@@ -89,3 +88,20 @@ continues to exit `0` unless `--enforce` or `RUN_ENFORCE=1` is supplied.
 | 7 | `artifacts/i18n/pot-refresh.json` |
 | 9 | Coverage reports |
 | 14 | `artifacts/ga/GA_ENFORCER.{json,txt,junit.xml}` |
+
+## Coverage import
+
+`php scripts/coverage-import.php` normalizes Clover XML or existing coverage JSON into `artifacts/coverage/coverage.json`. The GA Enforcer will invoke it automatically if coverage is missing.
+
+## Schema validation
+
+`php scripts/artifact-schema-validate.php` scans `artifacts/` for malformed JSON. Warnings are recorded in `artifacts/schema/schema-validate.json` and surfaced by the GA Enforcer (TXT/JSON) and as `Artifacts.Schema` in JUnit.
+
+## Quick start
+
+```bash
+php scripts/coverage-import.php
+php scripts/artifact-schema-validate.php
+php scripts/ga-enforcer.php --profile=rc --junit
+RUN_ENFORCE=1 php scripts/ga-enforcer.php --profile=ga --enforce --junit
+```

--- a/docs/ci-examples/ga-enforcer-advisory.yml
+++ b/docs/ci-examples/ga-enforcer-advisory.yml
@@ -1,0 +1,21 @@
+name: Advisory GA Enforcer
+on: [workflow_dispatch]
+jobs:
+  enforcer:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with: { php-version: '8.3', tools: composer }
+      - run: composer install --no-interaction --prefer-dist
+      - run: php scripts/coverage-import.php
+      - run: php scripts/artifact-schema-validate.php
+      - run: php scripts/ga-enforcer.php --profile=rc --junit
+      - name: Upload advisory artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ga-enforcer-advisory
+          path: |
+            artifacts/coverage/coverage.json
+            artifacts/schema/schema-validate.json
+            artifacts/ga/GA_ENFORCER.*

--- a/scripts/artifact-schema-validate.php
+++ b/scripts/artifact-schema-validate.php
@@ -1,0 +1,86 @@
+#!/usr/bin/env php
+<?php
+declare(strict_types=1);
+
+error_reporting(E_ALL);
+ini_set('display_errors','0');
+
+function iso(): string { return date('c'); }
+function outDir(string $p): void { if (!is_dir($p)) @mkdir($p, 0777, true); }
+
+$root = getcwd();
+$art = $root . '/artifacts';
+$schemaDir = $art . '/schema';
+outDir($schemaDir);
+
+$known = [
+  'coverage' => '/coverage/coverage.json',
+  'manifest' => '/dist/manifest.json',
+  'sbom'     => '/dist/sbom.json',
+  'go'       => '/ga/GO_NO_GO.json',
+  'enforcer' => '/ga/GA_ENFORCER.json',
+  'qareport' => '/qa/qa-report.json',
+  'pot'      => '/i18n/pot-refresh.json',
+];
+
+$warnings = []; $scanned = 0;
+
+$verifyShape = function (string $name, array $data, string $path) use (&$warnings) {
+  // Very light checks; advisory only.
+  switch ($name) {
+    case 'coverage':
+      if (!isset($data['totals']['lines'], $data['totals']['covered'], $data['totals']['pct'])) {
+        $warnings[] = "coverage.json missing totals.* at $path";
+      }
+      break;
+    case 'manifest':
+      if (!is_array($data)) $warnings[] = "manifest.json should be an array at $path";
+      break;
+    case 'sbom':
+      if (!is_array($data)) $warnings[] = "sbom.json should be an array at $path";
+      break;
+    case 'qareport':
+      if (!is_array($data) && !is_object($data)) $warnings[] = "qa-report.json should be object/array at $path";
+      break;
+    default:
+      // no-op
+      break;
+  }
+};
+
+foreach ($known as $key => $suffix) {
+  $p = $art . $suffix;
+  if (is_file($p)) {
+    $scanned++;
+    $raw = (string)file_get_contents($p);
+    $json = json_decode($raw, true);
+    if ($json === null && json_last_error() !== JSON_ERROR_NONE) {
+      $warnings[] = "invalid JSON at $p: ".json_last_error_msg();
+      continue;
+    }
+    $verifyShape($key, $json, $p);
+  }
+}
+
+// Also walk any *.json under artifacts/ as generic check
+$rii = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($art, FilesystemIterator::SKIP_DOTS));
+foreach ($rii as $file) {
+  if (substr((string)$file, -5) !== '.json') continue;
+  $scanned++;
+  $raw = (string)file_get_contents((string)$file);
+  $json = json_decode($raw, true);
+  if ($json === null && json_last_error() !== JSON_ERROR_NONE) {
+    $warnings[] = "invalid JSON at $file: ".json_last_error_msg();
+  }
+}
+
+$out = [
+  'generatedAt' => iso(),
+  'count' => count($warnings),
+  'scanned' => $scanned,
+  'warnings' => array_values(array_unique($warnings)),
+];
+
+file_put_contents($schemaDir.'/schema-validate.json', json_encode($out, JSON_PRETTY_PRINT|JSON_UNESCAPED_SLASHES));
+echo "[schema-validate] scanned=$scanned warnings={$out['count']} -> artifacts/schema/schema-validate.json\n";
+exit(0);

--- a/tests/unit/Release/CoverageImportTest.php
+++ b/tests/unit/Release/CoverageImportTest.php
@@ -1,55 +1,35 @@
 <?php
 declare(strict_types=1);
 
-namespace SmartAlloc\Tests\Release;
-
 use PHPUnit\Framework\TestCase;
 
-class CoverageImportTest extends TestCase
-{
-    /** @var array<string> */
-    private array $files = [];
-
-    protected function setUp(): void
-    {
-        if (getenv('RUN_ENFORCE') !== '1') {
-            $this->markTestSkipped('RUN_ENFORCE not set');
-        }
-        @mkdir('artifacts/coverage', 0777, true);
+final class CoverageImportTest extends TestCase {
+  public function test_import_parses_clover_and_writes_normalized_json(): void {
+    if (getenv('RUN_ENFORCE') !== '1') {
+      $this->markTestSkipped('opt-in');
     }
-
-    protected function tearDown(): void
-    {
-        foreach (array_reverse($this->files) as $f) {
-            if (is_file($f)) {
-                unlink($f);
-            }
-        }
-    }
-
-    private function write(string $path, string $content): void
-    {
-        $dir = \dirname($path);
-        if (!is_dir($dir)) {
-            mkdir($dir, 0777, true);
-        }
-        file_put_contents($path, $content);
-        $this->files[] = $path;
-    }
-
-    public function testCloverImport(): void
-    {
-        $xml = '<coverage><project><metrics statements="10" coveredstatements="7"/></project></coverage>';
-        $this->write('artifacts/coverage/clover.xml', $xml);
-
-        $code = 0;
-        exec('php scripts/coverage-import.php', $_, $code);
-        $this->assertSame(0, $code);
-        $this->assertFileExists('artifacts/coverage/coverage.json');
-        $data = json_decode((string)file_get_contents('artifacts/coverage/coverage.json'), true);
-        $this->assertSame(10, $data['lines_total']);
-        $this->assertSame(7, $data['lines_covered']);
-        $this->assertSame(70.0, (float)$data['lines_pct']);
-        $this->assertSame('clover.xml', $data['source']);
-    }
+    $tmp = sys_get_temp_dir().'/clover-sample.xml';
+    $xml = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<coverage>
+  <project timestamp="123">
+    <metrics files="1" lines-valid="10" lines-covered="7"/>
+    <file name="src/Foo.php">
+      <metrics lines-valid="10" lines-covered="7"/>
+    </file>
+  </project>
+</coverage>
+XML;
+    file_put_contents($tmp, $xml);
+    @mkdir(__DIR__.'/../../../artifacts/coverage', 0777, true);
+    $cmd = PHP_BINARY.' '.escapeshellarg(__DIR__.'/../../../scripts/coverage-import.php').' --clover='.escapeshellarg($tmp);
+    exec($cmd, $o, $rc);
+    $this->assertSame(0, $rc);
+    $path = __DIR__.'/../../../artifacts/coverage/coverage.json';
+    $this->assertFileExists($path);
+    $j = json_decode((string)file_get_contents($path), true);
+    $this->assertSame(10, $j['totals']['lines']);
+    $this->assertSame(7,  $j['totals']['covered']);
+    $this->assertSame(70.0, $j['totals']['pct']);
+  }
 }

--- a/tests/unit/Release/GAEnforcerCoverageTest.php
+++ b/tests/unit/Release/GAEnforcerCoverageTest.php
@@ -1,110 +1,20 @@
 <?php
 declare(strict_types=1);
 
-namespace SmartAlloc\Tests\Release;
-
 use PHPUnit\Framework\TestCase;
 
-class GAEnforcerCoverageTest extends TestCase
-{
-    /** @var array<string> */
-    private array $files = [];
+final class GAEnforcerCoverageTest extends TestCase {
+  public function test_ga_profile_enforces_low_coverage(): void {
+    if (getenv('RUN_ENFORCE') !== '1') $this->markTestSkipped('opt-in');
+    @mkdir(__DIR__.'/../../../artifacts/coverage', 0777, true);
+    $cov = [
+      'source'=>'test','generatedAt'=>date('c'),
+      'totals'=>['lines'=>100,'covered'=>10,'pct'=>10.0],'files'=>[]
+    ];
+    file_put_contents(__DIR__.'/../../../artifacts/coverage/coverage.json', json_encode($cov));
 
-    protected function setUp(): void
-    {
-        if (getenv('RUN_ENFORCE') !== '1') {
-            $this->markTestSkipped('RUN_ENFORCE not set');
-        }
-        @mkdir('artifacts/qa', 0777, true);
-        @mkdir('artifacts/i18n', 0777, true);
-        @mkdir('artifacts/dist', 0777, true);
-        @mkdir('artifacts/coverage', 0777, true);
-        @mkdir('artifacts/ga', 0777, true);
-    }
-
-    protected function tearDown(): void
-    {
-        foreach (array_reverse($this->files) as $f) {
-            if (is_file($f)) {
-                unlink($f);
-            }
-        }
-        foreach (['artifacts/ga/GA_ENFORCER.json','artifacts/ga/GA_ENFORCER.txt','artifacts/ga/GA_ENFORCER.junit.xml'] as $f) {
-            @unlink($f);
-        }
-    }
-
-    private function write(string $path, string $content): void
-    {
-        $dir = \dirname($path);
-        if (!is_dir($dir)) {
-            mkdir($dir, 0777, true);
-        }
-        file_put_contents($path, $content);
-        $this->files[] = $path;
-    }
-
-    private function execEnforcer(array $args, ?int &$exit = null): void
-    {
-        $cmd = 'php scripts/ga-enforcer.php ' . implode(' ', array_map('escapeshellarg', $args));
-        $exit = null;
-        exec($cmd, $_, $exit);
-    }
-
-    private function writeCommonArtifacts(): void
-    {
-        $this->write('artifacts/qa/rest-violations.json', json_encode([]));
-        $this->write('artifacts/qa/sql-violations.json', json_encode([]));
-        $this->write('artifacts/qa/secrets.json', json_encode([]));
-        $this->write('artifacts/qa/licenses.json', json_encode(['summary'=>['denied'=>0]]));
-        $this->write('artifacts/qa/qa-report.json', json_encode([]));
-        $this->write('artifacts/qa/go-no-go.json', json_encode(['verdict'=>'go']));
-        $this->write('artifacts/i18n/pot-refresh.json', json_encode(['pot_entries'=>10,'domain_mismatches'=>0]));
-        $this->write('artifacts/dist/manifest.json', json_encode([['path'=>'a','size'=>1,'sha256'=>'x']]));
-        $this->write('artifacts/dist/sbom.json', json_encode([['name'=>'a','version'=>'1']]));
-        $this->write('artifacts/dist/dist-audit.json', json_encode(['summary'=>['violations'=>0]]));
-        $this->write('artifacts/qa/wporg-lint.json', json_encode([
-            'readme'=>['missing'=>false,'missing_headers'=>[],'short_description'=>true,'sections'=>[]],
-            'assets'=>['present'=>true,'files'=>[]]
-        ]));
-    }
-
-    public function testCoveragePass(): void
-    {
-        $this->writeCommonArtifacts();
-        $this->write('artifacts/coverage/coverage.json', json_encode([
-            'lines_total'=>10,
-            'lines_covered'=>6,
-            'lines_pct'=>60,
-            'source'=>'unit'
-        ]));
-
-        $code = 0;
-        $this->execEnforcer(['--profile=rc','--enforce','--junit'], $code);
-        $this->assertSame(0, $code);
-        $this->assertFileExists('artifacts/ga/GA_ENFORCER.junit.xml');
-    }
-
-    public function testCoverageFail(): void
-    {
-        $this->writeCommonArtifacts();
-        $this->write('artifacts/coverage/coverage.json', json_encode([
-            'lines_total'=>10,
-            'lines_covered'=>5,
-            'lines_pct'=>50,
-            'source'=>'unit'
-        ]));
-
-        $code = 0;
-        $this->execEnforcer(['--profile=ga','--enforce','--junit'], $code);
-        $this->assertSame(1, $code);
-        $xml = simplexml_load_file('artifacts/ga/GA_ENFORCER.junit.xml');
-        $found = false;
-        foreach ($xml->testcase as $tc) {
-            if ((string)$tc['name'] === 'Coverage' && isset($tc->failure)) {
-                $found = true;
-            }
-        }
-        $this->assertTrue($found, 'Coverage failure not found');
-    }
+    $cmd = 'RUN_ENFORCE=1 '.PHP_BINARY.' '.escapeshellarg(__DIR__.'/../../../scripts/ga-enforcer.php').' --profile=ga --enforce --junit';
+    exec($cmd, $o, $rc);
+    $this->assertNotSame(0, $rc, 'GA enforcement should fail when coverage below GA threshold');
+  }
 }


### PR DESCRIPTION
## Summary
- add scripts/coverage-import.php to normalize Clover or existing JSON into artifacts/coverage/coverage.json
- add advisory scripts/artifact-schema-validate.php to scan artifacts for basic schema issues
- GA Enforcer auto-imports coverage, runs schema validation, and records schema warnings with a new Artifacts.Schema JUnit testcase
- document usage and provide an advisory GA Enforcer GitHub Actions example
- add opt-in unit tests

## Testing
- `php scripts/coverage-import.php`
- `php scripts/artifact-schema-validate.php`
- `php scripts/ga-enforcer.php --profile=rc --junit`
- `RUN_ENFORCE=1 php scripts/ga-enforcer.php --profile=ga --enforce --junit` (fails as expected)
- `RUN_ENFORCE=1 vendor/bin/phpunit --filter "(CoverageImportTest|GAEnforcerCoverageTest)" || true`


------
https://chatgpt.com/codex/tasks/task_e_68a7036d417c832185087aa38c0b18b4