### PR TITLE
Add security headers guard and QA aggregation

### DIFF
--- a/docs/QA_ORCHESTRATOR.md
+++ b/docs/QA_ORCHESTRATOR.md
@@ -1,0 +1,21 @@
+# QA Orchestrator
+
+`scripts/qa-orchestrator.sh` runs advisory quality checks and gathers their
+artifacts. Each step is optional; missing tools are skipped and the script
+always exits with zero.
+
+After invoking available scanners it builds an index at
+`artifacts/qa/index.html`. The index is rendered with `dir="rtl"` and links
+to the JSON or HTML reports for:
+
+- coverage/coverage.json
+- schema/schema-validate.json
+- security/sql-prepare.json
+- security/rest-permissions.json
+- security/secrets.json
+- compliance/license-audit.json
+- security/headers.json
+- qa-report.html / qa-report.json
+
+The index uses relative paths so the entire `artifacts` directory can be
+shared as-is.

--- a/docs/SECURITY_HEADERS.md
+++ b/docs/SECURITY_HEADERS.md
@@ -1,0 +1,18 @@
+# Security Headers
+
+The `scripts/headers-guard.php` utility checks HTTP responses for common
+security headers. The following headers are expected:
+
+- Content-Security-Policy
+- X-Frame-Options
+- X-Content-Type-Options
+- Referrer-Policy
+- Permissions-Policy
+
+If a header is intentionally omitted in certain environments, list it in
+the allowlist below. The guard will ignore missing headers that appear
+here.
+
+## Allowlist
+
+(No allowlisted headers.)

--- a/scripts/headers-guard.php
+++ b/scripts/headers-guard.php
@@ -1,0 +1,136 @@
+#!/usr/bin/env php
+<?php
+declare(strict_types=1);
+
+/**
+ * Scan HTTP response headers and report missing security headers.
+ * Advisory and deterministic; exits 0 always.
+ */
+
+const HG_REQUIRED_HEADERS = [
+    'Content-Security-Policy',
+    'Permissions-Policy',
+    'Referrer-Policy',
+    'X-Content-Type-Options',
+    'X-Frame-Options',
+];
+
+/** Load allowlist entries from docs/SECURITY_HEADERS.md. */
+function hg_load_allowlist(string $file): array
+{
+    if (!is_file($file)) {
+        return [];
+    }
+    $lines = file($file, FILE_IGNORE_NEW_LINES);
+    if ($lines === false) {
+        return [];
+    }
+    $allow = [];
+    $in = false;
+    foreach ($lines as $line) {
+        if (preg_match('/^##\s+Allowlist/i', $line)) {
+            $in = true;
+            continue;
+        }
+        if ($in && str_starts_with(trim($line), '##')) {
+            break;
+        }
+        if ($in && preg_match('/^-\s*(.+)/', trim($line), $m)) {
+            $allow[] = strtolower($m[1]);
+        }
+    }
+    sort($allow);
+    return $allow;
+}
+
+/** Analyse headers against required list. */
+function hg_analyze(array $headers, array $allow): array
+{
+    $out = [];
+    $present = 0;
+    $missing = 0;
+    $allowlisted = 0;
+    foreach (HG_REQUIRED_HEADERS as $h) {
+        $value = null;
+        foreach ($headers as $k => $v) {
+            if (strcasecmp($k, $h) === 0) {
+                $value = trim((string)$v);
+                break;
+            }
+        }
+        $out[$h] = $value;
+        if ($value !== null && $value !== '') {
+            $present++;
+        } elseif (in_array(strtolower($h), $allow, true)) {
+            $allowlisted++;
+        } else {
+            $missing++;
+        }
+    }
+    ksort($out);
+    return [
+        'headers' => $out,
+        'counts' => [
+            'present' => $present,
+            'missing' => $missing,
+            'allowlisted' => $allowlisted,
+        ],
+        'notes' => [],
+    ];
+}
+
+/** Fetch headers via curl -I. */
+function hg_fetch(string $url): array
+{
+    $raw = shell_exec('curl -fsI ' . escapeshellarg($url) . ' 2>/dev/null');
+    if (!is_string($raw) || $raw === '') {
+        return [];
+    }
+    $lines = preg_split('/\r?\n/', trim($raw));
+    $headers = [];
+    foreach ($lines as $line) {
+        if (strpos($line, ':') === false) {
+            continue;
+        }
+        [$k, $v] = explode(':', $line, 2);
+        $headers[trim($k)] = trim($v);
+    }
+    return $headers;
+}
+
+/** Execute scan and emit report. */
+function hg_scan(string $url, string $allowFile, string $outFile): array
+{
+    $allow = hg_load_allowlist($allowFile);
+    $headers = hg_fetch($url);
+    if ($headers === []) {
+        $report = [
+            'generated_at_utc' => gmdate('Y-m-d\TH:i:s\Z'),
+            'headers' => [],
+            'counts' => ['present' => 0, 'missing' => 0, 'allowlisted' => 0],
+            'notes' => ['fetch_failed'],
+        ];
+    } else {
+        $report = hg_analyze($headers, $allow);
+        $report['generated_at_utc'] = gmdate('Y-m-d\TH:i:s\Z');
+    }
+    ksort($report);
+    if (!is_dir(dirname($outFile))) {
+        @mkdir(dirname($outFile), 0777, true);
+    }
+    file_put_contents($outFile, json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n");
+    return $report;
+}
+
+if (PHP_SAPI === 'cli' && realpath($_SERVER['argv'][0] ?? '') === __FILE__) {
+    $root = dirname(__DIR__);
+    $opts = getopt('', ['url::','allowlist::','output::','q']);
+    $url = $opts['url'] ?? 'http://localhost';
+    $allow = $opts['allowlist'] ?? ($root . '/docs/SECURITY_HEADERS.md');
+    $out = $opts['output'] ?? ($root . '/artifacts/security/headers.json');
+    $report = hg_scan($url, $allow, $out);
+    if (!isset($opts['q'])) {
+        echo json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . PHP_EOL;
+    }
+    exit(0);
+}

--- a/scripts/scan-rest-permissions.php
+++ b/scripts/scan-rest-permissions.php
@@ -225,7 +225,7 @@ function rp_rel(string $path): string
     return $path;
 }
 
