### PR TITLE
Ensure Artifacts.Schema JUnit coverage and document manifest schema

### DIFF
--- a/.ai-conventions.md
+++ b/.ai-conventions.md
@@ -14,6 +14,7 @@
 
 - When adding tests or changing code that affects translation or UI:
   - Run `php scripts/coverage-import.php` and `php scripts/artifact-schema-validate.php` before `php scripts/ga-enforcer.php --profile=rc --junit`.
+  - The JUnit output always includes a testcase `Artifacts.Schema`; it is skipped in advisory mode and fails under `--enforce` if schema warnings exceed thresholds.
 Always append **post-change commands** in your answer:
 ```bash
 php scripts/coverage-import.php

--- a/docs/GA_ENFORCER.md
+++ b/docs/GA_ENFORCER.md
@@ -66,9 +66,11 @@ artifacts. It inspects, when present:
 
 Coverage and dist artifacts receive structural checks. The manifest requires a
 canonical `entries[]` array where each entry has a `path`, `sha256` (hex), and
-`size`. A legacy `files[]` array triggers the warning above.
-`artifacts/qa/**/*.json` and `artifacts/i18n/**/*.json` are parsed only to verify
-they are valid JSON.
+`size`. A legacy `files[]` array triggers the warning above. Downstream CI can
+rely on the JUnit testcase `Artifacts.Schema` to surface these warnings; it is
+always emitted, skipped in advisory runs, and fails when thresholds are
+exceeded under enforcement. `artifacts/qa/**/*.json` and
+`artifacts/i18n/**/*.json` are parsed only to verify they are valid JSON.
 Results are written to `artifacts/schema/schema-validate.json`:
 
 ```json

--- a/tests/unit/Release/GAEnforcerCoverageTest.php
+++ b/tests/unit/Release/GAEnforcerCoverageTest.php
@@ -44,8 +44,7 @@ final class GAEnforcerCoverageTest extends TestCase
         $junit = $rootArtifacts . '/ga/GA_ENFORCER.junit.xml';
         $this->assertFileExists($junit);
         $xml = (string)file_get_contents($junit);
-        $this->assertStringContainsString('<testcase name="Artifacts.Schema">', $xml);
-        $this->assertStringContainsString('<skipped', $xml);
+        $this->assertMatchesRegularExpression('/<testcase name="Artifacts\.Schema">\s*<skipped\/>/s', $xml);
 
         $bad = [
             'files' => [
@@ -61,7 +60,7 @@ final class GAEnforcerCoverageTest extends TestCase
         exec($cmd, $o2, $rc2);
         $this->assertNotSame(0, $rc2);
         $xml2 = (string)file_get_contents($junit);
-        $this->assertStringContainsString('<testcase name="Artifacts.Schema">', $xml2);
-        $this->assertStringContainsString('<failure', $xml2);
+        $this->assertMatchesRegularExpression('/<testcase name="Artifacts\.Schema">\s*<failure/s', $xml2);
+        $this->assertDoesNotMatchRegularExpression('/<testcase name="Artifacts\.Schema">\s*<skipped/s', $xml2);
     }
 }


### PR DESCRIPTION
## Summary
- Document that GA Enforcer's JUnit output always includes an `Artifacts.Schema` testcase and clarify schema warnings behaviour
- Highlight `Artifacts.Schema` lifecycle in AI conventions
- Harden `GAEnforcerCoverageTest` to verify `Artifacts.Schema` is skipped in advisory runs and fails under enforcement

## Testing
- `php scripts/coverage-import.php`
- `php scripts/artifact-schema-validate.php`
- `php scripts/ga-enforcer.php --profile=rc --junit`
- `RUN_ENFORCE=1 vendor/bin/phpunit tests/unit/Release/GAEnforcerCoverageTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68a736b92d04832188b19199c5fa1015