### PR TITLE
Add SQL prepare scanner and integrate with GA

### DIFF
--- a/docs/AI_GUIDELINES.md
+++ b/docs/AI_GUIDELINES.md
@@ -39,3 +39,11 @@ warnings.
 skipped; GA enforcement (`--profile=ga --enforce`) fails the testcase when
 schema warnings exceed configured thresholds.
 
+Before committing tooling or tests, run the SQL prepare scanner locally:
+
+```bash
+php scripts/scan-sql-prepare.php
+```
+
+Review and justify any allowlist entries in `tools/sql-allowlist.json`.
+

--- a/docs/GA_ENFORCER.md
+++ b/docs/GA_ENFORCER.md
@@ -80,6 +80,14 @@ report always includes a testcase `Artifacts.Schema`; advisory runs mark it
 skipped, and GA enforcement fails the testcase when schema warnings exceed the
 configured threshold.
 
+The SQL prepare scanner integrates similarly. GA Enforcer runs
+`scan-sql-prepare.php` automatically and emits a testcase `SQL.Prepare` in its
+JUnit output. Advisory and RC profiles mark the testcase skipped with a message
+containing the violation and allowlist counts. When run with
+`--profile=ga --enforce`, any non‑allowlisted violations cause the testcase to
+fail and the first few `file:line` locations are included in the failure
+message.
+
 ### Profiles
 
 * RC: `coverage_pct_min` 60, `schema_warnings` ≤ 3

--- a/docs/SQL_PREPARE_SCANNER.md
+++ b/docs/SQL_PREPARE_SCANNER.md
@@ -1,0 +1,76 @@
+# SQL Prepare Scanner
+
+This repository includes an opt‑in static scanner for detecting raw SQL
+queries that bypass `$wpdb->prepare()`. It is conservative: false negatives are
+tolerated but false positives are minimised.
+
+## Heuristics
+
+The scanner inspects PHP files under the given root and ignores `vendor/`,
+`node_modules/`, `.git/`, `artifacts/`, and `coverage/`. A violation is
+reported when:
+
+* A call to `$wpdb->{query,get_results,get_row,get_var,get_col}` receives a
+  string containing `SELECT`, `INSERT`, `UPDATE`, or `DELETE`.
+* The argument is not proven to be the result of `$wpdb->prepare()`.
+* One‑hop taint propagation is supported: assigning a raw SQL string to a
+  variable and later passing it to `$wpdb` triggers a violation unless the
+  variable originated from `$wpdb->prepare()`.
+* Inline `$wpdb->prepare()` calls and variables assigned from
+  `$wpdb->prepare()` are considered safe.
+
+## Allowlist
+
+Some legacy queries may be intentionally unprepared. These must be explicitly
+allowlisted in `tools/sql-allowlist.json`:
+
+```json
+{
+  "path/to/file.php": [
+    {
+      "fingerprint": "<sha1>",
+      "reason": "legacy dynamic query reviewed on 2025-08-21"
+    }
+  ]
+}
+```
+
+The `fingerprint` is `sha1(normalized(callsite_text))` where `normalized()`
+trims leading/trailing whitespace and collapses internal whitespace to a single
+space. The `callsite_text` is the SQL string or call expression that triggered
+the violation.
+
+To compute a fingerprint for a new allowlist entry:
+
+```bash
+echo -n "$(php -r 'echo preg_replace("/\\s+/", " ", trim("SELECT * FROM wp_posts"));')" | sha1sum
+```
+
+The allowlist is a last resort. Each entry must include a human justification
+and review date. Regularly revisit allowlisted queries to ensure they remain
+necessary.
+
+## Output
+
+Running `php scripts/scan-sql-prepare.php` writes
+`artifacts/security/sql-prepare.json` with deterministic contents:
+
+```json
+{
+  "generated_at_utc": "YYYY-MM-DDTHH:MM:SSZ",
+  "total_files_scanned": 0,
+  "violations": [
+    {
+      "file": "file.php",
+      "line": 123,
+      "call": "$wpdb->query",
+      "sql_preview": "SELECT …",
+      "fingerprint": "<sha1>",
+      "allowlisted": false
+    }
+  ],
+  "counts": {"violations": 0, "allowlisted": 0}
+}
+```
+
+The script always exits with code `0` to remain advisory by default.

