### PR TITLE
feat: add release audit tooling

### DIFF
--- a/docs/DIST_AUDIT.md
+++ b/docs/DIST_AUDIT.md
@@ -1,0 +1,22 @@
+# Distribution Audit
+
+`dist-build.php` assembles the release package under `dist/SmartAlloc/`.
+Only production files are copied. Excluded paths:
+
+- `.git/`
+- `node_modules/`
+- `vendor/*dev*/`
+- `tests/`
+- `.github/`
+- `artifacts/`
+- `coverage/`
+- `*.md` files except `readme.txt`
+
+Files and directories are copied in deterministic sorted order. Text files
+have their line endings normalised to LF. All files are set to `0644` and
+directories to `0755`.
+
+`dist-audit.php` inspects the built package and emits
+`artifacts/dist/audit.json` containing any advisory warnings such as
+unexpected developer artefacts, missing plugin headers or readme, and
+text‑domain inconsistencies.

--- a/docs/GA_ENFORCER.md
+++ b/docs/GA_ENFORCER.md
@@ -80,6 +80,11 @@ report always includes a testcase `Artifacts.Schema`; advisory runs mark it
 skipped, and GA enforcement fails the testcase when schema warnings exceed the
 configured threshold.
 
+GA Enforcer also emits a testcase `Dist.Manifest`. It aggregates warnings from
+the manifest, version coherence and readme linting steps. RC/advisory runs mark
+the testcase skipped. Under `--profile=ga --enforce` the testcase fails when
+`dist_manifest_warnings` (default `0`) is exceeded.
+
 The SQL prepare scanner integrates similarly. GA Enforcer runs
 `scan-sql-prepare.php` automatically and emits a testcase `SQL.Prepare` in its
 JUnit output. Advisory and RC profiles mark the testcase skipped with a message

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -1,0 +1,14 @@
+# Release Checklist
+
+1. `php scripts/dist-build.php`
+2. `php scripts/dist-manifest.php`
+3. `php scripts/dist-audit.php`
+4. `php scripts/version-coherence.php`
+5. `php scripts/validate-readme.php`
+6. `php scripts/sbom-from-composer.php`
+7. `php scripts/tag-preflight.php`
+8. `bash scripts/tag-dry-run.sh`
+
+Inspect artifacts under `artifacts/dist/` and `artifacts/release/` for any
+warnings. `tag-preflight.php --enforce` exits non‑zero when blocking
+warnings are present.

--- a/scripts/dist-audit.php
+++ b/scripts/dist-audit.php
@@ -8,7 +8,7 @@ $violations = [];
 $summary = ['scanned' => 0];
 
 if ($path === null) {
-    echo json_encode(['summary' => ['scanned' => 0, 'error' => 'path not found'], 'violations' => []], JSON_PRETTY_PRINT) . PHP_EOL;
+    echo json_encode(['summary' => ['scanned' => 0, 'error' => 'path not found'], 'warnings' => []], JSON_PRETTY_PRINT) . PHP_EOL;
     exit(0);
 }
 
@@ -134,10 +134,15 @@ if (!is_file($readme)) {
     }
 }
 
