### PR TITLE
feat: add sabt export pipeline

### DIFF
--- a/config/SmartAlloc_Exporter_Config_v1.json
+++ b/config/SmartAlloc_Exporter_Config_v1.json
@@ -1,0 +1,9 @@
+{
+  "columns": [
+    {"field": "tracking", "label": "Tracking", "gf": "76", "normalize": ["digits_16"]},
+    {"field": "mobile", "label": "Mobile", "gf": "20", "normalize": ["mobile_ir"]},
+    {"field": "postal_code", "label": "Postal Code", "gf": "postal_code", "normalize": ["digits_10"]},
+    {"field": "hakmat_code", "label": "Hakmat Code", "gf": "hakmat_code"},
+    {"field": "hakmat_name", "label": "Hakmat Name", "gf": "hakmat_name"}
+  ]
+}

--- a/docs/EXPORT.md
+++ b/docs/EXPORT.md
@@ -1,0 +1,25 @@
+# Export Pipeline
+
+The Sabt export pipeline generates Excel files from Gravity Forms entries.
+
+## Usage
+
+1. Configure column mapping in `config/SmartAlloc_Exporter_Config_v1.json`.
+2. Trigger the exporter (CLI or admin UI) to build the workbook.
+3. Download the file named `SabtExport-ALLOCATED-YYYY_MM_DD-####-B{nnn}.xlsx`.
+
+## Sheets
+
+- **Summary** – contains all valid rows based on the mapping.
+- **Errors** – entries failing validation (invalid mobile numbers, duplicate phones or tracking, etc.).
+
+## Validation Rules
+
+- Mobile numbers must match `09\d{9}` after normalisation.
+- Tracking code of `1111111111111111` is rejected.
+- Postal code alias overrides the postal code.
+- Hakmat fields are cleared unless support status equals `3`.
+
+The exporter writes a deterministic report to
+`artifacts/export/export-report.json` describing counts of processed,
+valid and error rows.

--- a/src/Admin/Pages/ExportPage.php
+++ b/src/Admin/Pages/ExportPage.php
@@ -26,7 +26,13 @@ final class ExportPage
         $table   = $wpdb->prefix . 'smartalloc_exports';
         // @security-ok-sql
         $exports = $wpdb->get_results(
-            $wpdb->prepare("SELECT * FROM {$table} ORDER BY created_at DESC LIMIT %d", 20),
+            $wpdb->prepare("SELECT * FROM {$table} ORDER BY created_at DESC LIMIT %d", 5),
+            ARRAY_A
+        );
+
+        $logTable = $wpdb->prefix . 'salloc_export_log';
+        $logs = $wpdb->get_results(
+            $wpdb->prepare("SELECT * FROM {$logTable} ORDER BY created_at DESC LIMIT %d", 5),
             ARRAY_A
         );
 
@@ -103,6 +109,29 @@ final class ExportPage
         echo '<tr><td colspan="7">' . esc_html__('No exports found.', 'smartalloc') . '</td></tr>';
         }
 
+        echo '</tbody></table>';
+
+        echo '<h2>' . esc_html__('Logs', 'smartalloc') . '</h2>';
+        echo '<table class="wp-list-table widefat striped">';
+        echo '<thead><tr>';
+        echo '<th>' . esc_html__('Filename', 'smartalloc') . '</th>';
+        echo '<th>' . esc_html__('Rows', 'smartalloc') . '</th>';
+        echo '<th>' . esc_html__('Failures', 'smartalloc') . '</th>';
+        echo '<th>' . esc_html__('Duration (ms)', 'smartalloc') . '</th>';
+        echo '<th>' . esc_html__('Created', 'smartalloc') . '</th>';
+        echo '</tr></thead><tbody>';
+        foreach ($logs as $log) {
+            echo '<tr>';
+            echo '<td>' . esc_html($log['file_name']) . '</td>';
+            echo '<td>' . esc_html((string) ($log['rows_total'] ?? 0)) . '</td>';
+            echo '<td>' . esc_html((string) ($log['rows_failed'] ?? 0)) . '</td>';
+            echo '<td>' . esc_html((string) ($log['duration_ms'] ?? 0)) . '</td>';
+            echo '<td>' . esc_html($log['created_at'] ?? '') . '</td>';
+            echo '</tr>';
+        }
+        if (empty($logs)) {
+            echo '<tr><td colspan="5">' . esc_html__('No logs found.', 'smartalloc') . '</td></tr>';
+        }
         echo '</tbody></table>';
         echo '</div></div>';
     }