--- a/scripts/scan-sql-prepare.php
+++ b/scripts/scan-sql-prepare.php
@@ -1,69 +1,246 @@
 <?php
 declare(strict_types=1);
 
-if (!function_exists('scan_sql_prepare')) {
-    function scan_sql_prepare(string $root, string $allowlistTag = '@security-ok-sql'): array
-    {
-        $violations = [];
-        $ignore = ['vendor', 'tests', 'dist', 'node_modules'];
-        $calls = ['query(', 'get_results(', 'get_row(', 'get_col(', 'update(', 'insert(', 'delete('];
+/**
+ * Scan PHP files for $wpdb calls using unprepared SQL.
+ *
+ * Outputs a deterministic JSON report at artifacts/security/sql-prepare.json.
+ * Always exits 0.
+ */
 
-        $iterator = new RecursiveIteratorIterator(
-            new RecursiveDirectoryIterator($root, FilesystemIterator::SKIP_DOTS)
-        );
-
-        foreach ($iterator as $file) {
-            if (!$file->isFile() || substr($file->getFilename(), -4) !== '.php') {
-                continue;
-            }
-            $path = str_replace('\\', '/', $file->getPathname());
-            $rel  = substr($path, strlen(rtrim($root, '/')) + 1);
-            foreach ($ignore as $dir) {
-                if (strpos($rel, $dir . '/') === 0 || strpos($rel, '/' . $dir . '/') !== false) {
-                    continue 2;
-                }
-            }
-
-            $lines = @file($path);
-            if ($lines === false) {
-                continue;
-            }
-            foreach ($lines as $i => $line) {
-                $found = false;
-                foreach ($calls as $call) {
-                    if (strpos($line, '$wpdb->' . $call) !== false) {
-                        $found = true;
-                        break;
-                    }
-                }
-                if (!$found) {
-                    continue;
-                }
-                $prev = $lines[$i - 1] ?? '';
-                $window = $prev . $line;
-                if (strpos($window, '$wpdb->prepare(') === false && strpos($window, $allowlistTag) === false) {
-                    $violations[] = [
-                        'file' => $rel,
-                        'line' => $i + 1,
-                        'snippet' => trim($line),
-                    ];
-                }
-            }
-        }
-
-        return $violations;
-    }
+/** Normalize whitespace for fingerprinting. */
+function sql_normalize(string $s): string
+{
+    return preg_replace('/\s+/', ' ', trim($s));
 }
 
-if (php_sapi_name() === 'cli' && realpath($argv[0] ?? '') === __FILE__) {
-    $allow = '@security-ok-sql';
-    foreach ($argv as $arg) {
-        if (strpos($arg, '--allowlist-tag=') === 0) {
-            $allow = substr($arg, strlen('--allowlist-tag='));
+/** Compute fingerprint for a callsite/SQL snippet. */
+function sql_fingerprint(string $s): string
+{
+    return sha1(sql_normalize($s));
+}
+
+/** Load allowlist map [file => [fingerprint => reason]]. */
+function sql_allowlist(string $root): array
+{
+    $file = $root . '/tools/sql-allowlist.json';
+    $map  = [];
+    if (is_file($file)) {
+        $data = json_decode((string)file_get_contents($file), true);
+        if (is_array($data)) {
+            foreach ($data as $path => $entries) {
+                $rel = str_replace('\\', '/', $path);
+                $map[$rel] = [];
+                if (is_array($entries)) {
+                    foreach ($entries as $row) {
+                        if (isset($row['fingerprint'])) {
+                            $map[$rel][$row['fingerprint']] = $row['reason'] ?? '';
+                        }
+                    }
+                }
+            }
         }
     }
-    $root = dirname(__DIR__);
-    $result = scan_sql_prepare($root, $allow);
-    echo json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . PHP_EOL;
+    return $map;
+}
+
+/**
+ * Scan the repository root for unprepared SQL.
+ *
+ * @return array{generated_at_utc:string,total_files_scanned:int,violations:array<int,array>,counts:array{violations:int,allowlisted:int}}
+ */
+function scan_sql_prepare(string $root): array
+{
+    $exclude = ['vendor', 'node_modules', '.git', 'artifacts', 'coverage'];
+    $allow   = sql_allowlist($root);
+
+    $iter = new RecursiveIteratorIterator(
+        new RecursiveCallbackFilterIterator(
+            new RecursiveDirectoryIterator($root, FilesystemIterator::SKIP_DOTS),
+            function ($current, $key, $iterator) use ($exclude) {
+                if ($iterator->hasChildren()) {
+                    return !in_array($current->getFilename(), $exclude, true);
+                }
+                return $current->isFile();
+            }
+        ),
+        RecursiveIteratorIterator::LEAVES_ONLY
+    );
+
+    $violations = [];
+    $filesScanned = 0;
+
+    foreach ($iter as $file) {
+        /** @var SplFileInfo $file */
+        if (substr($file->getFilename(), -4) !== '.php') {
+            continue;
+        }
+        $filesScanned++;
+        $path = str_replace('\\', '/', $file->getPathname());
+        $rel  = substr($path, strlen(rtrim($root, '/')) + 1);
+        $code = (string)file_get_contents($path);
+        $tokens = token_get_all($code);
+        $prepared = [];
+        $raw = [];
+        $count = count($tokens);
+        for ($i = 0; $i < $count; $i++) {
+            $tok = $tokens[$i];
+            $line = is_array($tok) ? $tok[2] : 0;
+
+            // Track assignments for one hop tainting.
+            if (is_array($tok) && $tok[0] === T_VARIABLE) {
+                $var = $tok[1];
+                $j = $i + 1;
+                while ($j < $count && is_array($tokens[$j]) && in_array($tokens[$j][0], [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT], true)) {
+                    $j++;
+                }
+                if ($j < $count && $tokens[$j] === '=') {
+                    $j++;
+                    $expr = '';
+                    $depth = 0;
+                    for (; $j < $count; $j++) {
+                        $t = $tokens[$j];
+                        if ($t === ';' && $depth === 0) {
+                            break;
+                        }
+                        if ($t === '(') {
+                            $depth++;
+                        } elseif ($t === ')') {
+                            $depth--;
+                        }
+                        $expr .= is_array($t) ? $t[1] : $t;
+                    }
+                    if (stripos($expr, '$wpdb->prepare(') !== false) {
+                        $prepared[$var] = true;
+                        unset($raw[$var]);
+                    } elseif (preg_match('/\b(SELECT|INSERT|UPDATE|DELETE)\b/i', $expr)) {
+                        $raw[$var] = trim($expr);
+                        unset($prepared[$var]);
+                    }
+                    $i = $j;
+                    continue;
+                }
+            }
+
+            // Detect $wpdb->calls
+            if (is_array($tok) && $tok[0] === T_VARIABLE && $tok[1] === '$wpdb') {
+                $j = $i + 1;
+                while ($j < $count && is_array($tokens[$j]) && $tokens[$j][0] === T_WHITESPACE) {
+                    $j++;
+                }
+                if ($j < $count && $tokens[$j][0] === T_OBJECT_OPERATOR) {
+                    $j++;
+                    while ($j < $count && is_array($tokens[$j]) && $tokens[$j][0] === T_WHITESPACE) {
+                        $j++;
+                    }
+                    if ($j < $count && is_array($tokens[$j]) && $tokens[$j][0] === T_STRING) {
+                        $name = $tokens[$j][1];
+                        if (in_array($name, ['query', 'get_results', 'get_row', 'get_var', 'get_col'], true)) {
+                            $callLine = $line;
+                            $j++;
+                            while ($j < $count && is_array($tokens[$j]) && $tokens[$j][0] === T_WHITESPACE) {
+                                $j++;
+                            }
+                            if ($j < $count && $tokens[$j] === '(') {
+                                $j++;
+                                $arg = '';
+                                $depth = 0;
+                                for (; $j < $count; $j++) {
+                                    $t = $tokens[$j];
+                                    if ($t === ',' && $depth === 0) {
+                                        break;
+                                    }
+                                    if ($t === '(') {
+                                        $depth++;
+                                    } elseif ($t === ')') {
+                                        if ($depth === 0) {
+                                            break;
+                                        }
+                                        $depth--;
+                                    }
+                                    $arg .= is_array($t) ? $t[1] : $t;
+                                }
+                                $argStr = trim($arg);
+                                $hasSql = preg_match('/\b(SELECT|INSERT|UPDATE|DELETE)\b/i', $argStr);
+                                $isPrepared = stripos($argStr, '$wpdb->prepare(') !== false;
+                                $violation = null;
+                                if ($isPrepared) {
+                                    // safe
+                                } elseif (preg_match('/^\s*(\$[A-Za-z_][A-Za-z0-9_]*)\s*$/', $argStr, $m)) {
+                                    $vn = $m[1];
+                                    if (isset($prepared[$vn])) {
+                                        // safe
+                                    } elseif (isset($raw[$vn]) && preg_match('/\b(SELECT|INSERT|UPDATE|DELETE)\b/i', $raw[$vn])) {
+                                        $violation = $raw[$vn];
+                                    }
+                                } elseif ($hasSql) {
+                                    $violation = $argStr;
+                                }
+                                if ($violation !== null) {
+                                    $preview = sql_normalize($violation);
+                                    if (strlen($preview) > 200) {
+                                        $preview = substr($preview, 0, 200) . '...';
+                                    }
+                                    $finger = sql_fingerprint($preview);
+                                    $allowlisted = ($allow[$rel][$finger] ?? null) !== null;
+                                    $row = [
+                                        'file' => $rel,
+                                        'line' => $callLine,
+                                        'call' => '$wpdb->' . $name,
+                                        'sql_preview' => $preview,
+                                        'fingerprint' => $finger,
+                                        'allowlisted' => $allowlisted,
+                                    ];
+                                    ksort($row);
+                                    $violations[] = $row;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    usort($violations, function (array $a, array $b): int {
+        $c = strcmp($a['file'], $b['file']);
+        if ($c !== 0) {
+            return $c;
+        }
+        return $a['line'] <=> $b['line'];
+    });
+
+    $v = 0; $a = 0;
+    foreach ($violations as $row) {
+        if ($row['allowlisted']) {
+            $a++;
+        } else {
+            $v++;
+        }
+    }
+    $counts = ['violations' => $v, 'allowlisted' => $a];
+    ksort($counts);
+
+    $report = [
+        'generated_at_utc' => gmdate('Y-m-d\TH:i:s\Z'),
+        'total_files_scanned' => $filesScanned,
+        'violations' => $violations,
+        'counts' => $counts,
+    ];
+    ksort($report);
+
+    $out = $root . '/artifacts/security/sql-prepare.json';
+    if (!is_dir(dirname($out))) {
+        @mkdir(dirname($out), 0777, true);
+    }
+    file_put_contents($out, json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n");
+
+    return $report;
+}
+
+if (PHP_SAPI === 'cli' && realpath($argv[0] ?? '') === __FILE__) {
+    $root = $argv[1] ?? dirname(__DIR__);
+    $rep = scan_sql_prepare($root);
+    echo json_encode($rep, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . PHP_EOL;
     exit(0);
 }

--- a/tests/unit/Release/GAEnforcerSqlPrepareTest.php
+++ b/tests/unit/Release/GAEnforcerSqlPrepareTest.php
@@ -1,0 +1,94 @@
+<?php
+declare(strict_types=1);
+
+namespace SmartAlloc\Tests\Release;
+
+use PHPUnit\Framework\TestCase;
+
+final class GAEnforcerSqlPrepareTest extends TestCase
+{
+    private string $dir;
+
+    protected function setUp(): void
+    {
+        $this->dir = sys_get_temp_dir() . '/ga-sql-' . uniqid();
+        mkdir($this->dir, 0777, true);
+        mkdir($this->dir . '/scripts', 0777, true);
+        mkdir($this->dir . '/artifacts/security', 0777, true);
+        mkdir($this->dir . '/artifacts/ga', 0777, true);
+        mkdir($this->dir . '/artifacts/coverage', 0777, true);
+        mkdir($this->dir . '/artifacts/schema', 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->rm($this->dir);
+    }
+
+    private function rm(string $path): void
+    {
+        if (!is_dir($path)) {
+            @unlink($path);
+            return;
+        }
+        $it = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+        foreach ($it as $item) {
+            if ($item->isDir()) {
+                @rmdir($item->getPathname());
+            } else {
+                @unlink($item->getPathname());
+            }
+        }
+        @rmdir($path);
+    }
+
+    private function write(string $relative, string $content): void
+    {
+        $path = $this->dir . '/' . $relative;
+        $dir = dirname($path);
+        if (!is_dir($dir)) {
+            mkdir($dir, 0777, true);
+        }
+        file_put_contents($path, $content);
+    }
+
+    public function test_sql_prepare_junit_behaviour(): void
+    {
+        $scripts = ['ga-enforcer.php', 'coverage-import.php', 'artifact-schema-validate.php'];
+        foreach ($scripts as $s) {
+            $src = dirname(__DIR__, 3) . '/scripts/' . $s;
+            $this->write('scripts/' . $s, file_get_contents($src));
+        }
+        // stub scanner
+        $this->write('scripts/scan-sql-prepare.php', "<?php\nexit(0);\n");
+
+        $report = [
+            'generated_at_utc' => '2025-01-01T00:00:00Z',
+            'total_files_scanned' => 1,
+            'violations' => [
+                ['file' => 'bad.php', 'line' => 1, 'call' => '$wpdb->query', 'sql_preview' => 'SELECT 1', 'fingerprint' => 'x', 'allowlisted' => false],
+            ],
+            'counts' => ['violations' => 1, 'allowlisted' => 0],
+        ];
+        $this->write('artifacts/security/sql-prepare.json', json_encode($report));
+
+        $cmd = 'php ' . escapeshellarg($this->dir . '/scripts/ga-enforcer.php') . ' --profile=rc --junit';
+        exec($cmd, $out, $code);
+        $this->assertSame(0, $code);
+        $xml = simplexml_load_file($this->dir . '/artifacts/ga/GA_ENFORCER.junit.xml');
+        $case = $xml->xpath('//testcase[@name="SQL.Prepare"]')[0];
+        $this->assertTrue(isset($case->skipped));
+        $this->assertStringContainsString('violations=1', (string)$case->skipped['message']);
+
+        $cmd = 'php ' . escapeshellarg($this->dir . '/scripts/ga-enforcer.php') . ' --profile=ga --enforce --junit';
+        exec($cmd, $out, $code);
+        $this->assertSame(1, $code);
+        $xml = simplexml_load_file($this->dir . '/artifacts/ga/GA_ENFORCER.junit.xml');
+        $case = $xml->xpath('//testcase[@name="SQL.Prepare"]')[0];
+        $this->assertTrue(isset($case->failure));
+        $this->assertStringContainsString('bad.php:1', (string)$case->failure['message']);
+    }
+}

--- a/tests/unit/Security/SqlPrepareScannerTest.php
+++ b/tests/unit/Security/SqlPrepareScannerTest.php
@@ -1,0 +1,63 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use org\bovigo\vfs\vfsStream;
+
+require_once dirname(__DIR__, 3) . '/scripts/scan-sql-prepare.php';
+
+final class SqlPrepareScannerTest extends TestCase
+{
+    /** Mirror vfs directory to real filesystem for CLI execution. */
+    private function mirror(string $src, string $dst): void
+    {
+        $it = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($src, FilesystemIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::SELF_FIRST
+        );
+        foreach ($it as $item) {
+            $target = $dst . '/' . $it->getSubPathName();
+            if ($item->isDir()) {
+                @mkdir($target, 0777, true);
+            } else {
+                @mkdir(dirname($target), 0777, true);
+                file_put_contents($target, file_get_contents($item->getPathname()));
+            }
+        }
+    }
+
+    public function test_scanner_reports_and_allowlists(): void
+    {
+        $root = vfsStream::setup('root', null, [
+            'safe-inline.php' => '<?php global $wpdb; $wpdb->get_results($wpdb->prepare("SELECT * FROM t WHERE id=%d",1));',
+            'safe-var.php' => '<?php global $wpdb; $sql=$wpdb->prepare("SELECT * FROM t WHERE id=%d",1); $wpdb->query($sql);',
+            'unsafe.php' => '<?php global $wpdb; $wpdb->query("SELECT * FROM t WHERE id=$id");',
+            'allowlisted.php' => '<?php global $wpdb; $wpdb->get_var("SELECT NOW()");',
+            'tools' => []
+        ]);
+        $finger = sha1('"SELECT NOW()"');
+        file_put_contents(vfsStream::url('root/tools/sql-allowlist.json'), json_encode([
+            'allowlisted.php' => [
+                ['fingerprint' => $finger, 'reason' => 'test']
+            ]
+        ]));
+
+        $tmp = sys_get_temp_dir() . '/sqlscan' . uniqid();
+        $this->mirror(vfsStream::url('root'), $tmp);
+
+        $cmd = 'php ' . escapeshellarg(dirname(__DIR__, 3) . '/scripts/scan-sql-prepare.php') . ' ' . escapeshellarg($tmp);
+        exec($cmd, $output, $code);
+        $this->assertSame(0, $code);
+
+        $json = file_get_contents($tmp . '/artifacts/security/sql-prepare.json');
+        $report = json_decode($json, true);
+
+        $this->assertSame(4, $report['total_files_scanned']);
+        $this->assertSame(['allowlisted' => 1, 'violations' => 1], $report['counts']);
+        $this->assertCount(2, $report['violations']);
+        $this->assertSame('allowlisted.php', $report['violations'][0]['file']);
+        $this->assertTrue($report['violations'][0]['allowlisted']);
+        $this->assertSame('unsafe.php', $report['violations'][1]['file']);
+        $this->assertFalse($report['violations'][1]['allowlisted']);
+    }
+}


### PR DESCRIPTION
## Summary
- add static SQL prepare scanner with allowlist support
- surface scanner counts in QA report
- enforce SQL prepare results via GA Enforcer with dedicated JUnit testcase

## Testing
- `vendor/bin/phpunit tests/unit/Security/SqlPrepareScannerTest.php tests/unit/Release/GAEnforcerSqlPrepareTest.php`
- `php scripts/coverage-import.php`
- `php scripts/artifact-schema-validate.php`
- `php scripts/ga-enforcer.php --profile=rc --junit`


------
https://chatgpt.com/codex/tasks/task_e_68a769b70c8c83218820aa7f23163ab9