-$summary['violations'] = count($violations);
-$result = ['summary' => $summary, 'violations' => $violations];
-
-echo json_encode($result, JSON_PRETTY_PRINT) . PHP_EOL;
+$summary['warnings'] = count($violations);
+$result = ['summary' => $summary, 'warnings' => $violations];
+$outDir = $root . '/artifacts/dist';
+if (!is_dir($outDir)) {
+    mkdir($outDir, 0777, true);
+}
+$json = json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+file_put_contents($outDir . '/audit.json', $json . PHP_EOL);
+echo $json . PHP_EOL;
 
 if ($cleanup !== null) {
     cleanupDir($cleanup);

--- a/scripts/dist-build.php
+++ b/scripts/dist-build.php
@@ -1,0 +1,79 @@
+<?php
+declare(strict_types=1);
+
+$root = dirname(__DIR__);
+$src  = $argv[1] ?? $root;
+$destBase = $argv[2] ?? ($root . '/dist');
+$dest = rtrim($destBase, '/\\') . '/SmartAlloc';
+
+if (is_dir($dest)) {
+    $it = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($dest, FilesystemIterator::SKIP_DOTS),
+        RecursiveIteratorIterator::CHILD_FIRST
+    );
+    foreach ($it as $file) {
+        $file->isDir() ? rmdir($file->getPathname()) : unlink($file->getPathname());
+    }
+    rmdir($dest);
+}
+
+$files = [];
+$iter = new RecursiveIteratorIterator(
+    new RecursiveDirectoryIterator($src, FilesystemIterator::SKIP_DOTS),
+    RecursiveIteratorIterator::SELF_FIRST
+);
+foreach ($iter as $info) {
+    $rel = substr($info->getPathname(), strlen($src) + 1);
+    $relPosix = str_replace('\\', '/', $rel);
+    if (shouldExclude($relPosix, $info->isDir())) {
+        continue;
+    }
+    $files[$relPosix] = $info;
+}
+ksort($files);
+
+foreach ($files as $rel => $info) {
+    $target = $dest . '/' . $rel;
+    if ($info->isDir()) {
+        if (!is_dir($target)) {
+            mkdir($target, 0755, true);
+        }
+        chmod($target, 0755);
+        continue;
+    }
+    $dir = dirname($target);
+    if (!is_dir($dir)) {
+        mkdir($dir, 0755, true);
+    }
+    $content = file_get_contents($info->getPathname());
+    if ($content !== false && strpos($content, "\0") === false) {
+        $content = str_replace(["\r\n", "\r"], "\n", $content);
+    }
+    file_put_contents($target, $content);
+    chmod($target, 0644);
+}
+
+exit(0);
+
+function shouldExclude(string $rel, bool $isDir): bool {
+    $patterns = [
+        '#^\.git(/|$)#',
+        '#^node_modules(/|$)#',
+        '#^vendor/[^/]*dev[^/]*(/|$)#i',
+        '#^tests(/|$)#',
+        '#^\.github(/|$)#',
+        '#^artifacts(/|$)#',
+        '#^coverage(/|$)#',
+    ];
+    foreach ($patterns as $p) {
+        if (preg_match($p, $rel)) {
+            return true;
+        }
+    }
+    if (!$isDir) {
+        if (preg_match('/\.md$/i', $rel) && strtolower($rel) !== 'readme.txt') {
+            return true;
+        }
+    }
+    return false;
+}

--- a/scripts/dist-manifest.php
+++ b/scripts/dist-manifest.php
@@ -2,76 +2,35 @@
 declare(strict_types=1);
 
 $root = dirname(__DIR__);
