### PR TITLE
Add coverage import and schema validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,8 @@ artifacts/qa/
 artifacts/i18n/
 artifacts/e2e/rtl/
 artifacts/wporg/
+artifacts/coverage/
+artifacts/schema/
 artifacts/ga/
 *.lhreport.html
 # allow committed artifact templates

--- a/scripts/.ga-enforce.ga.json
+++ b/scripts/.ga-enforce.ga.json
@@ -1,6 +1,7 @@
 {
   "rest_permission_violations": 0,
-  "coverage_min_lines_pct": 80,
+  "coverage_pct_min": 85,
+  "schema_warnings": 0,
   "pot_min_entries": 10,
   "dist_audit_max_errors": 0,
   "wporg_lint_max_warnings": 0,

--- a/scripts/.ga-enforce.json
+++ b/scripts/.ga-enforce.json
@@ -4,7 +4,8 @@
   "secrets_findings": 0,
   "license_denied": 0,
   "i18n_domain_mismatches": 0,
-  "coverage_min_lines_pct": 0,
+  "coverage_pct_min": 0,
+  "schema_warnings": 0,
   "require_manifest": true,
   "require_sbom": true,
   "version_mismatch_fatal": true

--- a/scripts/.ga-enforce.rc.json
+++ b/scripts/.ga-enforce.rc.json
@@ -1,6 +1,7 @@
 {
   "rest_permission_violations": 1,
-  "coverage_min_lines_pct": 50,
+  "coverage_pct_min": 70,
+  "schema_warnings": 0,
   "pot_min_entries": 5,
   "dist_audit_max_errors": 2,
   "wporg_lint_max_warnings": 5,

--- a/scripts/artifact-schema-validate.php
+++ b/scripts/artifact-schema-validate.php
@@ -2,85 +2,86 @@
 <?php
 declare(strict_types=1);
 
-error_reporting(E_ALL);
-ini_set('display_errors','0');
-
-function iso(): string { return date('c'); }
-function outDir(string $p): void { if (!is_dir($p)) @mkdir($p, 0777, true); }
-
-$root = getcwd();
-$art = $root . '/artifacts';
-$schemaDir = $art . '/schema';
-outDir($schemaDir);
-
-$known = [
-  'coverage' => '/coverage/coverage.json',
-  'manifest' => '/dist/manifest.json',
-  'sbom'     => '/dist/sbom.json',
-  'go'       => '/ga/GO_NO_GO.json',
-  'enforcer' => '/ga/GA_ENFORCER.json',
-  'qareport' => '/qa/qa-report.json',
-  'pot'      => '/i18n/pot-refresh.json',
-];
-
-$warnings = []; $scanned = 0;
-
-$verifyShape = function (string $name, array $data, string $path) use (&$warnings) {
-  // Very light checks; advisory only.
-  switch ($name) {
-    case 'coverage':
-      if (!isset($data['totals']['lines'], $data['totals']['covered'], $data['totals']['pct'])) {
-        $warnings[] = "coverage.json missing totals.* at $path";
-      }
-      break;
-    case 'manifest':
-      if (!is_array($data)) $warnings[] = "manifest.json should be an array at $path";
-      break;
-    case 'sbom':
-      if (!is_array($data)) $warnings[] = "sbom.json should be an array at $path";
-      break;
-    case 'qareport':
-      if (!is_array($data) && !is_object($data)) $warnings[] = "qa-report.json should be object/array at $path";
-      break;
-    default:
-      // no-op
-      break;
-  }
-};
-
-foreach ($known as $key => $suffix) {
-  $p = $art . $suffix;
-  if (is_file($p)) {
-    $scanned++;
-    $raw = (string)file_get_contents($p);
-    $json = json_decode($raw, true);
-    if ($json === null && json_last_error() !== JSON_ERROR_NONE) {
-      $warnings[] = "invalid JSON at $p: ".json_last_error_msg();
-      continue;
-    }
-    $verifyShape($key, $json, $p);
-  }
+if (PHP_SAPI !== 'cli') {
+    echo "CLI only\n";
+    exit(0);
 }
 
-// Also walk any *.json under artifacts/ as generic check
-$rii = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($art, FilesystemIterator::SKIP_DOTS));
-foreach ($rii as $file) {
-  if (substr((string)$file, -5) !== '.json') continue;
-  $scanned++;
-  $raw = (string)file_get_contents((string)$file);
-  $json = json_decode($raw, true);
-  if ($json === null && json_last_error() !== JSON_ERROR_NONE) {
-    $warnings[] = "invalid JSON at $file: ".json_last_error_msg();
-  }
+error_reporting(E_ALL);
+ini_set('display_errors', '0');
+
+function ensure_dir(string $dir): void
+{
+    if (!is_dir($dir)) {
+        @mkdir($dir, 0777, true);
+    }
+}
+
+function iso(): string
+{
+    return date('c');
+}
+
+$root = dirname(__DIR__);
+$artifacts = $root . '/artifacts';
+$schemaDir = $artifacts . '/schema';
+ensure_dir($schemaDir);
+
+$items = [];
+
+$paths = [];
+$cov = $artifacts . '/coverage/coverage.json';
+if (is_file($cov)) {
+    $paths[] = $cov;
+}
+foreach (['qa', 'dist', 'i18n'] as $dir) {
+    foreach (glob($artifacts . '/' . $dir . '/*.json') ?: [] as $f) {
+        $paths[] = $f;
+    }
+}
+
+foreach ($paths as $p) {
+    $raw = (string)file_get_contents($p);
+    $data = json_decode($raw, true);
+    if ($data === null && json_last_error() !== JSON_ERROR_NONE) {
+        $items[] = ['path' => substr($p, strlen($root) + 1), 'issue' => 'Invalid JSON'];
+        continue;
+    }
+    $base = basename($p);
+    switch ($base) {
+        case 'coverage.json':
+            if (!isset($data['totals']['pct'])) {
+                $items[] = ['path' => substr($p, strlen($root) + 1), 'issue' => 'Missing field', 'field' => 'totals.pct'];
+            }
+            break;
+        case 'manifest.json':
+            if (empty($data['entries']) || !is_array($data['entries'])) {
+                $items[] = ['path' => substr($p, strlen($root) + 1), 'issue' => 'Missing field', 'field' => 'entries'];
+            }
+            break;
+        case 'sbom.json':
+            if (empty($data['packages']) || !is_array($data['packages'])) {
+                $items[] = ['path' => substr($p, strlen($root) + 1), 'issue' => 'Missing field', 'field' => 'packages'];
+            }
+            break;
+        case 'go-no-go.json':
+            if (!isset($data['verdict'])) {
+                $items[] = ['path' => substr($p, strlen($root) + 1), 'issue' => 'Missing field', 'field' => 'verdict'];
+            }
+            break;
+        default:
+            // no-op
+            break;
+    }
 }
 
 $out = [
-  'generatedAt' => iso(),
-  'count' => count($warnings),
-  'scanned' => $scanned,
-  'warnings' => array_values(array_unique($warnings)),
+    'generated_at' => iso(),
+    'warnings' => count($items),
+    'items' => $items,
 ];
 
-file_put_contents($schemaDir.'/schema-validate.json', json_encode($out, JSON_PRETTY_PRINT|JSON_UNESCAPED_SLASHES));
-echo "[schema-validate] scanned=$scanned warnings={$out['count']} -> artifacts/schema/schema-validate.json\n";
+file_put_contents($schemaDir . '/schema-validate.json', json_encode($out, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n");
+echo '[schema-validate] warnings=' . $out['warnings'] . "\n";
 exit(0);
+

--- a/tests/fixtures/clover/minimal-clover.xml
+++ b/tests/fixtures/clover/minimal-clover.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<coverage>
+  <project>
+    <file name="src/B.php">
+      <metrics lines-valid="3" lines-covered="1"/>
+    </file>
+    <file name="src/A.php">
+      <metrics lines-valid="4" lines-covered="3"/>
+    </file>
+  </project>
+</coverage>

--- a/tests/unit/Release/CoverageImportTest.php
+++ b/tests/unit/Release/CoverageImportTest.php
@@ -3,33 +3,31 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
-final class CoverageImportTest extends TestCase {
-  public function test_import_parses_clover_and_writes_normalized_json(): void {
-    if (getenv('RUN_ENFORCE') !== '1') {
-      $this->markTestSkipped('opt-in');
+final class CoverageImportTest extends TestCase
+{
+    public function test_import_normalizes_clover_fixture(): void
+    {
+        if (getenv('RUN_ENFORCE') !== '1') {
+            $this->markTestSkipped('opt-in');
+        }
+
+        @mkdir(__DIR__ . '/../../../artifacts/coverage', 0777, true);
+        $fixture = __DIR__ . '/../../fixtures/clover/minimal-clover.xml';
+        putenv('COVERAGE_INPUT=' . $fixture);
+        $cmd = PHP_BINARY . ' ' . escapeshellarg(__DIR__ . '/../../../scripts/coverage-import.php');
+        exec($cmd, $o, $rc);
+        $this->assertSame(0, $rc);
+
+        $path = __DIR__ . '/../../../artifacts/coverage/coverage.json';
+        $this->assertFileExists($path);
+        $j = json_decode((string)file_get_contents($path), true);
+        $this->assertSame('clover', $j['source']);
+        $this->assertSame(7, $j['totals']['lines_total']);
+        $this->assertSame(4, $j['totals']['lines_covered']);
+        $this->assertSame(57.14, $j['totals']['pct']);
+        $this->assertSame('src/A.php', $j['files'][0]['path']);
+        $this->assertSame('src/B.php', $j['files'][1]['path']);
+        $this->assertSame(33.33, $j['files'][1]['pct']);
     }
-    $tmp = sys_get_temp_dir().'/clover-sample.xml';
-    $xml = <<<XML
-<?xml version="1.0" encoding="UTF-8"?>
-<coverage>
-  <project timestamp="123">
-    <metrics files="1" lines-valid="10" lines-covered="7"/>
-    <file name="src/Foo.php">
-      <metrics lines-valid="10" lines-covered="7"/>
-    </file>
-  </project>
-</coverage>
-XML;
-    file_put_contents($tmp, $xml);
-    @mkdir(__DIR__.'/../../../artifacts/coverage', 0777, true);
-    $cmd = PHP_BINARY.' '.escapeshellarg(__DIR__.'/../../../scripts/coverage-import.php').' --clover='.escapeshellarg($tmp);
-    exec($cmd, $o, $rc);
-    $this->assertSame(0, $rc);
-    $path = __DIR__.'/../../../artifacts/coverage/coverage.json';
-    $this->assertFileExists($path);
-    $j = json_decode((string)file_get_contents($path), true);
-    $this->assertSame(10, $j['totals']['lines']);
-    $this->assertSame(7,  $j['totals']['covered']);
-    $this->assertSame(70.0, $j['totals']['pct']);
-  }
 }
+

--- a/tests/unit/Release/GAEnforcerCoverageTest.php
+++ b/tests/unit/Release/GAEnforcerCoverageTest.php
@@ -3,18 +3,28 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
-final class GAEnforcerCoverageTest extends TestCase {
-  public function test_ga_profile_enforces_low_coverage(): void {
-    if (getenv('RUN_ENFORCE') !== '1') $this->markTestSkipped('opt-in');
-    @mkdir(__DIR__.'/../../../artifacts/coverage', 0777, true);
-    $cov = [
-      'source'=>'test','generatedAt'=>date('c'),
-      'totals'=>['lines'=>100,'covered'=>10,'pct'=>10.0],'files'=>[]
-    ];
-    file_put_contents(__DIR__.'/../../../artifacts/coverage/coverage.json', json_encode($cov));
+final class GAEnforcerCoverageTest extends TestCase
+{
+    public function test_ga_profile_enforces_low_coverage(): void
+    {
+        if (getenv('RUN_ENFORCE') !== '1') {
+            $this->markTestSkipped('opt-in');
+        }
 
-    $cmd = 'RUN_ENFORCE=1 '.PHP_BINARY.' '.escapeshellarg(__DIR__.'/../../../scripts/ga-enforcer.php').' --profile=ga --enforce --junit';
-    exec($cmd, $o, $rc);
-    $this->assertNotSame(0, $rc, 'GA enforcement should fail when coverage below GA threshold');
-  }
+        @mkdir(__DIR__ . '/../../../artifacts/coverage', 0777, true);
+        $cov = [
+            'source' => 'json',
+            'generated_at' => date('c'),
+            'totals' => ['lines_total' => 100, 'lines_covered' => 10, 'pct' => 10.0],
+            'files' => [],
+        ];
+        file_put_contents(__DIR__ . '/../../../artifacts/coverage/coverage.json', json_encode($cov));
+
+        $cmd = 'RUN_ENFORCE=1 ' . PHP_BINARY . ' ' .
+            escapeshellarg(__DIR__ . '/../../../scripts/ga-enforcer.php') .
+            ' --profile=ga --enforce --junit';
+        exec($cmd, $o, $rc);
+        $this->assertNotSame(0, $rc, 'GA enforcement should fail when coverage below GA threshold');
+    }
 }
+


### PR DESCRIPTION
## Summary
- normalize coverage inputs from Clover XML or JSON
- add advisory artifact schema validator
- enforce coverage and schema thresholds via GA Enforcer

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_68a7076679b08321b72bc3e30d5bc712