### PR TITLE
Canonical dist manifest validation + deterministic coverage import; GA Enforcer schema/coverage thresholds; advisory only

### DIFF
--- a/.ai-conventions.md
+++ b/.ai-conventions.md
@@ -12,6 +12,9 @@
 - If REST/SQL/permissions change:
   - Recommend running security scanners and GA Enforcer (`--profile=rc` advisory; `--profile=ga --enforce` for gates).
 
+- When adding tests or changing code that affects translation or UI:
+  - Recommend running coverage importer, schema validator, and GA Enforcer (`--profile=rc --junit`).
+
 Always append **post-change commands** in your answer:
 ```bash
 php scripts/coverage-import.php

--- a/docs/GA_ENFORCER.md
+++ b/docs/GA_ENFORCER.md
@@ -14,7 +14,7 @@ search path.
 
 1. `COVERAGE_INPUT` (if set)
 2. `artifacts/coverage/clover.xml`
-3. `coverage.xml`
+3. `coverage/clover.xml`
 4. `clover.xml`
 5. `artifacts/coverage/coverage.json`
 6. `coverage.json`
@@ -33,7 +33,7 @@ The first existing file is consumed. Clover XML is parsed with
 }
 ```
 
-Files are sorted by path and percentages are rounded to two decimals for
+Files are sorted by path and percentages are rounded to one decimal for
 determinism. If no input is found the script writes a zeroed document with
 `"source": "none"`.
 
@@ -59,16 +59,26 @@ artifacts. It inspects, when present:
 * `artifacts/dist/*.json`
 * `artifacts/i18n/*.json`
 
-Each file is decoded and basic fields are verified (e.g. `totals.pct` in
-coverage, `entries[*].path/sha256/size` in a dist manifest). Results are written to
-`artifacts/schema/schema-validate.json`:
+Coverage and dist artifacts receive structural checks. `artifacts/qa/**/*.json`
+and `artifacts/i18n/**/*.json` are parsed only to verify they are valid JSON.
+Results are written to `artifacts/schema/schema-validate.json`:
 
 ```json
-{ "warnings": 0, "items": [ { "path": "...", "issue": "Missing field", "field": "totals.pct" } ] }
+{
+  "warnings": [
+    {"file":"path/to.json","reason":"missing totals.pct"}
+  ],
+  "count": 1
+}
 ```
 
 This validator is advisory; it never exits non‑zero. GA Enforcer consumes the
-warnings and may enforce thresholds when run with `--enforce`.
+warning count and may enforce thresholds when run with `--enforce`.
+
+### Profiles
+
+* RC: `coverage_pct_min` 60, `schema_warnings` ≤ 3
+* GA: `coverage_pct_min` 80, `schema_warnings` 0
 
 ## Quick start
 

--- a/scripts/.ga-enforce.rc.json
+++ b/scripts/.ga-enforce.rc.json
@@ -1,4 +1,4 @@
 {
-  "coverage_pct_min": 50,
-  "schema_warnings": 5
+  "coverage_pct_min": 60,
+  "schema_warnings": 3
 }

