### PR TITLE
Add QA report aggregation, metrics endpoints, and health checks

### DIFF
--- a/docs/REPORTS_METRICS.md
+++ b/docs/REPORTS_METRICS.md
@@ -1,0 +1,78 @@
+# Reports & Metrics
+
+## QA Report
+
+`scripts/qa-report.php` aggregates the following signals and emits both JSON and RTL-friendly HTML:
+
+- Artifact schema warnings
+- Code coverage percentage
+- SQL prepare scanner results
+- REST permission warnings
+- Secret scan results
+- HTTP header guard results
+- License audit summary
+- Exporter validation counts
+- Form150 validation rule violations
+
+Output is deterministic and always includes `timestamp_utc`.
+
+### Sample JSON
+
+```json
+{
+  "timestamp_utc": "2025-01-01T00:00:00Z",
+  "summary": {
+    "coverage_pct": 92.5,
+    "schema_warnings": 1,
+    "rest_permissions": { "routes": 5, "mutating_warnings": 0, "readonly_warnings": 1 },
+    "sql_prepare": { "violations": 0, "allowlisted": 0 },
+    "secrets": { "violations": 0, "allowlisted": 0 },
+    "headers": { "missing": 0, "allowlisted": 0 },
+    "license": { "unapproved": 0 },
+    "exporter": { "errors": 0, "warnings": 0 },
+    "validation": {
+      "national_id_checksum": 0,
+      "mobile_prefix_09": 1,
+      "landline_eq_mobile": 0,
+      "duplicate_liaison_phone": 0,
+      "postal_code_fuzzy": {"accept": 10, "manual": 2, "reject": 1},
+      "hikmat_tracking_sentinel": 0
+    }
+  },
+  "notes": []
+}
+```
+
+## REST Metrics
+
+`scripts/metrics-endpoints.php` registers read-only endpoints under `/smartalloc/v1/metrics`.
+
+- Capability required: `manage_smartalloc`
+- Response is deterministic and sorted
+- Metrics include:
+  - Allocation counts (total, by mentor, by center – capacity limited to 60)
+  - Export counts (total and error counts)
+  - Validation errors grouped by rule and field
+  - Dead-letter queue backlog statistics
+
+## Site Health Checks
+
+`SmartAlloc\Services\HealthCheckService` hooks into WordPress Site Health and reports:
+
+- Database connectivity
+- Redis/queue availability
+- Dead-letter queue backlog
+- Mentor capacity utilisation (flags mentors with assigned > 60)
+
+## Validation Rule Mapping
+
+The QA report and metrics map to SmartAlloc execution document rules:
+
+| Rule | Description |
+| --- | --- |
+| national_id_checksum | Iranian national code checksum |
+| mobile_prefix_09 | Mobile numbers must start with 09 and be 11 digits |
+| landline_eq_mobile | Landline must not equal mobile |
+| duplicate_liaison_phone | Removes liaison duplicate when field 23 equals field 21 |
+| postal_code_fuzzy | Postal code fuzzy matching (≥0.90 accept, 0.80–0.89 manual, <0.80 reject) |
+| hikmat_tracking_sentinel | حكمة tracking sentinel `1111111111111111` |

