### PR TITLE
Validate dist manifest entries and expose schema warnings

### DIFF
--- a/.ai-conventions.md
+++ b/.ai-conventions.md
@@ -13,8 +13,7 @@
   - Recommend running security scanners and GA Enforcer (`--profile=rc` advisory; `--profile=ga --enforce` for gates).
 
 - When adding tests or changing code that affects translation or UI:
-  - Recommend running coverage importer and schema validator before GA Enforcer (`--profile=rc --junit`).
-
+  - Run `php scripts/coverage-import.php` and `php scripts/artifact-schema-validate.php` before `php scripts/ga-enforcer.php --profile=rc --junit`.
 Always append **post-change commands** in your answer:
 ```bash
 php scripts/coverage-import.php

--- a/docs/GA_ENFORCER.md
+++ b/docs/GA_ENFORCER.md
@@ -47,7 +47,12 @@ canonical `entries` array. Each entry is sorted by path and includes:
 ```
 
 Legacy fields may appear for backwards compatibility, but `entries` is the
-source of truth for consumers.
+source of truth for consumers. If a legacy `files[]` array exists the schema
+validator emits a warning:
+
+```
+legacy files[] present; use entries[] as canonical
+```
 
 ## Artifact Schema Validation
 
@@ -59,8 +64,11 @@ artifacts. It inspects, when present:
 * `artifacts/dist/*.json`
 * `artifacts/i18n/*.json`
 
-Coverage and dist artifacts receive structural checks. `artifacts/qa/**/*.json`
-and `artifacts/i18n/**/*.json` are parsed only to verify they are valid JSON.
+Coverage and dist artifacts receive structural checks. The manifest requires a
+canonical `entries[]` array where each entry has a `path`, `sha256` (hex), and
+`size`. A legacy `files[]` array triggers the warning above.
+`artifacts/qa/**/*.json` and `artifacts/i18n/**/*.json` are parsed only to verify
+they are valid JSON.
 Results are written to `artifacts/schema/schema-validate.json`:
 
 ```json


### PR DESCRIPTION
## Summary
- ensure artifact-schema-validate requires canonical entries and warns on legacy files
- document schema warning handling and GA Enforcer testcase behavior
- test GA Enforcer JUnit output for schema warnings

## Testing
- `php scripts/coverage-import.php`
- `php scripts/artifact-schema-validate.php`
- `php scripts/ga-enforcer.php --profile=rc --junit`
- `RUN_ENFORCE=1 php scripts/ga-enforcer.php --profile=ga --enforce --junit || echo "expected non-zero if thresholds not met"`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68a732eeb1108321b5fc74aa69ddf787