### PR TITLE
refactor: improve artifact metadata and coverage

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,7 +3,6 @@
          xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          bootstrap="tests/bootstrap.php"
          colors="true"
-         verbose="true"
          stopOnFailure="false">
     <testsuites>
         <testsuite name="SmartAlloc Test Suite">
@@ -24,10 +23,10 @@
             <directory>vendor</directory>
             <directory>tests</directory>
         </exclude>
+        <report>
+            <clover outputFile="artifacts/coverage/clover.xml"/>
+        </report>
     </coverage>
-    <logging>
-        <log type="coverage-clover" target="artifacts/coverage/clover.xml"/>
-    </logging>
     <php>
         <env name="WP_TESTS_DIR" value="vendor/wordpress/wordpress-tests-lib"/>
         <env name="WP_CORE_DIR" value="vendor/wordpress/wordpress"/>

--- a/scripts/announce.php
+++ b/scripts/announce.php
@@ -35,8 +35,9 @@ $go = is_file($goFile) ? json_decode((string)file_get_contents($goFile), true) :
 $checksums = [];
 if (is_file($manifest)) {
     $m = json_decode((string)file_get_contents($manifest), true);
-    if (isset($m['files']) && is_array($m['files'])) {
-        foreach ($m['files'] as $f) {
+    $entries = $m['entries'] ?? ($m['files'] ?? []);
+    if (is_array($entries)) {
+        foreach ($entries as $f) {
             $checksums[] = [$f['path'] ?? '', $f['sha256'] ?? '', $f['size'] ?? ''];
         }
     }

--- a/scripts/dist-manifest.php
+++ b/scripts/dist-manifest.php
@@ -46,7 +46,10 @@ $manifestDir = $root . '/artifacts/dist';
 if (!is_dir($manifestDir)) {
     mkdir($manifestDir, 0777, true);
 }
-file_put_contents($manifestDir . '/manifest.json', json_encode(['files' => $files], JSON_PRETTY_PRINT));
+file_put_contents(
+    $manifestDir . '/manifest.json',
+    json_encode(['entries' => $files], JSON_PRETTY_PRINT)
+);
 
 exit(0);
 

--- a/scripts/release-draft.php
+++ b/scripts/release-draft.php
@@ -75,8 +75,9 @@ $lines[] = '## Artifacts';
 $manifestPath = $distDir . '/manifest.json';
 if (is_file($manifestPath)) {
     $manifest = json_decode((string)file_get_contents($manifestPath), true);
-    if (isset($manifest['files']) && is_array($manifest['files'])) {
-        foreach ($manifest['files'] as $file) {
+    $entries = $manifest['entries'] ?? ($manifest['files'] ?? []);
+    if (is_array($entries)) {
+        foreach ($entries as $file) {
             $path = $file['path'] ?? '';
             $sha = $file['sha256'] ?? '';
             if ($path !== '' && $sha !== '') {

--- a/scripts/release-notes.php
+++ b/scripts/release-notes.php
@@ -47,8 +47,10 @@ if ($goNoGoFile) {
         $metrics['sql'] = isset($inputs['sql']['count']) ? (int)$inputs['sql']['count'] : null;
         $metrics['license'] = isset($inputs['licenses']['denied']) ? (int)$inputs['licenses']['denied'] : null;
         $metrics['secrets'] = isset($inputs['secrets']['count']) ? (int)$inputs['secrets']['count'] : null;
-        if (isset($inputs['manifest']['files']) && is_array($inputs['manifest']['files'])) {
-            $metrics['manifest'] = $inputs['manifest']['files'];
+        $m = $inputs['manifest'] ?? [];
+        $entries = $m['entries'] ?? ($m['files'] ?? []);
+        if (is_array($entries)) {
+            $metrics['manifest'] = $entries;
         }
     }
 }

--- a/scripts/rollback-check.php
+++ b/scripts/rollback-check.php
@@ -38,10 +38,11 @@ if ($prev !== null) {
     $lines[] = 'Fetch previous GA artifact:';
     $lines[] = 'curl -LO https://downloads.wordpress.org/plugin/smart-alloc.' . $prev . '.zip';
     $lines[] = 'unzip -q smart-alloc.' . $prev . '.zip -d rollback-' . $prev;
-    if (!empty($manifest['files'])) {
-        $lines[] = 'cd rollback-' . $prev; 
+    $entries = $manifest['entries'] ?? ($manifest['files'] ?? []);
+    if (!empty($entries)) {
+        $lines[] = 'cd rollback-' . $prev;
         $lines[] = 'sha256sum --check <<\'EOF\'';
-        foreach ($manifest['files'] as $f) {
+        foreach ($entries as $f) {
             $path = $f['path'] ?? '';
             $sha = $f['sha256'] ?? '';
             if ($path !== '' && $sha !== '') {

--- a/scripts/validate-artifacts.php
+++ b/scripts/validate-artifacts.php
@@ -25,11 +25,18 @@ $defs = [
         return (is_array($data) && array_key_exists('verdict', $data)) ? [] : ['missing verdict'];
     }],
     ['artifacts/dist/manifest.json', function ($data) {
-        if (!is_array($data)) {
+        $entries = $data['entries'] ?? $data;
+        if (!is_array($entries)) {
             return ['not array'];
         }
-        foreach ($data as $i => $row) {
-            if (!is_array($row) || !isset($row['path'], $row['size'], $row['sha256']) || !is_string($row['path']) || !is_string($row['sha256']) || !is_int($row['size'])) {
+        foreach ($entries as $i => $row) {
+            if (
+                !is_array($row)
+                || !isset($row['path'], $row['size'], $row['sha256'])
+                || !is_string($row['path'])
+                || !is_string($row['sha256'])
+                || !is_int($row['size'])
+            ) {
                 return ['invalid entry at ' . $i];
             }
         }

--- a/smart-alloc.php
+++ b/smart-alloc.php
@@ -61,6 +61,19 @@ spl_autoload_register(function ($class) {
     }
 });
 
+// Lazy-load Composer autoloader on demand to conserve memory.
+spl_autoload_register(function ($class) {
+    static $loaded = false;
+    if ($loaded || str_starts_with($class, 'SmartAlloc\\')) {
+        return;
+    }
+    $autoload = __DIR__ . '/vendor/autoload.php';
+    if (file_exists($autoload)) {
+        $loaded = true;
+        require_once $autoload;
+    }
+}, true, true);
+
 // Activation hook
 register_activation_hook(__FILE__, function (bool $network_wide) {
     SmartAlloc\Bootstrap::activate($network_wide);
@@ -68,10 +81,6 @@ register_activation_hook(__FILE__, function (bool $network_wide) {
 
 // Load textdomain and initialize
 add_action('plugins_loaded', function () {
-    $autoload = __DIR__ . '/vendor/autoload.php';
-    if (file_exists($autoload)) {
-        require_once $autoload;
-    }
     load_plugin_textdomain('smartalloc', false, dirname(plugin_basename(__FILE__)) . '/languages');
     SmartAlloc\Bootstrap::init();
 

--- a/tools/coverage.php
+++ b/tools/coverage.php
@@ -14,14 +14,15 @@ if (!$hasDriver) {
     exit(1);
 }
 
-if (!is_dir('build')) {
-    mkdir('build', 0777, true);
+if (!is_dir('artifacts/coverage')) {
+    mkdir('artifacts/coverage', 0777, true);
 }
 
-passthru('vendor/bin/phpunit --coverage-clover build/coverage.xml', $code);
+passthru('vendor/bin/phpunit', $code);
 if ($code !== 0) {
     exit($code);
 }
 
-passthru('php tools/coverage-check.php build/coverage.xml', $code);
+$clover = 'artifacts/coverage/clover.xml';
+passthru('php tools/coverage-check.php ' . escapeshellarg($clover), $code);
 exit($code);


### PR DESCRIPTION
## Summary
- ensure dist manifest uses `entries` with checksums
- lazy-load Composer autoloader to lower memory use
- generate clover.xml via PHPUnit and streamline coverage import

## Testing
- `php scripts/coverage-import.php`
- `php scripts/artifact-schema-validate.php`
- `php scripts/ga-enforcer.php --profile=rc --junit`
- `RUN_PERFORMANCE_TESTS=1 vendor/bin/phpunit tests/integration/Performance/RequestBudgetTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68a71f4cb26c8321bf7b3e232440e4a9