--- a/scripts/metrics-endpoints.php
+++ b/scripts/metrics-endpoints.php
@@ -1,0 +1,96 @@
+<?php
+// @security-ok-rest
+
+declare(strict_types=1);
+/**
+ * Register SmartAlloc metrics endpoints.
+ */
+function sa_register_metrics_endpoints(): void
+{
+    add_action('rest_api_init', function (): void {
+        register_rest_route('smartalloc/v1', '/metrics', [
+            'methods'             => 'GET',
+            'permission_callback' => fn() => current_user_can(SMARTALLOC_CAP),
+            'callback'            => 'sa_metrics_handle',
+        ]);
+    });
+}
+
+/**
+ * Handle metrics endpoint.
+ *
+ * @return WP_REST_Response|WP_Error
+ */
+function sa_metrics_handle(WP_REST_Request $request)
+{
+    if (!current_user_can(SMARTALLOC_CAP)) {
+        return new WP_Error('forbidden', 'Forbidden', ['status' => 403]);
+    }
+
+    global $wpdb;
+    $allocTable   = $wpdb->prefix . 'smartalloc_allocations';
+    $mentorsTable = $wpdb->prefix . 'salloc_mentors';
+    $exportsTable = $wpdb->prefix . 'salloc_exports';
+    $validTable   = $wpdb->prefix . 'salloc_validation_errors';
+    $dlqTable     = $wpdb->prefix . 'salloc_dlq';
+
+    // Allocation counts
+    $totalAlloc = (int) ($wpdb->get_var("SELECT COUNT(*) FROM {$allocTable}") ?: 0);
+    $byMentor   = $wpdb->get_results("SELECT mentor_id, assigned, capacity FROM {$mentorsTable} ORDER BY mentor_id", ARRAY_A) ?: [];
+    foreach ($byMentor as &$m) {
+        $m['mentor_id'] = (int) $m['mentor_id'];
+        $m['assigned']  = (int) $m['assigned'];
+        $m['capacity']  = (int) min($m['capacity'], 60);
+    }
+    unset($m);
+    usort($byMentor, fn($a, $b) => $a['mentor_id'] <=> $b['mentor_id']);
+    $byCenter = $wpdb->get_results("SELECT center_id, SUM(assigned) AS assigned, SUM(capacity) AS capacity FROM {$mentorsTable} GROUP BY center_id ORDER BY center_id", ARRAY_A) ?: [];
+    foreach ($byCenter as &$c) {
+        $c['center_id'] = (int) $c['center_id'];
+        $c['assigned']  = (int) $c['assigned'];
+        $c['capacity']  = (int) min($c['capacity'], 60);
+    }
+    unset($c);
+    usort($byCenter, fn($a, $b) => $a['center_id'] <=> $b['center_id']);
+
+    // Export counts
+    $exports = [
+        'total'  => (int) ($wpdb->get_var("SELECT COUNT(*) FROM {$exportsTable}") ?: 0),
+        'errors' => (int) ($wpdb->get_var("SELECT COUNT(*) FROM {$exportsTable} WHERE status='error'") ?: 0),
+    ];
+
+    // Validation errors grouped by rule and field
+    $validation = $wpdb->get_results("SELECT rule, field, COUNT(*) AS count FROM {$validTable} GROUP BY rule, field ORDER BY rule, field", ARRAY_A) ?: [];
+    foreach ($validation as &$v) {
+        $v['rule']  = (string) $v['rule'];
+        $v['field'] = (int) $v['field'];
+        $v['count'] = (int) $v['count'];
+    }
+    unset($v);
+    usort($validation, fn($a, $b) => [$a['rule'], $a['field']] <=> [$b['rule'], $b['field']]);
+
+    // DLQ backlog stats
+    $dlq = [
+        'ready'  => (int) ($wpdb->get_var("SELECT COUNT(*) FROM {$dlqTable} WHERE status='ready'") ?: 0),
+        'failed' => (int) ($wpdb->get_var("SELECT COUNT(*) FROM {$dlqTable} WHERE status='failed'") ?: 0),
+    ];
+
+    $metrics = [
+        'allocations'       => [
+            'total'     => $totalAlloc,
+            'by_mentor' => $byMentor,
+            'by_center' => $byCenter,
+        ],
+        'exports'           => $exports,
+        'validation_errors' => $validation,
+        'dlq'               => $dlq,
+        'timestamp_utc'     => gmdate('Y-m-d\TH:i:s\Z'),
+    ];
+    ksort($metrics);
+
+    return new WP_REST_Response($metrics, 200);
+}
+
+if (PHP_SAPI !== 'cli') {
+    sa_register_metrics_endpoints();
+}

--- a/src/Services/HealthCheckService.php
+++ b/src/Services/HealthCheckService.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SmartAlloc\Services;
+
+/**
+ * Integrate SmartAlloc checks into WordPress Site Health.
+ */
+final class HealthCheckService
+{
+    /** Register Site Health hooks. */
+    public function register(): void
+    {
+        add_filter('site_status_tests', [$this, 'addTests']);
+    }
+
+    /**
+     * Add SmartAlloc tests to Site Health.
+     *
+     * @param array $tests
+     * @return array
+     */
+    public function addTests(array $tests): array
+    {
+        $tests['direct']['smartalloc'] = [
+            'label' => function_exists('__') ? __('SmartAlloc health', 'smartalloc') : 'SmartAlloc health',
+            'test'  => [$this, 'run'],
+        ];
+        return $tests;
+    }
+
+    /**
+     * Execute SmartAlloc health checks.
+     *
+     * @return array{label:string,status:string,description:string}
+     */
+    public function run(): array
+    {
+        global $wpdb;
+        $dbOk = (bool) ($wpdb->get_var('SELECT 1') !== null);
+
+        $cacheOk = false;
+        if (function_exists('wp_cache_get')) {
+            $testKey = '__sa_health__';
+            $cacheOk = wp_cache_set($testKey, '1', 'smartalloc', 1) && wp_cache_get($testKey, 'smartalloc') === '1';
+        }
+
+        $dlqTable = $wpdb->prefix . 'salloc_dlq';
+        $dlqBacklog = (int) ($wpdb->get_var("SELECT COUNT(*) FROM {$dlqTable} WHERE status='ready'") ?: 0);
+
+        $mentorsTable = $wpdb->prefix . 'salloc_mentors';
+        $overCapacity = (int) ($wpdb->get_var("SELECT COUNT(*) FROM {$mentorsTable} WHERE assigned > 60") ?: 0);
+
+        $status = ($dbOk && $cacheOk && $dlqBacklog === 0 && $overCapacity === 0) ? 'good' : 'critical';
+
+        $desc  = '<ul>';
+        $desc .= '<li>DB: ' . ($dbOk ? 'ok' : 'error') . '</li>';
+        $desc .= '<li>Queue: ' . ($cacheOk ? 'ok' : 'error') . '</li>';
+        $desc .= '<li>DLQ backlog: ' . $dlqBacklog . '</li>';
+        $desc .= '<li>Mentors over capacity: ' . $overCapacity . '</li>';
+        $desc .= '</ul>';
+
+        return [
+            'label'       => function_exists('__') ? __('SmartAlloc health', 'smartalloc') : 'SmartAlloc health',
+            'status'      => $status,
+            'description' => $desc,
+        ];
+    }
+}

