### PR TITLE
Validate manifest schema and enforce warnings in GA

### DIFF
--- a/docs/AI_GUIDELINES.md
+++ b/docs/AI_GUIDELINES.md
@@ -27,8 +27,9 @@ where each object includes:
 { "path": "file.php", "sha256": "<64-hex>", "size": 123 }
 ```
 
-If a legacy `files[]` key is present, `artifact-schema-validate.php` emits an
-advisory warning. Missing or malformed manifests also raise warnings.
+`artifact-schema-validate.php` only inspects this manifest. A legacy `files[]`
+key triggers an advisory warning; missing or malformed manifests also raise
+warnings.
 
 ## GA Enforcer JUnit
 

--- a/docs/GA_ENFORCER.md
+++ b/docs/GA_ENFORCER.md
@@ -58,22 +58,12 @@ legacy files[] present; use entries[] as canonical
 
 ## Artifact Schema Validation
 
-`scripts/artifact-schema-validate.php` scans for malformed or incomplete JSON
-artifacts. It inspects, when present:
-
-* `artifacts/coverage/coverage.json`
-* `artifacts/qa/*.json`
-* `artifacts/dist/*.json`
-* `artifacts/i18n/*.json`
-
-Coverage and dist artifacts receive structural checks. The manifest requires a
-canonical `entries[]` array where each entry has a `path`, `sha256` (hex), and
-`size`. A legacy `files[]` array triggers the warning above. Downstream CI can
-rely on the JUnit testcase `Artifacts.Schema` to surface these warnings; it is
-always emitted, skipped in advisory runs, and fails when thresholds are
-exceeded under enforcement. `artifacts/qa/**/*.json` and
-`artifacts/i18n/**/*.json` are parsed only to verify they are valid JSON.
-Results are written to `artifacts/schema/schema-validate.json`:
+`scripts/artifact-schema-validate.php` validates only the distribution manifest
+under `artifacts/dist/manifest.json`. The manifest must contain a canonical
+`entries[]` array where each object includes a `path`, 64‑character `sha256`, and
+integer `size`. Missing manifests, empty or malformed `entries`, or a legacy
+`files[]` array produce advisory warnings. All warnings are sorted for
+deterministic output in `artifacts/schema/schema-validate.json`:
 
 ```json
 {
@@ -84,11 +74,11 @@ Results are written to `artifacts/schema/schema-validate.json`:
 }
 ```
 
-This validator is advisory; it never exits non‑zero. GA Enforcer consumes the
-warning count and may enforce thresholds when run with `--enforce`. JUnit
-reports always include a testcase `Artifacts.Schema`; it is marked skipped in
-advisory runs and fails when schema warnings exceed thresholds under
-enforcement.
+The validator is advisory and always exits zero. GA Enforcer consumes the
+warning count and may enforce thresholds when run with `--enforce`. Its JUnit
+report always includes a testcase `Artifacts.Schema`; advisory runs mark it
+skipped, and GA enforcement fails the testcase when schema warnings exceed the
+configured threshold.
 
 ### Profiles
 

--- a/scripts/artifact-schema-validate.php
+++ b/scripts/artifact-schema-validate.php
@@ -24,29 +24,6 @@ ensure_dir($schemaDir);
 
 $warnings = [];
 
-// coverage
-$cov = $artifacts . '/coverage/coverage.json';
-if (is_file($cov)) {
-    $raw = (string)file_get_contents($cov);
-    $data = json_decode($raw, true);
-    if (!is_array($data)) {
-        $warnings[] = ['file' => substr($cov, strlen($root) + 1), 'reason' => 'invalid JSON'];
-    } else {
-        $rel = substr($cov, strlen($root) + 1);
-        $tot = $data['totals']['pct'] ?? null;
-        if (!is_numeric($tot)) {
-            $warnings[] = ['file' => $rel, 'reason' => 'missing totals.pct'];
-        }
-        foreach ($data['files'] ?? [] as $idx => $f) {
-            foreach (['path', 'lines_total', 'lines_covered', 'pct'] as $field) {
-                if (!array_key_exists($field, $f)) {
-                    $warnings[] = ['file' => $rel, 'reason' => "files[$idx].$field missing"];
-                }
-            }
-        }
-    }
-}
-
 // dist manifest
 $manifest = $artifacts . '/dist/manifest.json';
 if (is_file($manifest)) {
@@ -79,25 +56,6 @@ if (is_file($manifest)) {
     }
 } else {
     $warnings[] = ['file' => substr($manifest, strlen($root) + 1), 'reason' => 'missing file'];
-}
-
-// qa and i18n JSON parseability
-foreach (['qa', 'i18n'] as $dir) {
-    $base = $artifacts . '/' . $dir;
-    if (!is_dir($base)) {
-        continue;
-    }
-    $iter = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($base));
-    foreach ($iter as $file) {
-        if ($file->isFile() && strtolower($file->getExtension()) === 'json') {
-            $path = $file->getPathname();
-            $raw = (string)file_get_contents($path);
-            json_decode($raw, true);
-            if (json_last_error() !== JSON_ERROR_NONE) {
-                $warnings[] = ['file' => substr($path, strlen($root) + 1), 'reason' => 'invalid JSON'];
-            }
-        }
-    }
 }
 
 usort(

--- a/scripts/coverage-import.php
+++ b/scripts/coverage-import.php
@@ -51,6 +51,7 @@ $candidates[] = $root . '/artifacts/coverage/clover.xml';
 $candidates[] = $root . '/coverage/clover.xml';
 $candidates[] = $root . '/clover.xml';
 $candidates[] = $root . '/artifacts/coverage/coverage.json';
+$candidates[] = $root . '/coverage/coverage.json';
 $candidates[] = $root . '/coverage.json';
 
 $out = [

--- a/scripts/ga-enforcer.php
+++ b/scripts/ga-enforcer.php
@@ -285,14 +285,18 @@ if (is_array($lintData)) {
 }
 
 // schema validation
-@passthru(PHP_BINARY.' '.escapeshellarg(__DIR__.'/artifact-schema-validate.php'));
+@passthru(PHP_BINARY . ' ' . escapeshellarg(__DIR__ . '/artifact-schema-validate.php'));
 $schemaPath = $root . '/artifacts/schema/schema-validate.json';
 $schemaWarn = null;
 if (is_file($schemaPath)) {
     $schemaData = json_decode((string)file_get_contents($schemaPath), true);
     if (is_array($schemaData)) {
         $schemaWarn = (int)($schemaData['count'] ?? 0);
+    } else {
+        $warnings[] = 'schema-validate.json parse failed';
     }
+} else {
+    $warnings[] = 'schema-validate.json missing';
 }
 $signals['schema_warnings'] = $schemaWarn;
 

--- a/tests/unit/Release/GAEnforcerCoverageTest.php
+++ b/tests/unit/Release/GAEnforcerCoverageTest.php
@@ -64,5 +64,8 @@ final class GAEnforcerCoverageTest extends TestCase
         $xml2 = (string)file_get_contents($junit);
         $this->assertMatchesRegularExpression('/<testcase name="Artifacts\.Schema">\s*<failure/s', $xml2);
         $this->assertDoesNotMatchRegularExpression('/<testcase name="Artifacts\.Schema">\s*<skipped/s', $xml2);
+
+        $report = json_decode((string)file_get_contents($rootArtifacts . '/ga/GA_ENFORCER.json'), true);
+        $this->assertGreaterThan(0, $report['signals']['schema_warnings'] ?? 0);
     }
 }


### PR DESCRIPTION
## Summary
- streamline artifact schema validation to manifest-only checks and canonical `entries` format
- expand coverage import search order and normalise coverage output
- ensure GA Enforcer records schema warnings and reports them via JUnit
- document manifest requirements, coverage search order, and Artifacts.Schema behaviour
- test GA enforcer JUnit behaviour under RC and GA enforcement

## Testing
- `php -l scripts/artifact-schema-validate.php`
- `php -l scripts/coverage-import.php`
- `php -l scripts/ga-enforcer.php`
- `vendor/bin/phpunit tests/unit/Release/GAEnforcerCoverageTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68a762e563988321813d8432df019da6