-if (PHP_SAPI === 'cli' && realpath($argv[0]) === __FILE__) {
+if (PHP_SAPI === 'cli' && realpath($_SERVER['argv'][0] ?? '') === __FILE__) {
     $opts = getopt('', ['output::','allowlist::','q']);
     $root = dirname(__DIR__);
     foreach ($argv as $i => $a) {

--- a/tests/integration/QAOrchestratorTest.php
+++ b/tests/integration/QAOrchestratorTest.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class QAOrchestratorTest extends TestCase
+{
+    public function test_index_generated_with_rtl(): void
+    {
+        $root = sys_get_temp_dir() . '/qa-orch-' . uniqid();
+        mkdir($root . '/scripts', 0777, true);
+        mkdir($root . '/artifacts/coverage', 0777, true);
+        mkdir($root . '/artifacts/schema', 0777, true);
+        copy(dirname(__DIR__, 2) . '/scripts/qa-orchestrator.sh', $root . '/scripts/qa-orchestrator.sh');
+        chmod($root . '/scripts/qa-orchestrator.sh', 0755);
+        file_put_contents($root . '/artifacts/coverage/coverage.json', '{}');
+        file_put_contents($root . '/artifacts/schema/schema-validate.json', '{}');
+        $cmd = 'bash ' . escapeshellarg($root . '/scripts/qa-orchestrator.sh') . ' >/dev/null 2>&1';
+        $code = 0;
+        system($cmd, $code);
+        $this->assertSame(0, $code);
+        $index = $root . '/artifacts/qa/index.html';
+        $this->assertFileExists($index);
+        $html = (string)file_get_contents($index);
+        $this->assertStringContainsString('dir="rtl"', $html);
+        $this->assertStringContainsString('coverage/coverage.json', $html);
+        $this->assertStringContainsString('schema/schema-validate.json', $html);
+    }
+}

--- a/tests/unit/Security/HeadersGuardTest.php
+++ b/tests/unit/Security/HeadersGuardTest.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
+require_once dirname(__DIR__, 3) . '/scripts/headers-guard.php';
+
 /**
  * Ensure security headers are applied when available.
  * Test is advisory and skipped if the plugin does not expose the
@@ -39,6 +41,21 @@ final class HeadersGuardTest extends TestCase
             'strict-origin-when-cross-origin',
         ];
         $this->assertContains($ref, $allowed);
+    }
+
+    public function test_analyze_reports_missing_and_present(): void
+    {
+        $report = hg_analyze([], []);
+        $this->assertSame(count(HG_REQUIRED_HEADERS), $report['counts']['missing']);
+        $this->assertSame(0, $report['counts']['present']);
+
+        $all = [];
+        foreach (HG_REQUIRED_HEADERS as $h) {
+            $all[$h] = 'v';
+        }
+        $report = hg_analyze($all, []);
+        $this->assertSame(count(HG_REQUIRED_HEADERS), $report['counts']['present']);
+        $this->assertSame(0, $report['counts']['missing']);
     }
 }
 


### PR DESCRIPTION
## Summary
- add `headers-guard.php` to scan HTTP responses and report missing security headers with allowlist
- enhance GA enforcer and QA report to include headers scan and produce RTL QA index
- document QA orchestrator and security headers policies; add tests for headers guard and orchestrator

## Testing
- `vendor/bin/phpunit tests/unit/Security/HeadersGuardTest.php tests/integration/QAOrchestratorTest.php`

------
https://chatgpt.com/codex/tasks/task_e_68a7c0d60e6483218041aca33ec92114