--- a/tests/Http/MetricsEndpointsTest.php
+++ b/tests/Http/MetricsEndpointsTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use SmartAlloc\Tests\BaseTestCase;
+
+require_once __DIR__ . '/../../scripts/metrics-endpoints.php';
+
+if (!class_exists('WP_Error')) {
+    class WP_Error { public function __construct(public string $c='', public string $m='', public array $d=[]){} public function get_error_data(): array { return $this->d; } }
+}
+if (!class_exists('WP_REST_Request')) { class WP_REST_Request { public function get_param($k){return null;} } }
+if (!class_exists('WP_REST_Response')) { class WP_REST_Response { public function __construct(private array $d=[], private int $s=200){} public function get_data(){return $this->d;} public function get_status(){return $this->s;} } }
+
+final class MetricsEndpointsTest extends BaseTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Monkey\setUp();
+    }
+    protected function tearDown(): void
+    {
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    public function test_requires_capability(): void
+    {
+        Functions\when('current_user_can')->justReturn(false);
+        $res = sa_metrics_handle(new WP_REST_Request());
+        $this->assertInstanceOf(WP_Error::class, $res);
+        $this->assertSame(403, $res->get_error_data()['status']);
+    }
+
+    public function test_returns_sorted_metrics(): void
+    {
+        Functions\when('current_user_can')->justReturn(true);
+        global $wpdb;
+        $wpdb = new class {
+            public $prefix = 'wp_';
+            public array $vars = [100, 5, 1, 2, 3];
+            public array $results = [
+                [ ['mentor_id'=>2,'assigned'=>20,'capacity'=>70], ['mentor_id'=>1,'assigned'=>10,'capacity'=>50] ],
+                [ ['center_id'=>10,'assigned'=>30,'capacity'=>120] ],
+                [ ['rule'=>'national_id_checksum','field'=>143,'count'=>2] ],
+            ];
+            public function get_var($sql){ return array_shift($this->vars); }
+            public function get_results($sql,$output){ return array_shift($this->results); }
+        };
+        $data = sa_metrics_handle(new WP_REST_Request())->get_data();
+        $this->assertSame(100, $data['allocations']['total']);
+        $this->assertSame(1, $data['allocations']['by_mentor'][0]['mentor_id']);
+        $this->assertSame(50, $data['allocations']['by_mentor'][0]['capacity']);
+        $this->assertSame(60, $data['allocations']['by_mentor'][1]['capacity']);
+        $this->assertSame('national_id_checksum', $data['validation_errors'][0]['rule']);
+        $this->assertMatchesRegularExpression('/T.*Z/', $data['timestamp_utc']);
+    }
+}