--- a/src/Infra/Export/SabtExporter.php
+++ b/src/Infra/Export/SabtExporter.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SmartAlloc\Infra\Export;
+
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Writer\Xlsx;
+use SmartAlloc\Infra\GF\SabtEntryMapper;
+
+/**
+ * Simple Sabt exporter that maps Gravity Forms entries
+ * and writes an Excel workbook with Summary and Errors sheets.
+ *
+ * This service is deterministic and writes an export report
+ * to artifacts/export/export-report.json.
+ */
+final class SabtExporter
+{
+    private array $config;
+    private static int $dailyCounter = 0;
+    private static int $batchCounter = 0;
+
+    public function __construct(?string $configPath = null)
+    {
+        $path = $configPath ?? dirname(__DIR__, 3) . '/config/SmartAlloc_Exporter_Config_v1.json';
+        $json = file_get_contents($path) ?: '{}';
+        $this->config = json_decode($json, true) ?: [];
+    }
+
+    /**
+     * @param list<array<string,mixed>> $entries
+     * @return array{path:string, valid:int, errors:int}
+     */
+    public function exportFromEntries(array $entries): array
+    {
+        $mapper = new SabtEntryMapper();
+        $valid = [];
+        $errors = [];
+
+        foreach ($entries as $idx => $entry) {
+            $mapped = $mapper->mapEntry($entry);
+            if ($mapped['ok']) {
+                $valid[] = $mapped['student'];
+            } else {
+                $errors[] = ['entry' => $idx, 'code' => $mapped['code'] ?? 'unknown'];
+            }
+        }
+
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+        $sheet->setTitle('Summary');
+
+        $columns = $this->config['columns'] ?? [];
+        $col = 1;
+        foreach ($columns as $column) {
+            $label = $column['label'] ?? ($column['field'] ?? '');
+            $sheet->setCellValueByColumnAndRow($col, 1, $label);
+            $col++;
+        }
+        $row = 2;
+        foreach ($valid as $student) {
+            $col = 1;
+            foreach ($columns as $column) {
+                $field = $column['field'] ?? '';
+                $sheet->setCellValueByColumnAndRow($col, $row, (string)($student[$field] ?? ''));
+                $col++;
+            }
+            $row++;
+        }
+
+        $errSheet = $spreadsheet->createSheet();
+        $errSheet->setTitle('Errors');
+        $errSheet->setCellValue('A1', 'Entry');
+        $errSheet->setCellValue('B1', 'Error');
+        $r = 2;
+        foreach ($errors as $err) {
+            $errSheet->setCellValueByColumnAndRow(1, $r, (string) $err['entry']);
+            $errSheet->setCellValueByColumnAndRow(2, $r, (string) $err['code']);
+            $r++;
+        }
+
+        $filename = $this->generateFilename();
+        $path = sys_get_temp_dir() . DIRECTORY_SEPARATOR . $filename;
+        $writer = new Xlsx($spreadsheet);
+        $writer->save($path);
+
+        $this->writeReport(count($entries), count($valid), count($errors));
+
+        return ['path' => $path, 'valid' => count($valid), 'errors' => count($errors)];
+    }
+
+    private function generateFilename(): string
+    {
+        self::$dailyCounter++;
+        self::$batchCounter++;
+        $date = date('Y_m_d');
+        return sprintf('SabtExport-ALLOCATED-%s-%04d-B%03d.xlsx', $date, self::$dailyCounter, self::$batchCounter);
+    }
+
+    private function writeReport(int $total, int $valid, int $errors): void
+    {
+        $root = dirname(__DIR__, 3);
+        $dir = $root . '/artifacts/export';
+        if (!is_dir($dir)) {
+            mkdir($dir, 0777, true);
+        }
+        $report = [
+            'total' => $total,
+            'valid' => $valid,
+            'errors' => $errors,
+        ];
+        $json = json_encode($report, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+        file_put_contents($dir . '/export-report.json', $json);
+    }
+}

--- a/src/Services/ExportService.php
+++ b/src/Services/ExportService.php
@@ -222,17 +222,21 @@ final class ExportService
         foreach ($normalize as $rule) {
             switch ($rule) {
                 case 'digits_10':
-                    $value = $this->normalizeDigits($value);
+                    $value = $this->normalizeDigits((string) $value, 10);
                     break;
-                    
+
+                case 'digits_16':
+                    $value = $this->normalizeDigits((string) $value, 16);
+                    break;
+
                 case 'mobile_ir':
-                    $value = $this->normalizeMobileIran($value);
+                    $value = $this->normalizeMobileIran((string) $value);
                     break;
-                    
+
                 case 'text_or_empty':
                     $value = empty($value) ? '' : (string) $value;
                     break;
-                    
+
                 case 'trim':
                     $value = trim((string) $value);
                     break;
@@ -489,16 +493,21 @@ final class ExportService
     /**
      * Normalize digits (Persian/Arabic to English)
      */
-    private function normalizeDigits(string $value): string
+    private function normalizeDigits(string $value, int $limit = 0): string
     {
         $persian = ['۰', '۱', '۲', '۳', '۴', '۵', '۶', '۷', '۸', '۹'];
         $arabic = ['٠', '١', '٢', '٣', '٤', '٥', '٦', '٧', '٨', '٩'];
         $english = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'];
-        
+
         $value = str_replace($persian, $english, $value);
         $value = str_replace($arabic, $english, $value);
-        
-        return preg_replace('/\D/', '', $value);
+        $value = preg_replace('/\D/', '', $value);
+
+        if ($limit > 0) {
+            $value = substr($value, 0, $limit);
+        }
+
+        return $value;
     }
 
     /**
@@ -506,7 +515,7 @@ final class ExportService
      */
     private function normalizeMobileIran(string $value): string
     {
-        $value = $this->normalizeDigits($value);
+        $value = $this->normalizeDigits($value, 11);
         
         // Remove country code if present
         if (str_starts_with($value, '98')) {

--- a/tests/Export/SabtExporterIntegrationTest.php
+++ b/tests/Export/SabtExporterIntegrationTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SmartAlloc\Tests\Export;
+
+use PhpOffice\PhpSpreadsheet\IOFactory;
+use SmartAlloc\Infra\Export\SabtExporter;
+use SmartAlloc\Tests\BaseTestCase;
+
+final class SabtExporterIntegrationTest extends BaseTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        if (!class_exists(IOFactory::class)) {
+            $this->markTestSkipped('PhpSpreadsheet unavailable');
+        }
+    }
+
+    public function test_export_creates_summary_and_errors(): void
+    {
+        $entries = [
+            ['20' => '09123456789', '76' => '1234567890123456', 'postal_code' => '1234567890', '75' => '3', 'hakmat_code' => 'H1', 'hakmat_name' => 'Hakmat'],
+            ['20' => '123', '76' => '1234567890123456', 'postal_code' => '1234567890', '75' => '3', 'hakmat_code' => 'H2', 'hakmat_name' => 'Hakmat2'],
+            ['20' => '09123456789', '76' => '1234567890123456', 'postal_code' => '1234567890', '75' => '2', 'hakmat_code' => 'HX', 'hakmat_name' => 'ShouldClear'],
+        ];
+
+        $exporter = new SabtExporter(dirname(__DIR__, 2) . '/config/SmartAlloc_Exporter_Config_v1.json');
+        $result = $exporter->exportFromEntries($entries);
+
+        $spreadsheet = IOFactory::load($result['path']);
+        $summary = $spreadsheet->getSheetByName('Summary')->toArray(null, true, true, true);
+        $errors = $spreadsheet->getSheetByName('Errors')->toArray(null, true, true, true);
+
+        $this->assertCount(3, $summary); // header + 2 valid rows
+        $this->assertSame('H1', $summary[2]['D']);
+        $this->assertNull($summary[3]['E']);
+
+        $this->assertCount(2, $errors); // header + 1 error
+        $this->assertSame('invalid_mobile', $errors[2]['B']);
+
+        unlink($result['path']);
+        $reportPath = dirname(__DIR__, 2) . '/artifacts/export/export-report.json';
+        $report = json_decode(file_get_contents($reportPath), true);
+        $this->assertSame(['total' => 3, 'valid' => 2, 'errors' => 1], $report);
+        @unlink($reportPath);
+    }
+}

--- a/tests/ExporterImporter/NormalizerTest.php
+++ b/tests/ExporterImporter/NormalizerTest.php
@@ -38,9 +38,9 @@ final class NormalizerTest extends BaseTestCase
 
     public function test_digits16_normalizer(): void
     {
-        $persian = '۰۱۲۳۴۵۶۷۸۹۰۱۲۳۴۵۶';
-        $normalized = $this->callNormalizeValue($persian, ['normalize' => ['digits_10']]);
-        $this->assertSame('01234567890123456', $normalized);
+        $persian = '۰۱۲۳۴۵۶۷۸۹۰۱۲۳۴۵۶۷۸';
+        $normalized = $this->callNormalizeValue($persian, ['normalize' => ['digits_16']]);
+        $this->assertSame('0123456789012345', $normalized);
     }
 
     public function test_mobile_ir_normalizer_valid(): void

--- a/tests/ExporterImporter/PriorityRulesTest.php
+++ b/tests/ExporterImporter/PriorityRulesTest.php
@@ -42,18 +42,19 @@ final class PriorityRulesTest extends BaseTestCase
 
     public function test_reg_status_clears_hakmat_fields(): void
     {
+        $mapper = new SabtEntryMapper();
         $entry = [
             '75' => '2',
+            '20' => '09123456789',
+            '76' => '1234567890123456',
             'hakmat_code' => 'ABC',
             'hakmat_name' => 'Foo',
         ];
 
-        if (($entry['75'] ?? '') !== '3') {
-            $entry['hakmat_code'] = '';
-            $entry['hakmat_name'] = '';
-        }
-
-        $this->assertSame('', $entry['hakmat_code']);
-        $this->assertSame('', $entry['hakmat_name']);
+        $result = $mapper->mapEntry($entry);
+        $this->assertTrue($result['ok']);
+        $student = $result['student'];
+        $this->assertSame('', $student['hakmat_code']);
+        $this->assertSame('', $student['hakmat_name']);
     }
 }


### PR DESCRIPTION
## Summary
- implement SabtExporter service and config-driven column mapping
- extend export normalizers and GF mapper with priority rules
- show recent exports and log stats in admin export page

## Testing
- `vendor/bin/phpunit tests/ExporterImporter/NormalizerTest.php tests/ExporterImporter/PriorityRulesTest.php tests/Export/SabtExporterIntegrationTest.php`
- `php scripts/pot-refresh.php`
- `php scripts/coverage-import.php`
- `php scripts/artifact-schema-validate.php`
- `php scripts/ga-enforcer.php --profile=rc --junit`
- `E2E=1 E2E_RTL=1 npx playwright test tests/e2e/rtl-snapshot.spec.ts` *(fails: Executable doesn't exist at /root/.cache/ms-playwright/...)*


------
https://chatgpt.com/codex/tasks/task_e_68a7fdb939b08321ade83d0aabe4ebfb