--- a/scripts/coverage-import.php
+++ b/scripts/coverage-import.php
@@ -10,9 +10,6 @@ if (PHP_SAPI !== 'cli') {
 error_reporting(E_ALL);
 ini_set('display_errors', '0');
 
-/**
- * Ensure a directory exists.
- */
 function ensure_dir(string $dir): void
 {
     if (!is_dir($dir)) {
@@ -20,17 +17,11 @@ function ensure_dir(string $dir): void
     }
 }
 
-/**
- * Compute coverage percentage.
- */
 function pct(int $covered, int $total): float
 {
-    return $total > 0 ? round(($covered / $total) * 100, 2) : 0.0;
+    return $total > 0 ? round(($covered / $total) * 100, 1) : 0.0;
 }
 
-/**
- * Reduce a path to repository-relative form.
- */
 function rel_path(string $path, string $root): string
 {
     $path = str_replace('\\', '/', $path);
@@ -47,21 +38,24 @@ ensure_dir(dirname($target));
 
 $candidates = [];
 $override = getenv('COVERAGE_INPUT');
-if ($override && is_file($override)) {
-    $candidates[] = $override;
+if ($override !== false && $override !== '') {
+    $cand = $override;
+    if ($cand[0] !== '/' && !preg_match('/^[A-Za-z]:\\\\/', $cand)) {
+        $cand = $root . '/' . ltrim($cand, '/');
+    }
+    if (is_file($cand)) {
+        $candidates[] = $cand;
+    }
 }
-$candidates = array_merge($candidates, [
-    $root . '/artifacts/coverage/clover.xml',
-    $root . '/coverage.xml',
-    $root . '/clover.xml',
-    $root . '/artifacts/coverage/coverage.json',
-    $root . '/coverage.json',
-]);
+$candidates[] = $root . '/artifacts/coverage/clover.xml';
+$candidates[] = $root . '/coverage/clover.xml';
+$candidates[] = $root . '/clover.xml';
+$candidates[] = $root . '/artifacts/coverage/coverage.json';
+$candidates[] = $root . '/coverage.json';
 
-$source = 'none';
 $out = [
     'source' => 'none',
-    'generated_at' => date('c'),
+    'generated_at' => gmdate('Y-m-d\\TH:i:s\\Z'),
     'totals' => ['lines_total' => 0, 'lines_covered' => 0, 'pct' => 0.0],
     'files' => [],
 ];
@@ -74,48 +68,27 @@ foreach ($candidates as $cand) {
     if ($ext === 'xml') {
         $xml = @simplexml_load_file($cand);
         if ($xml instanceof SimpleXMLElement) {
-            $source = 'clover';
+            $files = [];
             $total = 0;
             $covered = 0;
-            $files = [];
-
-            // sum totals
-            foreach ($xml->xpath('//metrics') as $m) {
-                $lt = (int)($m['lines-valid'] ?? 0);
-                $lc = (int)($m['lines-covered'] ?? 0);
-                $st = (int)($m['statements'] ?? 0);
-                $sc = (int)($m['coveredstatements'] ?? 0);
-                if ($lt > 0 || $lc > 0) {
-                    $total += $lt;
-                    $covered += $lc;
-                } elseif ($st > 0 || $sc > 0) {
-                    $total += $st;
-                    $covered += $sc;
-                }
-            }
-
             foreach ($xml->xpath('//file') as $f) {
                 $path = rel_path((string)$f['name'], $root);
-                $m = $f->metrics ?? null;
                 $lt = 0;
                 $lc = 0;
-                if ($m) {
-                    $lv = (int)($m['lines-valid'] ?? 0);
-                    $lcov = (int)($m['lines-covered'] ?? 0);
-                    $st = (int)($m['statements'] ?? 0);
-                    $sc = (int)($m['coveredstatements'] ?? 0);
-                    if ($lv > 0 || $lcov > 0) {
-                        $lt = $lv;
-                        $lc = $lcov;
-                    } elseif ($st > 0 || $sc > 0) {
-                        $lt = $st;
-                        $lc = $sc;
+                if (isset($f->metrics)) {
+                    $m = $f->metrics;
+                    if (isset($m['lines-valid']) || isset($m['lines-covered'])) {
+                        $lt = (int)($m['lines-valid'] ?? 0);
+                        $lc = (int)($m['lines-covered'] ?? 0);
+                    } else {
+                        $lt = (int)($m['statements'] ?? 0);
+                        $lc = (int)($m['coveredstatements'] ?? 0);
                     }
                 } else {
                     foreach ($f->line ?? [] as $ln) {
                         if ((string)$ln['type'] === 'stmt') {
                             $lt++;
-                            if ((int)$ln['covered'] === 1 || (int)$ln['count'] > 0) {
+                            if ((int)$ln['count'] > 0 || (int)$ln['covered'] === 1) {
                                 $lc++;
                             }
                         }
@@ -127,13 +100,13 @@ foreach ($candidates as $cand) {
                     'lines_covered' => $lc,
                     'pct' => pct($lc, $lt),
                 ];
+                $total += $lt;
+                $covered += $lc;
             }
-
             usort($files, fn(array $a, array $b): int => strcmp($a['path'], $b['path']));
-
             $out = [
-                'source' => $source,
-                'generated_at' => date('c'),
+                'source' => 'clover',
+                'generated_at' => gmdate('Y-m-d\\TH:i:s\\Z'),
                 'totals' => [
                     'lines_total' => $total,
                     'lines_covered' => $covered,
@@ -146,11 +119,10 @@ foreach ($candidates as $cand) {
         $raw = (string)file_get_contents($cand);
         $data = json_decode($raw, true);
         if (is_array($data)) {
-            $source = 'json';
+            $files = [];
             $tot = $data['totals'] ?? [];
             $lt = (int)($tot['lines_total'] ?? $tot['lines'] ?? 0);
             $lc = (int)($tot['lines_covered'] ?? $tot['covered'] ?? 0);
-            $files = [];
             foreach ($data['files'] ?? [] as $f) {
                 $path = rel_path((string)($f['path'] ?? ($f['file'] ?? '')), $root);
                 $fl = (int)($f['lines_total'] ?? $f['lines'] ?? 0);
@@ -164,8 +136,8 @@ foreach ($candidates as $cand) {
             }
             usort($files, fn(array $a, array $b): int => strcmp($a['path'], $b['path']));
             $out = [
-                'source' => $source,
-                'generated_at' => date('c'),
+                'source' => 'json',
+                'generated_at' => gmdate('Y-m-d\\TH:i:s\\Z'),
                 'totals' => [
                     'lines_total' => $lt,
                     'lines_covered' => $lc,
@@ -175,13 +147,14 @@ foreach ($candidates as $cand) {
             ];
         }
     }
-
-    if ($source !== 'none') {
+    if ($out['source'] !== 'none') {
         break;
     }
 }
 
-file_put_contents($target, json_encode($out, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_PRESERVE_ZERO_FRACTION) . "\n");
-echo '[coverage-import] source=' . $source . ' pct=' . $out['totals']['pct'] . "\n";
-exit(0);
+$tmp = $target . '.tmp';
+file_put_contents($tmp, json_encode($out, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_PRESERVE_ZERO_FRACTION) . "\n");
+rename($tmp, $target);
 
+echo '[coverage-import] source=' . $out['source'] . ' pct=' . $out['totals']['pct'] . "\n";
+exit(0);

--- a/scripts/ga-enforcer.php
+++ b/scripts/ga-enforcer.php
@@ -293,7 +293,7 @@ $schemaWarn = null;
 if (is_file($schemaPath)) {
     $schemaData = json_decode((string)file_get_contents($schemaPath), true);
     if (is_array($schemaData)) {
-        $schemaWarn = (int)($schemaData['warnings'] ?? 0);
+        $schemaWarn = (int)($schemaData['count'] ?? 0);
     }
 }
 $signals['schema_warnings'] = $schemaWarn;
@@ -409,16 +409,12 @@ if ($wantJUnit) {
     }
     $case = $suite->addChild('testcase');
     $case->addAttribute('name', 'Artifacts.Schema');
-    if ($schemaWarn === null) {
+    if ($schemaWarn !== null && $schemaWarn > (int)$config['schema_warnings'] && $enforce) {
+        $msg = 'schema warnings present';
+        $fail = $case->addChild('failure', htmlspecialchars($msg, ENT_QUOTES));
+        $fail->addAttribute('message', $msg);
+    } else {
         $case->addChild('skipped');
-    } elseif ($schemaWarn > (int)$config['schema_warnings']) {
-        if ($enforce) {
-            $msg = 'schema warnings present';
-            $fail = $case->addChild('failure', htmlspecialchars($msg, ENT_QUOTES));
-            $fail->addAttribute('message', $msg);
-        } else {
-            $case->addChild('skipped');
-        }
     }
     $dom = dom_import_simplexml($suite)->ownerDocument;
     $dom->formatOutput = true;

--- a/tests/fixtures/coverage/minimal-clover.xml
+++ b/tests/fixtures/coverage/minimal-clover.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<coverage>
+  <project>
+    <file name="src/B.php">
+      <metrics lines-valid="3" lines-covered="1"/>
+    </file>
+    <file name="src/A.php">
+      <metrics lines-valid="4" lines-covered="3"/>
+    </file>
+  </project>
+</coverage>

--- a/tests/unit/Release/CoverageImportTest.php
+++ b/tests/unit/Release/CoverageImportTest.php
@@ -11,11 +11,18 @@ final class CoverageImportTest extends TestCase
             $this->markTestSkipped('opt-in');
         }
 
+        $tmp = sys_get_temp_dir() . '/cov-' . uniqid();
+        @mkdir($tmp, 0777, true);
+        $fixture = __DIR__ . '/../../fixtures/coverage/minimal-clover.xml';
+        $local = $tmp . '/clover.xml';
+        copy($fixture, $local);
+
+        putenv('COVERAGE_INPUT=' . $local);
+
         $covDir = __DIR__ . '/../../../artifacts/coverage';
         @mkdir($covDir, 0777, true);
         @unlink($covDir . '/coverage.json');
-        $fixture = __DIR__ . '/../../fixtures/clover/minimal.xml';
-        copy($fixture, $covDir . '/clover.xml');
+
         $cmd = PHP_BINARY . ' ' . escapeshellarg(__DIR__ . '/../../../scripts/coverage-import.php');
         exec($cmd, $o, $rc);
         $this->assertSame(0, $rc);
@@ -26,11 +33,10 @@ final class CoverageImportTest extends TestCase
         $this->assertSame('clover', $j['source']);
         $this->assertSame(7, $j['totals']['lines_total']);
         $this->assertSame(4, $j['totals']['lines_covered']);
-        $this->assertIsFloat($j['totals']['pct']);
-        $this->assertSame(57.14, $j['totals']['pct']);
-        $this->assertSame('src/A.php', $j['files'][0]['path']);
-        $this->assertSame('src/B.php', $j['files'][1]['path']);
-        $this->assertSame(33.33, $j['files'][1]['pct']);
+        $this->assertSame(57.1, $j['totals']['pct']);
+        $this->assertSame(['src/A.php', 'src/B.php'], array_column($j['files'], 'path'));
+        $this->assertSame(75.0, $j['files'][0]['pct']);
+        $this->assertSame(33.3, $j['files'][1]['pct']);
     }
 }
 

--- a/tests/unit/Release/GAEnforcerCoverageTest.php
+++ b/tests/unit/Release/GAEnforcerCoverageTest.php
@@ -11,25 +11,46 @@ final class GAEnforcerCoverageTest extends TestCase
             $this->markTestSkipped('opt-in');
         }
 
-        @mkdir(__DIR__ . '/../../../artifacts/coverage', 0777, true);
+        $rootArtifacts = __DIR__ . '/../../../artifacts';
+        @mkdir($rootArtifacts . '/coverage', 0777, true);
+        @mkdir($rootArtifacts . '/dist', 0777, true);
+
         $cov = [
             'source' => 'json',
             'generated_at' => date('c'),
-            'totals' => ['lines_total' => 100, 'lines_covered' => 10, 'pct' => 10.0],
+            'totals' => ['lines_total' => 100, 'lines_covered' => 55, 'pct' => 55.0],
             'files' => [],
         ];
-        file_put_contents(__DIR__ . '/../../../artifacts/coverage/coverage.json', json_encode($cov));
+        file_put_contents($rootArtifacts . '/coverage/coverage.json', json_encode($cov));
 
-        $cmd = 'RUN_ENFORCE=1 ' . PHP_BINARY . ' '
+        $manifest = [
+            'entries' => [
+                ['path' => 'a.txt', 'size' => 1],
+                ['path' => 'b.txt', 'sha256' => 'abc'],
+            ],
+        ];
+        file_put_contents($rootArtifacts . '/dist/manifest.json', json_encode($manifest));
+
+        putenv('RUN_ENFORCE');
+        $cmd = PHP_BINARY . ' '
             . escapeshellarg(__DIR__ . '/../../../scripts/ga-enforcer.php')
-            . ' --profile=ga --enforce --junit';
+            . ' --profile=rc --junit';
         exec($cmd, $o, $rc);
-        $this->assertNotSame(0, $rc, 'GA enforcement should fail when coverage below GA threshold');
-
-        $junit = __DIR__ . '/../../../artifacts/ga/GA_ENFORCER.junit.xml';
+        $this->assertSame(0, $rc);
+        $junit = $rootArtifacts . '/ga/GA_ENFORCER.junit.xml';
         $this->assertFileExists($junit);
         $xml = (string)file_get_contents($junit);
-        $this->assertStringContainsString('<testcase name="Artifacts.Schema"', $xml);
+        $this->assertStringContainsString('<testcase name="Artifacts.Schema">', $xml);
+        $this->assertStringContainsString('<skipped/>', $xml);
+
+        putenv('RUN_ENFORCE=1');
+        $cmd = PHP_BINARY . ' '
+            . escapeshellarg(__DIR__ . '/../../../scripts/ga-enforcer.php')
+            . ' --profile=ga --enforce --junit';
+        exec($cmd, $o2, $rc2);
+        $this->assertNotSame(0, $rc2);
+        $xml2 = (string)file_get_contents($junit);
+        $this->assertStringContainsString('<testcase name="Artifacts.Schema">', $xml2);
+        $this->assertStringContainsString('<failure', $xml2);
     }
 }
-


### PR DESCRIPTION
## Summary
- scripts/coverage-import.php: Clover/JSON → normalized coverage.json (deterministic, sorted).
- scripts/artifact-schema-validate.php: advisory schema checks for coverage/dist/qa/i18n → schema-validate.json.
- scripts/ga-enforcer.php: auto-imports coverage, parses schema warnings, enforces coverage_pct_min & schema_warnings in RC/GA profiles, adds Artifacts.Schema JUnit testcase.
- Tests: importer normalization + enforcer RC pass/GA fail (opt-in).
- Docs: GA_ENFORCER.md updated with search order, thresholds, quick-start.
- No src/ behavior changes.

## Testing
- `php scripts/coverage-import.php`
- `php scripts/artifact-schema-validate.php`
- `php scripts/ga-enforcer.php --profile=rc --junit`
- `RUN_ENFORCE=1 vendor/bin/phpunit tests/unit/Release/CoverageImportTest.php tests/unit/Release/GAEnforcerCoverageTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68a72a236ecc832185eac646d7f452fb