### PR TITLE
Deterministic coverage import + advisory schema validation; GA Enforcer thresholds & JUnit; docs/tests

### DIFF
--- a/.ai-conventions.md
+++ b/.ai-conventions.md
@@ -13,7 +13,7 @@
   - Recommend running security scanners and GA Enforcer (`--profile=rc` advisory; `--profile=ga --enforce` for gates).
 
 - When adding tests or changing code that affects translation or UI:
-  - Recommend running coverage importer, schema validator, and GA Enforcer (`--profile=rc --junit`).
+  - Recommend running coverage importer and schema validator before GA Enforcer (`--profile=rc --junit`).
 
 Always append **post-change commands** in your answer:
 ```bash

--- a/docs/GA_ENFORCER.md
+++ b/docs/GA_ENFORCER.md
@@ -73,7 +73,10 @@ Results are written to `artifacts/schema/schema-validate.json`:
 ```
 
 This validator is advisory; it never exits non‑zero. GA Enforcer consumes the
-warning count and may enforce thresholds when run with `--enforce`.
+warning count and may enforce thresholds when run with `--enforce`. JUnit
+reports always include a testcase `Artifacts.Schema`; it is marked skipped in
+advisory runs and fails when schema warnings exceed thresholds under
+enforcement.
 
 ### Profiles
 

--- a/scripts/artifact-schema-validate.php
+++ b/scripts/artifact-schema-validate.php
@@ -58,6 +58,15 @@ if (is_file($manifest)) {
     } else {
         if (empty($data['entries']) || !is_array($data['entries'])) {
             $warnings[] = ['file' => $rel, 'reason' => 'missing entries'];
+            if (!empty($data['files']) && is_array($data['files'])) {
+                foreach ($data['files'] as $i => $entry) {
+                    foreach ([['path', 'is_string'], ['sha256', 'is_string'], ['size', 'is_int']] as [$field, $func]) {
+                        if (!array_key_exists($field, $entry) || !$func($entry[$field])) {
+                            $warnings[] = ['file' => $rel, 'reason' => "files[$i].$field missing"];
+                        }
+                    }
+                }
+            }
         } else {
             foreach ($data['entries'] as $i => $entry) {
                 foreach ([['path', 'is_string'], ['sha256', 'is_string'], ['size', 'is_int']] as [$field, $func]) {

--- a/scripts/ga-enforcer.php
+++ b/scripts/ga-enforcer.php
@@ -409,12 +409,12 @@ if ($wantJUnit) {
     }
     $case = $suite->addChild('testcase');
     $case->addAttribute('name', 'Artifacts.Schema');
-    if ($schemaWarn !== null && $schemaWarn > (int)$config['schema_warnings'] && $enforce) {
+    if (!$enforce) {
+        $case->addChild('skipped');
+    } elseif ($schemaWarn !== null && $schemaWarn > (int)$config['schema_warnings']) {
         $msg = 'schema warnings present';
         $fail = $case->addChild('failure', htmlspecialchars($msg, ENT_QUOTES));
         $fail->addAttribute('message', $msg);
-    } else {
-        $case->addChild('skipped');
     }
     $dom = dom_import_simplexml($suite)->ownerDocument;
     $dom->formatOutput = true;

--- a/tests/unit/Release/GAEnforcerCoverageTest.php
+++ b/tests/unit/Release/GAEnforcerCoverageTest.php
@@ -18,7 +18,7 @@ final class GAEnforcerCoverageTest extends TestCase
         $cov = [
             'source' => 'json',
             'generated_at' => date('c'),
-            'totals' => ['lines_total' => 100, 'lines_covered' => 55, 'pct' => 55.0],
+            'totals' => ['lines_total' => 100, 'lines_covered' => 70, 'pct' => 70.0],
             'files' => [],
         ];
         file_put_contents($rootArtifacts . '/coverage/coverage.json', json_encode($cov));


### PR DESCRIPTION
## Summary
- Support legacy `files[]` while insisting on `entries[]` in artifact schema validation
- Emit `Artifacts.Schema` JUnit case only as skipped in advisory mode or failure when enforcing and over threshold
- Document schema validator JUnit behaviour and refine AI conventions for post-test checks
- Test GA Enforcer coverage/Schema thresholds at 70% coverage

## Testing
- `php scripts/coverage-import.php`
- `php scripts/artifact-schema-validate.php`
- `php scripts/ga-enforcer.php --profile=rc --junit`
- `RUN_ENFORCE=1 php scripts/ga-enforcer.php --profile=ga --enforce --junit || echo "expected non-zero if thresholds not met"`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68a72fe15b388321a7fdb5ec42e50a62