### PR TITLE
chore: add advisory QA workflows and templates

### DIFF
--- a/.ai-conventions.md
+++ b/.ai-conventions.md
@@ -1,0 +1,24 @@
+# 🤖 AI Development Conventions (SmartAlloc)
+
+**Before proposing code**, the LLM must consider QA, i18n/RTL, security, and release impact.
+
+- If you touch translation calls (`__`, `_e`, `_x`, etc.):
+  - Run `php scripts/pot-refresh.php` post-change.
+  - Ensure text-domain is `smartalloc`.
+
+- If UI changes (admin screen, Gutenberg, front-end):
+  - Recommend RTL/E2E snapshot: `E2E=1 E2E_RTL=1 npx playwright test tests/e2e/rtl-snapshot.spec.ts`.
+
+- If REST/SQL/permissions change:
+  - Recommend running security scanners and GA Enforcer (`--profile=rc` advisory; `--profile=ga --enforce` for gates).
+
+Always append **post-change commands** in your answer:
+```bash
+php scripts/coverage-import.php
+php scripts/artifact-schema-validate.php
+php scripts/ga-enforcer.php --profile=rc --junit
+# If UI changed:
+E2E=1 E2E_RTL=1 npx playwright test tests/e2e/rtl-snapshot.spec.ts
+```
+
+Never assume a change is “too small” to impact QA.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+## Summary
+<!-- What changed? Why? -->
+
+## QA Checklist (advisory)
+- [ ] Ran `composer qa:advisory` locally (coverage import + schema validate + GA Enforcer RC)
+- [ ] If i18n touched: ran `php scripts/pot-refresh.php`
+- [ ] If UI touched: ran `E2E=1 E2E_RTL=1 npx playwright test tests/e2e/rtl-snapshot.spec.ts`
+- [ ] No unprepared `$wpdb` queries; REST routes have non-trivial `permission_callback`
+
+## Artifacts (links if available)
+- Coverage: `artifacts/coverage/coverage.json`
+- Schema: `artifacts/schema/schema-validate.json`
+- GA Enforcer: `artifacts/ga/…`

--- a/.github/workflows/ga-enforce.yml
+++ b/.github/workflows/ga-enforce.yml
@@ -1,0 +1,44 @@
+name: GA Enforce (manual)
+on:
+  workflow_dispatch:
+    inputs:
+      profile:
+        description: 'Threshold profile'
+        required: true
+        default: 'ga'
+        type: choice
+        options: [rc, ga]
+      junit:
+        description: 'Emit JUnit'
+        required: false
+        default: true
+        type: boolean
+jobs:
+  enforce:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          extensions: dom, mbstring, xml, json
+          coverage: none
+      - run: composer install --no-interaction --prefer-dist || true
+      - name: Import coverage (advisory)
+        run: php scripts/coverage-import.php || true
+      - name: Validate artifacts (advisory)
+        run: php scripts/artifact-schema-validate.php || true
+      - name: Enforce thresholds (blocking)
+        env:
+          RUN_ENFORCE: '1'
+        run: |
+          ARGS="--profile=${{ inputs.profile }} --enforce"
+          if [ "${{ inputs.junit }}" = "true" ]; then ARGS="$ARGS --junit"; fi
+          php scripts/ga-enforcer.php $ARGS
+      - name: Upload GA enforcer artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ga-enforcer-${{ inputs.profile }}
+          path: artifacts/ga/**
+          if-no-files-found: ignore

--- a/.github/workflows/qa-advisory.yml
+++ b/.github/workflows/qa-advisory.yml
@@ -1,0 +1,44 @@
+name: QA Advisory (coverage + schema + GA Enforcer RC)
+on:
+  pull_request:
+  workflow_dispatch:
+permissions:
+  contents: read
+jobs:
+  qa:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP 8.3
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          extensions: dom, mbstring, xml, json
+          coverage: none
+
+      - name: Install Composer deps (no dev if project uses lock)
+        run: composer install --no-interaction --prefer-dist || true
+
+      - name: Coverage import (advisory)
+        run: php scripts/coverage-import.php || true
+
+      - name: Artifact schema validate (advisory)
+        run: php scripts/artifact-schema-validate.php || true
+
+      - name: GA Enforcer (RC profile, advisory)
+        run: php scripts/ga-enforcer.php --profile=rc --junit || true
+
+      - name: Upload QA artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: qa-advisory-artifacts
+          path: |
+            artifacts/coverage/**
+            artifacts/schema/**
+            artifacts/ga/**
+            artifacts/qa/**
+            artifacts/dist/**
+          if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,7 @@ artifacts/e2e/rtl/
 artifacts/wporg/
 artifacts/coverage/
 artifacts/schema/
+artifacts/dist/
 artifacts/ga/
 *.lhreport.html
 # allow committed artifact templates

--- a/composer.json
+++ b/composer.json
@@ -49,6 +49,14 @@
         "test:e2e": "phpunit --testsuite E2E",
         "coverage": "php tools/coverage.php",
         "qa": "composer cs && composer psalm && composer test",
+        "qa:advisory": [
+            "@php scripts/coverage-import.php",
+            "@php scripts/artifact-schema-validate.php",
+            "@php scripts/ga-enforcer.php --profile=rc --junit"
+        ],
+        "qa:enforce:ga": [
+            "RUN_ENFORCE=1 php scripts/ga-enforcer.php --profile=ga --enforce --junit"
+        ],
         "ci": "composer cs && composer test:security && composer coverage",
         "preflight": "php tools/preflight.php",
         "docs": "@php bin/docs_build.php --in=docs/Docs-Bundle.md --out=docs/Docs-Bundle.compiled.md || exit 0",

--- a/docs/GA_ENFORCER.md
+++ b/docs/GA_ENFORCER.md
@@ -95,3 +95,19 @@ jobs:
 The job above runs the enforcer in advisory mode and uploads the generated
 artifacts for inspection.
 
+
+## CI quick start
+
+### Local advisory
+```bash
+php scripts/coverage-import.php
+php scripts/artifact-schema-validate.php
+php scripts/ga-enforcer.php --profile=rc --junit
+```
+
+### Manual enforce (GA threshold)
+```bash
+RUN_ENFORCE=1 php scripts/ga-enforcer.php --profile=ga --enforce --junit
+```
+
+See `.github/workflows/qa-advisory.yml` for advisory signals and `.github/workflows/ga-enforce.yml` for manual enforcement.


### PR DESCRIPTION
## Summary
- add non-blocking QA advisory workflow for coverage, schema and GA signals
- add manual GA enforce workflow and composer helpers
- document AI conventions and QA steps for contributors

## Testing
- `composer validate`
- `composer qa:advisory`


------
https://chatgpt.com/codex/tasks/task_e_68a7123d11b88321bfb0dd7496249132