--- a/tests/Scripts/QaReportAggregationTest.php
+++ b/tests/Scripts/QaReportAggregationTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+use SmartAlloc\Tests\BaseTestCase;
+
+require_once __DIR__ . '/../../scripts/qa-report.php';
+
+final class QaReportAggregationTest extends BaseTestCase
+{
+    public function test_aggregates_signals_and_validations(): void
+    {
+        $root = sys_get_temp_dir() . '/sa_qa_' . uniqid();
+        $art = $root . '/artifacts';
+        @mkdir($art . '/coverage', 0777, true);
+        @mkdir($art . '/schema', 0777, true);
+        @mkdir($art . '/security', 0777, true);
+        @mkdir($art . '/compliance', 0777, true);
+        @mkdir($art . '/exporter', 0777, true);
+        @mkdir($art . '/validation', 0777, true);
+
+        file_put_contents($art . '/coverage/coverage.json', json_encode(['totals'=>['lines'=>['pct'=>95]]], JSON_UNESCAPED_SLASHES));
+        file_put_contents($art . '/schema/schema-validate.json', json_encode(['count'=>3], JSON_UNESCAPED_SLASHES));
+        file_put_contents($art . '/security/rest-permissions.json', json_encode(['summary'=>['routes'=>5,'mutating_warnings'=>1,'readonly_warnings'=>2]], JSON_UNESCAPED_SLASHES));
+        file_put_contents($art . '/security/sql-prepare.json', json_encode(['counts'=>['violations'=>1,'allowlisted'=>2]], JSON_UNESCAPED_SLASHES));
+        file_put_contents($art . '/security/secrets.json', json_encode(['counts'=>['violations'=>0,'allowlisted'=>0]], JSON_UNESCAPED_SLASHES));
+        file_put_contents($art . '/security/headers.json', json_encode(['counts'=>['missing'=>1,'allowlisted'=>0]], JSON_UNESCAPED_SLASHES));
+        file_put_contents($art . '/compliance/license-audit.json', json_encode(['counts'=>['unapproved'=>0]], JSON_UNESCAPED_SLASHES));
+        file_put_contents($art . '/exporter/validate.json', json_encode(['counts'=>['errors'=>0,'warnings'=>1]], JSON_UNESCAPED_SLASHES));
+        file_put_contents($art . '/validation/form150.json', json_encode(['violations'=>[
+            'national_id_checksum'=>1,
+            'mobile_prefix_09'=>2,
+            'landline_eq_mobile'=>3,
+            'duplicate_liaison_phone'=>4,
+            'postal_code_fuzzy'=>['accept'=>5,'manual'=>6,'reject'=>7],
+            'hikmat_tracking_sentinel'=>8,
+        ]], JSON_UNESCAPED_SLASHES));
+
+        $out = $root . '/out';
+        $rep1 = qa_report($root, $out);
+        $json1 = file_get_contents($out . '/qa-report.json');
+        $rep2 = qa_report($root, $out);
+        $json2 = file_get_contents($out . '/qa-report.json');
+
+        $this->assertSame($rep1['summary']['exporter']['warnings'], 1);
+        $this->assertSame(1, $rep1['summary']['validation']['national_id_checksum']);
+        $this->assertMatchesRegularExpression('/T.*Z/', $rep1['timestamp_utc']);
+        $this->assertSame($json1, $json2, 'Report must be deterministic');
+    }
+}

--- a/tests/Services/HealthCheckServiceTest.php
+++ b/tests/Services/HealthCheckServiceTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+use SmartAlloc\Services\HealthCheckService;
+use SmartAlloc\Tests\BaseTestCase;
+
+final class HealthCheckServiceTest extends BaseTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+    }
+
+    public function test_run_flags_issues_and_good_status(): void
+    {
+        global $wpdb;
+        $wpdb = new class {
+            public $prefix = 'wp_';
+            public function get_var($sql){
+                if (str_contains($sql, 'salloc_dlq')) return 1; // backlog
+                if (str_contains($sql, 'salloc_mentors')) return 2; // over capacity
+                return 1; // db ok
+            }
+        };
+        wp_cache_flush();
+        $svc = new HealthCheckService();
+        $res = $svc->run();
+        $this->assertSame('critical', $res['status']);
+
+        $wpdb = new class {
+            public $prefix = 'wp_';
+            public function get_var($sql){ return 0; }
+        };
+        wp_cache_flush();
+        wp_cache_set('__sa_health__', '1', 'smartalloc', 1);
+        $res2 = $svc->run();
+        $this->assertSame('good', $res2['status']);
+    }
+}


### PR DESCRIPTION
## Summary
- extend QA report to include exporter validation and detailed Form150 rule violations with timestamp
- add REST metrics endpoint exposing allocation, export, validation, and DLQ stats
- integrate SmartAlloc checks into WordPress Site Health
- document QA reports, metrics, and health checks

## Testing
- `vendor/bin/phpunit tests/Scripts/QaReportAggregationTest.php`
- `vendor/bin/phpunit tests/Http/MetricsEndpointsTest.php`
- `vendor/bin/phpunit tests/Services/HealthCheckServiceTest.php`
- `composer test` *(fails: Class SmartAlloc\Services\AllocationService@anonymous cannot extend final class SmartAlloc\Services\AllocationService)*

------
https://chatgpt.com/codex/tasks/task_e_68a809f8d8b08321bf7cdf10baf23c32