### PR TITLE
feat: enforce canonical artifacts and schema

### DIFF
--- a/docs/AI_GUIDELINES.md
+++ b/docs/AI_GUIDELINES.md
@@ -1,0 +1,40 @@
+# AI Guidelines
+
+This repository uses several generated artifacts. When updating tooling or
+writing tests, keep the following expectations in mind:
+
+## Coverage import
+
+Coverage is normalised to `artifacts/coverage/coverage.json` via
+`scripts/coverage-import.php`. The search order is:
+
+1. `COVERAGE_INPUT` (if set)
+2. `artifacts/coverage/clover.xml`
+3. `coverage/clover.xml`
+4. `clover.xml`
+5. `artifacts/coverage/coverage.json`
+6. `coverage.json`
+
+The first existing file is consumed. The output lists totals and per-file
+metrics sorted by path with percentages rounded to one decimal place.
+
+## Distribution manifest
+
+`artifacts/dist/manifest.json` is canonical. It must contain an `entries` array
+where each object includes:
+
+```json
+{ "path": "file.php", "sha256": "<64-hex>", "size": 123 }
+```
+
+If a legacy `files[]` key is present, `artifact-schema-validate.php` emits an
+advisory warning. Missing or malformed manifests also raise warnings.
+
+## GA Enforcer JUnit
+
+`scripts/ga-enforcer.php` runs `coverage-import.php` and
+`artifact-schema-validate.php` automatically. Its JUnit report always contains a
+`testcase` named `Artifacts.Schema`. Advisory runs (e.g. `--profile=rc`) mark it
+skipped; GA enforcement (`--profile=ga --enforce`) fails the testcase when
+schema warnings exceed configured thresholds.
+

--- a/docs/GA_ENFORCER.md
+++ b/docs/GA_ENFORCER.md
@@ -7,8 +7,9 @@ fails a build when enforcement is explicitly enabled.
 ## Coverage Import
 
 `scripts/coverage-import.php` normalises coverage reports into
-`artifacts/coverage/coverage.json`. Set `COVERAGE_INPUT` to override the
-search path.
+`artifacts/coverage/coverage.json`. GA Enforcer invokes this script
+automatically before evaluating coverage signals. Set `COVERAGE_INPUT` to
+override the search path.
 
 **Search order**
 
@@ -40,7 +41,8 @@ determinism. If no input is found the script writes a zeroed document with
 ## Dist Manifest
 
 `scripts/dist-manifest.php` writes `artifacts/dist/manifest.json` containing a
-canonical `entries` array. Each entry is sorted by path and includes:
+canonical `entries` array. The schema validator requires this manifest to
+exist. Each entry is sorted by path and includes:
 
 ```json
 { "path": "file.php", "sha256": "...", "size": 123 }
@@ -48,7 +50,7 @@ canonical `entries` array. Each entry is sorted by path and includes:
 
 Legacy fields may appear for backwards compatibility, but `entries` is the
 source of truth for consumers. If a legacy `files[]` array exists the schema
-validator emits a warning:
+validator emits an advisory warning:
 
 ```
 legacy files[] present; use entries[] as canonical

--- a/scripts/artifact-schema-validate.php
+++ b/scripts/artifact-schema-validate.php
@@ -77,6 +77,8 @@ if (is_file($manifest)) {
             $warnings[] = ['file' => $rel, 'reason' => 'legacy files[] present; use entries[] as canonical'];
         }
     }
+} else {
+    $warnings[] = ['file' => substr($manifest, strlen($root) + 1), 'reason' => 'missing file'];
 }
 
 // qa and i18n JSON parseability
@@ -98,12 +100,19 @@ foreach (['qa', 'i18n'] as $dir) {
     }
 }
 
-usort($warnings, fn(array $a, array $b): int => strcmp($a['file'], $b['file']));
+usort(
+    $warnings,
+    function (array $a, array $b): int {
+        $cmp = strcmp($a['file'], $b['file']);
+        return $cmp !== 0 ? $cmp : strcmp($a['reason'], $b['reason']);
+    }
+);
 
 $out = [
     'warnings' => $warnings,
     'count' => count($warnings),
 ];
+ksort($out);
 
 $tmp = $schemaDir . '/schema-validate.json.tmp';
 file_put_contents($tmp, json_encode($out, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n");

--- a/scripts/coverage-import.php
+++ b/scripts/coverage-import.php
@@ -94,24 +94,28 @@ foreach ($candidates as $cand) {
                         }
                     }
                 }
-                $files[] = [
+                $row = [
                     'path' => $path,
                     'lines_total' => $lt,
                     'lines_covered' => $lc,
                     'pct' => pct($lc, $lt),
                 ];
+                ksort($row);
+                $files[] = $row;
                 $total += $lt;
                 $covered += $lc;
             }
             usort($files, fn(array $a, array $b): int => strcmp($a['path'], $b['path']));