-$argPath = $argv[1] ?? '';
-$path = resolvePath($argPath, $root);
-$files = [];
-
-if ($path !== null) {
-    if (is_file($path) && preg_match('/\.zip$/i', $path)) {
-        $zip = new ZipArchive();
-        if ($zip->open($path) === true) {
-            for ($i = 0; $i < $zip->numFiles; $i++) {
-                $stat = $zip->statIndex($i);
-                $name = $stat['name'];
-                if (str_ends_with($name, '/')) {
-                    continue;
-                }
-                $content = $zip->getFromIndex($i);
-                $files[] = [
-                    'path' => $name,
-                    'sha256' => hash('sha256', (string)$content),
-                    'size' => (int)($stat['size'] ?? strlen((string)$content)),
-                ];
-            }
-            $zip->close();
-        }
-    } elseif (is_dir($path)) {
-        $iter = new RecursiveIteratorIterator(
-            new RecursiveDirectoryIterator($path, FilesystemIterator::SKIP_DOTS)
-        );
-        foreach ($iter as $fileinfo) {
-            if ($fileinfo->isFile()) {
-                $rel = substr($fileinfo->getPathname(), strlen($path) + 1);
-                $files[] = [
-                    'path' => str_replace('\\', '/', $rel),
-                    'sha256' => hash_file('sha256', $fileinfo->getPathname()),
-                    'size' => (int)$fileinfo->getSize(),
-                ];
-            }
+$scanPath = $argv[1] ?? ($root . '/dist/SmartAlloc');
+if (!is_dir($scanPath)) {
+    $scanPath = $root . '/dist';
+}
+$entries = [];
+if (is_dir($scanPath)) {
+    $it = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($scanPath, FilesystemIterator::SKIP_DOTS)
+    );
+    foreach ($it as $info) {
+        if ($info->isFile()) {
+            $rel = substr($info->getPathname(), strlen($scanPath) + 1);
+            $rel = str_replace('\\', '/', $rel);
+            $entries[] = [
+                'path' => $rel,
+                'sha256' => hash_file('sha256', $info->getPathname()),
+                'size' => (int)$info->getSize(),
+            ];
         }
     }
 }
-
-$files = array_values($files);
-usort($files, fn(array $a, array $b): int => strcmp($a['path'], $b['path']));
-
-$manifestDir = $root . '/artifacts/dist';
-if (!is_dir($manifestDir)) {
-    mkdir($manifestDir, 0777, true);
+usort($entries, static fn($a, $b) => strcmp($a['path'], $b['path']));
+$outDir = $root . '/artifacts/dist';
+if (!is_dir($outDir)) {
+    mkdir($outDir, 0777, true);
 }
-file_put_contents(
-    $manifestDir . '/manifest.json',
-    json_encode([
-        'entries' => $files,
-        // legacy alias maintained for backward compatibility
-        'files' => $files,
-    ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)
-);
-
+$manifest = [
+    'entries' => $entries,
+    'generated_at_utc' => gmdate('c'),
+];
+file_put_contents($outDir . '/manifest.json', json_encode($manifest, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n");
 exit(0);
-
-function resolvePath(string $arg, string $root): ?string {
-    if ($arg !== '') {
-        $real = realpath($arg);
-        return $real !== false ? $real : null;
-    }
-    $dist = $root . '/dist';
-    if (is_dir($dist) || is_file($dist)) {
-        return $dist;
-    }
-    $zips = glob($root . '/build/*.zip');
-    if (!empty($zips)) {
-        return $zips[0];
-    }
-    return null;
-}

--- a/scripts/sbom-from-composer.php
+++ b/scripts/sbom-from-composer.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-$root = dirname(__DIR__);
+$root = $argv[1] ?? dirname(__DIR__);
 $lockFile = $root . '/composer.lock';
 $packages = [];
 if (is_file($lockFile)) {
@@ -12,7 +12,6 @@ if (is_file($lockFile)) {
                 'name' => $pkg['name'] ?? '',
                 'version' => $pkg['version'] ?? '',
                 'license' => $pkg['license'][0] ?? '',
-                'type' => 'composer',
             ];
             $sha = $pkg['dist']['sha256'] ?? ($pkg['dist']['shasum'] ?? '');
             if ($sha !== '') {
@@ -22,12 +21,13 @@ if (is_file($lockFile)) {
         }
     }
 }
+usort($packages, static fn($a, $b) => strcmp($a['name'], $b['name']));
 $destDir = $root . '/artifacts/dist';
 if (!is_dir($destDir)) {
     mkdir($destDir, 0777, true);
 }
 $sbomFile = $destDir . '/sbom.json';
-file_put_contents($sbomFile, json_encode(['packages' => $packages], JSON_PRETTY_PRINT) . PHP_EOL);
-$result = ['summary' => ['written' => is_file($sbomFile), 'count' => count($packages)]];
-echo json_encode($result, JSON_PRETTY_PRINT) . PHP_EOL;
+file_put_contents($sbomFile, json_encode(['packages' => $packages], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . PHP_EOL);
+$result = ['packages' => count($packages)];
+echo json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . PHP_EOL;
 exit(0);

--- a/scripts/tag-dry-run.sh
+++ b/scripts/tag-dry-run.sh
@@ -1,21 +1,22 @@
 #!/usr/bin/env bash
+set -e
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+summary="$root/artifacts/release/preflight.json"
 
-plugin_version=$(php -r '@preg_match("/^\\s*Version:\\s*(.+)$/m", file_get_contents($argv[1] ?? ""), $m); echo $m[1] ?? "";' "$root/smart-alloc.php" 2>/dev/null)
-readme_tag=$(php -r '@preg_match("/^Stable tag:\\s*(.+)$/m", file_get_contents($argv[1] ?? ""), $m); echo $m[1] ?? "";' "$root/readme.txt" 2>/dev/null)
+version=$(php -r '@preg_match("/^\\s*Version:\\s*(.+)$/m", file_get_contents("'$root'/smart-alloc.php"), $m); echo $m[1] ?? "";')
 
-tag="$plugin_version"
-if [ -n "$readme_tag" ] && [ "$plugin_version" != "$readme_tag" ]; then
-  tag="$plugin_version (plugin) / $readme_tag (readme)"
+echo "Simulated release steps:"
+echo "1. Build distribution"
+echo "2. Generate manifest and audits"
+echo "3. Tag version v$version"
+echo "4. Prepare release package"
+
+echo ""
+echo "Preflight summary:"
+if [ -f "$summary" ]; then
+  cat "$summary"
+else
+  echo "(not found)"
 fi
-
-date=$(date +%F)
-
-echo "Tag: $tag"
-echo "Date: $date"
-echo "Artifacts:"
-echo " - $root/artifacts/dist/manifest.json"
-echo " - $root/artifacts/dist/sbom.json"
-echo " - $root/artifacts/dist/release-notes.md"
 
 exit 0

--- a/scripts/tag-preflight.php
+++ b/scripts/tag-preflight.php
@@ -2,49 +2,47 @@
 declare(strict_types=1);
 
 $root = dirname(__DIR__);
+$enforce = in_array('--enforce', $argv, true);
 
-$changelog = $root . '/CHANGELOG.md';
-$version = '';
-$date = '';
-$highlights = [];
-if (is_file($changelog)) {
-    $content = (string)file_get_contents($changelog);
-    if (preg_match('/^##\s*\[?([^\]\s]+)\]?\s*-\s*(\d{4}-\d{2}-\d{2})\s*\n(.*?)(?:\n##\s|\z)/s', $content, $m)) {
-        $version = $m[1];
-        $date = $m[2];
-        $body = trim($m[3]);
-        foreach (preg_split('/\r?\n/', $body) as $line) {
-            if (preg_match('/^\s*[-*]\s*(.+)/', $line, $lm)) {
-                $highlights[] = trim($lm[1]);
-            }
-        }
+function readJson(string $path): array {
+    if (!is_file($path)) {
+        return [];
     }
+    $data = json_decode((string)file_get_contents($path), true);
+    return is_array($data) ? $data : [];
 }
 
-$artifacts = [];
-$paths = [
-    'manifest' => $root . '/artifacts/dist/manifest.json',
-    'sbom' => $root . '/artifacts/dist/sbom.json',
+$manifest = readJson($root . '/artifacts/dist/manifest.json');
+$audit = readJson($root . '/artifacts/dist/audit.json');
+$version = readJson($root . '/artifacts/dist/version-coherence.json');
+$readme = readJson($root . '/artifacts/dist/readme-lint.json');
+$sbom = readJson($root . '/artifacts/dist/sbom.json');
+
+$summary = [
+    'manifest_entries' => count($manifest['entries'] ?? []),
+    'audit_warnings' => count($audit['warnings'] ?? []),
+    'version_warnings' => count($version['warnings'] ?? []),
+    'readme_warnings' => count($readme['warnings'] ?? []),
+    'sbom_packages' => count($sbom['packages'] ?? []),
+    'generated_at_utc' => gmdate('c'),
 ];
-foreach ($paths as $name => $path) {
-    if (is_file($path)) {
-        $artifacts[$name] = [
-            'present' => true,
-            'sha256' => hash_file('sha256', $path),
-        ];
-    } else {
-        $artifacts[$name] = [
-            'present' => false,
-        ];
-    }
+
+$outDir = $root . '/artifacts/release';
+if (!is_dir($outDir)) {
+    mkdir($outDir, 0777, true);
 }
+file_put_contents($outDir . '/preflight.json', json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n");
 
-$result = [
-    'version' => $version,
-    'date' => $date,
-    'highlights' => $highlights,
-    'artifacts' => $artifacts,
-];
+printf("Preflight summary\nManifest entries: %d\nAudit warnings: %d\nVersion warnings: %d\nReadme warnings: %d\nSBOM packages: %d\n",
+    $summary['manifest_entries'],
+    $summary['audit_warnings'],
+    $summary['version_warnings'],
+    $summary['readme_warnings'],
+    $summary['sbom_packages']
+);
 
-echo json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . PHP_EOL;
+$blocking = $summary['audit_warnings'] + $summary['version_warnings'] + $summary['readme_warnings'];
+if ($enforce && $blocking > 0) {
+    exit(1);
+}
 exit(0);

--- a/scripts/validate-readme.php
+++ b/scripts/validate-readme.php
@@ -1,75 +1,42 @@
 <?php
 declare(strict_types=1);
 
-$root = dirname(__DIR__);
+$root = $argv[1] ?? dirname(__DIR__);
 $file = $root . '/readme.txt';
 $warnings = [];
 
 if (!is_file($file)) {
-    $warnings[] = 'readme_missing';
+    $warnings[] = 'missing_readme';
     $content = '';
 } else {
     $content = (string)file_get_contents($file);
-    $lines = preg_split('/\r?\n/', $content);
-    $headers = [];
-    $idx = 1; // start after title
-    for (; $idx < count($lines); $idx++) {
-        $line = $lines[$idx];
-        if ($line === '') {
-            $idx++;
-            break;
-        }
-        if (strpos($line, ':') !== false) {
-            [$k, $v] = array_map('trim', explode(':', $line, 2));
-            $headers[$k] = $v;
-        }
+    if (!preg_match('/^Requires at least:\s*\S+/mi', $content)) {
+        $warnings[] = 'requires_at_least';
     }
-    $requiredHeaders = ['Contributors', 'Requires at least', 'Tested up to', 'Requires PHP', 'Stable tag'];
-    foreach ($requiredHeaders as $h) {
-        if (!isset($headers[$h])) {
-            $warnings[] = 'header_missing:' . $h;
-        }
+    if (!preg_match('/^Tested up to:\s*\S+/mi', $content)) {
+        $warnings[] = 'tested_up_to';
     }
-    if (($headers['Stable tag'] ?? '') === '') {
-        $warnings[] = 'stable_tag_missing';
+    if (!preg_match('/^Stable tag:\s*\S+/mi', $content)) {
+        $warnings[] = 'stable_tag';
     }
-    $shortDesc = '';
-    for (; $idx < count($lines); $idx++) {
-        $line = trim($lines[$idx]);
-        if ($line !== '') {
-            $shortDesc = $line;
-            break;
-        }
-    }
-    if ($shortDesc === '') {
-        $warnings[] = 'short_description_missing';
-    } elseif (strlen($shortDesc) > 150) {
-        $warnings[] = 'short_description_long';
-    }
-    if (stripos($content, '== Description ==') === false) {
-        $warnings[] = 'description_section_missing';
-    }
-    if (stripos($content, '== Changelog ==') === false) {
-        $warnings[] = 'changelog_section_missing';
-    }
-    // oversized sections
-    if (preg_match_all('/^==\s*(.+?)\s*==/m', $content, $matches, PREG_SET_ORDER)) {
-        $positions = [];
-        foreach ($matches as $m) {
-            $positions[] = ['name' => $m[1], 'pos' => strpos($content, $m[0])];
-        }
-        for ($i = 0; $i < count($positions); $i++) {
-            $start = $positions[$i]['pos'] + strlen($positions[$i]['name']) + 4; // approx
-            $end = $positions[$i + 1]['pos'] ?? strlen($content);
-            $sectionLines = substr_count(substr($content, $start, $end - $start), "\n");
-            if ($sectionLines > 400) {
-                $warnings[] = 'section_oversized:' . $positions[$i]['name'];
+    if (preg_match('/==\s*Screenshots\s*==(?P<section>.*?)(\n==|\z)/si', $content, $m)) {
+        $lines = array_filter(array_map('trim', preg_split('/\r?\n/', trim($m['section']))));
+        $n = 1;
+        foreach ($lines as $line) {
+            if (!preg_match('/^' . $n . '\.\s+/', $line)) {
+                $warnings[] = 'screenshots_format';
+                break;
             }
+            $n++;
         }
     }
 }
 
-$ok = empty($warnings);
-$result = ['summary' => ['ok' => $ok, 'warnings' => $warnings]];
-echo json_encode($result, JSON_PRETTY_PRINT) . PHP_EOL;
+$outDir = $root . '/artifacts/dist';
+if (!is_dir($outDir)) {
+    mkdir($outDir, 0777, true);
+}
+$result = ['warnings' => $warnings];
+file_put_contents($outDir . '/readme-lint.json', json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n");
+echo json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n";
 exit(0);

--- a/scripts/version-coherence.php
+++ b/scripts/version-coherence.php
@@ -1,75 +1,67 @@
 <?php
 declare(strict_types=1);
 
-$root = dirname(__DIR__);
-$mismatches = [];
+$root = $argv[1] ?? dirname(__DIR__);
+$warnings = [];
 
+$pluginVersion = '';
 $pluginFile = null;
 foreach (glob($root . '/*.php') as $file) {
     $chunk = (string)file_get_contents($file, false, null, 0, 8192);
     if (preg_match('/Plugin Name\s*:/i', $chunk)) {
         $pluginFile = $file;
+        if (preg_match('/^\s*Version:\s*(.+)$/mi', $chunk, $m)) {
+            $pluginVersion = trim($m[1]);
+        }
         break;
     }
 }
-
-$version = '';
-$textDomain = '';
 if ($pluginFile === null) {
-    $mismatches[] = ['type' => 'plugin_file_missing'];
-} else {
-    $header = (string)file_get_contents($pluginFile, false, null, 0, 8192);
-    $required = ['Plugin Name', 'Version', 'Requires at least', 'Tested up to', 'Requires PHP', 'Text Domain'];
-    foreach ($required as $name) {
-        if (!preg_match('/' . preg_quote($name, '/') . '\s*:\s*(.+)/i', $header, $m)) {
-            $mismatches[] = ['type' => 'header_missing', 'field' => $name];
-            continue;
-        }
-        $val = trim($m[1]);
-        if ($name === 'Version') {
-            $version = $val;
-        } elseif ($name === 'Text Domain') {
-            $textDomain = $val;
-            if ($textDomain === '') {
-                $mismatches[] = ['type' => 'text_domain_empty'];
-            }
-        }
-    }
+    $warnings[] = 'plugin_file_missing';
 }
 
+$readmeStable = '';
 $readme = $root . '/readme.txt';
 if (!is_file($readme)) {
-    $mismatches[] = ['type' => 'readme_missing'];
-    $stable = '';
+    $warnings[] = 'readme_missing';
 } else {
     $content = (string)file_get_contents($readme);
-    if (stripos($content, '== Changelog ==') === false || stripos($content, '== Description ==') === false) {
-        $mismatches[] = ['type' => 'readme_sections'];
-    }
     if (!preg_match('/^Stable tag:\s*(.+)$/mi', $content, $m)) {
-        $mismatches[] = ['type' => 'stable_tag_missing'];
-        $stable = '';
+        $warnings[] = 'stable_tag_missing';
     } else {
-        $stable = trim($m[1]);
-        if ($version !== '' && $version !== $stable) {
-            $mismatches[] = ['type' => 'version_mismatch', 'plugin' => $version, 'readme' => $stable];
-        }
-    }
-    if ($textDomain === '') {
-        // Already flagged empty, but ensure readme mentions same domain? Not required.
+        $readmeStable = trim($m[1]);
     }
 }
 
+$changelogVersion = '';
 $changelog = $root . '/CHANGELOG.md';
-if (is_file($changelog) && $version !== '') {
-    $chContent = (string)file_get_contents($changelog);
-    if (preg_match('/^##\s*' . preg_quote($version, '/') . '\b/m', $chContent) === 0) {
-        $mismatches[] = ['type' => 'changelog_missing_entry', 'version' => $version];
+if (is_file($changelog)) {
+    $ch = (string)file_get_contents($changelog);
+    if (preg_match('/^##\s*([^\s]+)\s*$/m', $ch, $m)) {
+        $changelogVersion = trim($m[1]);
     }
 }
 
-$ok = empty($mismatches);
-$result = ['summary' => ['ok' => $ok, 'mismatches' => $mismatches]];
+if ($pluginVersion !== '' && $readmeStable !== '' && $pluginVersion !== $readmeStable) {
+    $warnings[] = 'plugin_vs_readme';
+}
+if ($readmeStable !== '' && $changelogVersion !== '' && $readmeStable !== $changelogVersion) {
+    $warnings[] = 'readme_vs_changelog';
+}
+if ($pluginVersion !== '' && $changelogVersion !== '' && $pluginVersion !== $changelogVersion) {
+    $warnings[] = 'plugin_vs_changelog';
+}
 
-echo json_encode($result, JSON_PRETTY_PRINT) . PHP_EOL;
+$outDir = $root . '/artifacts/dist';
+if (!is_dir($outDir)) {
+    mkdir($outDir, 0777, true);
+}
+$result = [
+    'plugin_version' => $pluginVersion,
+    'readme_stable_tag' => $readmeStable,
+    'changelog_version' => $changelogVersion,
+    'warnings' => $warnings,
+];
+file_put_contents($outDir . '/version-coherence.json', json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n");
+echo json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n";
 exit(0);

--- a/tests/unit/Release/DistBuildTest.php
+++ b/tests/unit/Release/DistBuildTest.php
@@ -1,0 +1,39 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class DistBuildTest extends TestCase
+{
+    public function test_build_excludes_and_normalises(): void
+    {
+        $src = sa_tests_temp_dir('src');
+        file_put_contents($src . '/plugin.php', "<?php\n/*Plugin Name: Test*/\n");
+        file_put_contents($src . '/readme.txt', "line1\r\nline2\r\n");
+        file_put_contents($src . '/notes.md', 'skip');
+        mkdir($src . '/node_modules', 0777, true);
+        file_put_contents($src . '/node_modules/mod.js', '');
+        mkdir($src . '/tests', 0777, true);
+        file_put_contents($src . '/tests/t.php', '');
+        mkdir($src . '/dir', 0777, true);
+        file_put_contents($src . '/dir/keep.php', "<?php\n");
+        $dest = sa_tests_temp_dir('distbuild');
+        $cmd = sprintf('%s %s %s %s',
+            escapeshellarg(PHP_BINARY),
+            escapeshellarg(dirname(__DIR__,3).'/scripts/dist-build.php'),
+            escapeshellarg($src),
+            escapeshellarg($dest)
+        );
+        exec($cmd, $_, $rc);
+        $this->assertSame(0, $rc);
+        $base = $dest . '/SmartAlloc';
+        $this->assertFileExists($base . '/plugin.php');
+        $this->assertFileExists($base . '/readme.txt');
+        $this->assertFileExists($base . '/dir/keep.php');
+        $this->assertFileDoesNotExist($base . '/notes.md');
+        $this->assertFileDoesNotExist($base . '/node_modules');
+        $this->assertStringNotContainsString("\r", file_get_contents($base . '/readme.txt'));
+        $this->assertSame('0644', substr(sprintf('%o', fileperms($base . '/plugin.php')), -4));
+        $this->assertSame('0755', substr(sprintf('%o', fileperms($base . '/dir')), -4));
+    }
+}

--- a/tests/unit/Release/DistManifestTest.php
+++ b/tests/unit/Release/DistManifestTest.php
@@ -7,33 +7,29 @@ final class DistManifestTest extends TestCase
 {
     public function test_manifest_entries_sorted_and_shaped(): void
     {
-        if (getenv('RUN_ENFORCE') !== '1') {
-            $this->markTestSkipped('opt-in');
-        }
-
-        $root = dirname(__DIR__, 3);
+        $root = dirname(__DIR__,3);
         $temp = sa_tests_temp_dir('manifest');
-        file_put_contents($temp . '/b.txt', 'bb');
-        file_put_contents($temp . '/a.txt', 'a');
-
+        file_put_contents($temp.'/b.txt','bb');
+        file_put_contents($temp.'/a.txt','a');
         $cmd = sprintf('%s %s %s',
             escapeshellarg(PHP_BINARY),
-            escapeshellarg($root . '/scripts/dist-manifest.php'),
+            escapeshellarg($root.'/scripts/dist-manifest.php'),
             escapeshellarg($temp)
         );
         exec($cmd, $_, $rc);
-        $this->assertSame(0, $rc);
-
-        $manifestPath = $root . '/artifacts/dist/manifest.json';
+        $this->assertSame(0,$rc);
+        $manifestPath = $root.'/artifacts/dist/manifest.json';
         $this->assertFileExists($manifestPath);
         $m = json_decode((string)file_get_contents($manifestPath), true);
         $this->assertIsArray($m['entries'] ?? null);
+        $this->assertArrayHasKey('generated_at_utc',$m);
         $this->assertSame('a.txt', $m['entries'][0]['path'] ?? '');
         $this->assertSame('b.txt', $m['entries'][1]['path'] ?? '');
         foreach ($m['entries'] as $e) {
-            $this->assertArrayHasKey('path', $e);
-            $this->assertArrayHasKey('sha256', $e);
-            $this->assertArrayHasKey('size', $e);
+            $this->assertArrayHasKey('path',$e);
+            $this->assertArrayHasKey('sha256',$e);
+            $this->assertArrayHasKey('size',$e);
+            $this->assertSame(64, strlen($e['sha256']));
         }
     }
 }

--- a/tests/unit/Release/GAEnforcerDistTest.php
+++ b/tests/unit/Release/GAEnforcerDistTest.php
@@ -1,0 +1,57 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class GAEnforcerDistTest extends TestCase
+{
+    private string $origReadme = '';
+
+    protected function setUp(): void
+    {
+        $this->origReadme = (string)file_get_contents('readme.txt');
+        @mkdir('artifacts/ga', 0777, true);
+        @mkdir('artifacts/dist', 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        file_put_contents('readme.txt', $this->origReadme);
+        @unlink('scripts/.ga-enforce.json');
+    }
+
+    public function test_dist_manifest_warnings_gate(): void
+    {
+        $broken = preg_replace('/^Stable tag:.*$/m', 'Stable tag:', $this->origReadme);
+        file_put_contents('readme.txt', (string)$broken);
+        $config = [
+            'rest_permission_violations' => 999,
+            'sql_prepare_violations' => 999,
+            'secrets_findings' => 999,
+            'license_denied' => 999,
+            'i18n_domain_mismatches' => 999,
+            'coverage_pct_min' => 0,
+            'schema_warnings' => 999,
+            'pot_min_entries' => 0,
+            'dist_audit_max_errors' => 999,
+            'wporg_lint_max_warnings' => 999,
+            'dist_manifest_warnings' => 0,
+            'require_manifest' => false,
+            'require_sbom' => false,
+            'version_mismatch_fatal' => false,
+        ];
+        file_put_contents('scripts/.ga-enforce.json', json_encode($config));
+
+        exec('php scripts/ga-enforcer.php --profile=rc --junit', $_, $rc);
+        $this->assertSame(0, $rc);
+        $xml = (string)file_get_contents('artifacts/ga/GA_ENFORCER.junit.xml');
+        $this->assertStringContainsString('<testcase name="Dist.Manifest"', $xml);
+        $this->assertStringContainsString('<skipped', $xml);
+
+        exec('RUN_ENFORCE=1 php scripts/ga-enforcer.php --profile=ga --enforce --junit', $_, $rc2);
+        $this->assertNotSame(0, $rc2);
+        $xml = (string)file_get_contents('artifacts/ga/GA_ENFORCER.junit.xml');
+        $this->assertStringContainsString('<testcase name="Dist.Manifest"', $xml);
+        $this->assertStringContainsString('<failure', $xml);
+    }
+}

--- a/tests/unit/Release/ReadmeLintTest.php
+++ b/tests/unit/Release/ReadmeLintTest.php
@@ -1,0 +1,39 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class ReadmeLintTest extends TestCase
+{
+    public function test_valid_readme(): void
+    {
+        $root = sa_tests_temp_dir('pkg');
+        file_put_contents($root . '/readme.txt', "=== Test ===\nRequires at least: 6.4\nTested up to: 6.4\nStable tag: 1.0.0\n\n== Screenshots ==\n1. One\n2. Two\n");
+        $cmd = sprintf('%s %s %s',
+            escapeshellarg(PHP_BINARY),
+            escapeshellarg(dirname(__DIR__,3).'/scripts/validate-readme.php'),
+            escapeshellarg($root)
+        );
+        exec($cmd, $_, $rc);
+        $this->assertSame(0, $rc);
+        $path = $root . '/artifacts/dist/readme-lint.json';
+        $data = json_decode((string)file_get_contents($path), true);
+        $this->assertEmpty($data['warnings']);
+    }
+
+    public function test_invalid_readme(): void
+    {
+        $root = sa_tests_temp_dir('pkg2');
+        file_put_contents($root . '/readme.txt', "=== Test ===\nTested up to: 6.4\nStable tag:\n\n== Screenshots ==\n* One\n");
+        $cmd = sprintf('%s %s %s',
+            escapeshellarg(PHP_BINARY),
+            escapeshellarg(dirname(__DIR__,3).'/scripts/validate-readme.php'),
+            escapeshellarg($root)
+        );
+        exec($cmd, $_, $rc);
+        $this->assertSame(0, $rc);
+        $path = $root . '/artifacts/dist/readme-lint.json';
+        $data = json_decode((string)file_get_contents($path), true);
+        $this->assertNotEmpty($data['warnings']);
+    }
+}

--- a/tests/unit/Release/VersionReadmeCoherenceTest.php
+++ b/tests/unit/Release/VersionReadmeCoherenceTest.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class VersionReadmeCoherenceTest extends TestCase
+{
+    public function test_mismatch_emits_warning(): void
+    {
+        $root = sa_tests_temp_dir('pkg');
+        file_put_contents($root . '/plugin.php', "<?php\n/*\nPlugin Name: Test\nVersion: 1.0.0\n*/\n");
+        file_put_contents($root . '/readme.txt', "=== Test ===\nRequires at least: 6.4\nTested up to: 6.4\nStable tag: 2.0.1\n\n== Changelog ==\n");
+        file_put_contents($root . '/CHANGELOG.md', "# Changelog\n## 1.0.0\n");
+        $cmd = sprintf('%s %s %s',
+            escapeshellarg(PHP_BINARY),
+            escapeshellarg(dirname(__DIR__,3).'/scripts/version-coherence.php'),
+            escapeshellarg($root)
+        );
+        exec($cmd, $_, $rc);
+        $this->assertSame(0, $rc);
+        $path = $root . '/artifacts/dist/version-coherence.json';
+        $data = json_decode((string)file_get_contents($path), true);
+        $this->assertNotEmpty($data['warnings']);
+    }
+}


### PR DESCRIPTION
## Summary
- add dist build and manifest generation with sbom, version, readme, and audit checks
- integrate release checks into GA enforcer with new Dist.Manifest testcase
- document distribution audit and release checklist

## Testing
- `vendor/bin/phpunit tests/unit/Release/DistBuildTest.php tests/unit/Release/DistManifestTest.php tests/unit/Release/VersionReadmeCoherenceTest.php tests/unit/Release/ReadmeLintTest.php tests/unit/Release/GAEnforcerDistTest.php`
- `php scripts/dist-build.php`
- `php scripts/dist-manifest.php`
- `php scripts/dist-audit.php`
- `php scripts/version-coherence.php`
- `php scripts/validate-readme.php`
- `php scripts/sbom-from-composer.php`
- `php scripts/tag-preflight.php`
- `bash scripts/tag-dry-run.sh`
- `php scripts/ga-enforcer.php --profile=rc --junit`
- `RUN_ENFORCE=1 php scripts/ga-enforcer.php --profile=ga --enforce --junit`


------
https://chatgpt.com/codex/tasks/task_e_68a7c4917254832182250af9f1aada52