+            $totals = [
+                'lines_total' => $total,
+                'lines_covered' => $covered,
+                'pct' => pct($covered, $total),
+            ];
+            ksort($totals);
             $out = [
                 'source' => 'clover',
                 'generated_at' => gmdate('Y-m-d\\TH:i:s\\Z'),
-                'totals' => [
-                    'lines_total' => $total,
-                    'lines_covered' => $covered,
-                    'pct' => pct($covered, $total),
-                ],
+                'totals' => $totals,
                 'files' => $files,
             ];
         }
@@ -127,22 +131,26 @@ foreach ($candidates as $cand) {
                 $path = rel_path((string)($f['path'] ?? ($f['file'] ?? '')), $root);
                 $fl = (int)($f['lines_total'] ?? $f['lines'] ?? 0);
                 $fc = (int)($f['lines_covered'] ?? $f['covered'] ?? 0);
-                $files[] = [
+                $row = [
                     'path' => $path,
                     'lines_total' => $fl,
                     'lines_covered' => $fc,
                     'pct' => pct($fc, $fl),
                 ];
+                ksort($row);
+                $files[] = $row;
             }
             usort($files, fn(array $a, array $b): int => strcmp($a['path'], $b['path']));
+            $totals = [
+                'lines_total' => $lt,
+                'lines_covered' => $lc,
+                'pct' => pct($lc, $lt),
+            ];
+            ksort($totals);
             $out = [
                 'source' => 'json',
                 'generated_at' => gmdate('Y-m-d\\TH:i:s\\Z'),
-                'totals' => [
-                    'lines_total' => $lt,
-                    'lines_covered' => $lc,
-                    'pct' => pct($lc, $lt),
-                ],
+                'totals' => $totals,
                 'files' => $files,
             ];
         }
@@ -153,6 +161,7 @@ foreach ($candidates as $cand) {
 }
 
 $tmp = $target . '.tmp';
+ksort($out);
 file_put_contents($tmp, json_encode($out, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_PRESERVE_ZERO_FRACTION) . "\n");
 rename($tmp, $target);
 

--- a/scripts/ga-enforcer.php
+++ b/scripts/ga-enforcer.php
@@ -203,9 +203,7 @@ if (is_file($vc)) {
 // coverage
 $signals['coverage_pct'] = null;
 $covJson = $root . '/artifacts/coverage/coverage.json';
-if (!is_file($covJson)) {
-    @passthru(PHP_BINARY . ' ' . escapeshellarg(__DIR__ . '/coverage-import.php'));
-}
+@passthru(PHP_BINARY . ' ' . escapeshellarg(__DIR__ . '/coverage-import.php'));
 if (is_file($covJson)) {
     $data = json_decode((string)file_get_contents($covJson), true);
     if (is_array($data)) {

--- a/tests/unit/Release/GAEnforcerCoverageTest.php
+++ b/tests/unit/Release/GAEnforcerCoverageTest.php
@@ -5,13 +5,12 @@ use PHPUnit\Framework\TestCase;
 
 final class GAEnforcerCoverageTest extends TestCase
 {
-    public function test_ga_profile_enforces_low_coverage(): void
+    public function test_artifacts_schema_junit_behavior(): void
     {
-        if (getenv('RUN_ENFORCE') !== '1') {
-            $this->markTestSkipped('opt-in');
-        }
-
         $rootArtifacts = __DIR__ . '/../../../artifacts';
+        if (is_dir($rootArtifacts)) {
+            exec('rm -rf ' . escapeshellarg($rootArtifacts));
+        }
         @mkdir($rootArtifacts . '/coverage', 0777, true);
         @mkdir($rootArtifacts . '/dist', 0777, true);
         @mkdir($rootArtifacts . '/i18n', 0777, true);
@@ -27,6 +26,9 @@ final class GAEnforcerCoverageTest extends TestCase
         $pot = ['pot_entries' => 10, 'domain_mismatch' => 0];
         file_put_contents($rootArtifacts . '/i18n/pot-refresh.json', json_encode($pot));
         file_put_contents($rootArtifacts . '/dist/sbom.json', '{}');
+        file_put_contents($rootArtifacts . '/dist/dist-audit.json', json_encode(['summary' => ['violations' => 0]]));
+        @mkdir($rootArtifacts . '/qa', 0777, true);
+        file_put_contents($rootArtifacts . '/qa/wporg-lint.json', json_encode(['readme' => [], 'assets' => []]));
 
         $clean = [
             'entries' => [


### PR DESCRIPTION
## Summary
- enforce canonical `manifest.json` entries and warn on legacy `files[]`
- ensure coverage importer and schema validator run under GA enforcer with JUnit `Artifacts.Schema`
- document canonical artifact formats and coverage search order

## Testing
- `php scripts/coverage-import.php`
- `php scripts/artifact-schema-validate.php`
- `php scripts/ga-enforcer.php --profile=rc --junit`
- `RUN_ENFORCE=1 php scripts/ga-enforcer.php --profile=ga --enforce --junit || echo "expected non-zero if thresholds not met"`
- `composer install --no-interaction --prefer-dist >/tmp/composer.log && tail -n 20 /tmp/composer.log`
- `vendor/bin/phpunit -c phpunit.xml.dist --filter GAEnforcerCoverageTest`


------
https://chatgpt.com/codex/tasks/task_e_68a739b230cc83218fa8c1d47b0158e7