### PR TITLE
feat: improve allocation pipeline with async DLQ

### DIFF
--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -164,7 +164,8 @@ final class Bootstrap
 
         $c->set(NotificationService::class, fn() => new NotificationService(
             $c->get(CircuitBreaker::class),
-            $c->get(Logging::class)
+            $c->get(Logging::class),
+            $c->get(Metrics::class)
         ));
 
         $c->set(StatsService::class, fn() => new StatsService(

--- a/src/Http/RestController.php
+++ b/src/Http/RestController.php
@@ -29,10 +29,11 @@ final class RestController
             // Health endpoint
             register_rest_route('smartalloc/v1', '/health', [
                 'methods' => 'GET',
-                'permission_callback' => function (): bool {
-                    return current_user_can('read');
-                },
+                'permission_callback' => '__return_true',
                 'callback' => function() {
+                    if (!current_user_can('read')) {
+                        return new \WP_Error('forbidden', 'Forbidden', ['status' => 403]);
+                    }
                     return $this->container->get(HealthService::class)->status();
                 }
             ]);
@@ -40,10 +41,11 @@ final class RestController
             // Metrics endpoint
             register_rest_route('smartalloc/v1', '/metrics', [
                 'methods' => 'GET',
-                'permission_callback' => function() {
-                    return current_user_can(SMARTALLOC_CAP);
-                },
+                'permission_callback' => '__return_true',
                 'callback' => function() {
+                    if (!current_user_can(SMARTALLOC_CAP)) {
+                        return new \WP_Error('forbidden', 'Forbidden', ['status' => 403]);
+                    }
                     return $this->getMetrics();
                 }
             ]);

--- a/src/Listeners/NotifyListener.php
+++ b/src/Listeners/NotifyListener.php
@@ -16,7 +16,8 @@ final class NotifyListener implements ListenerInterface
 
     public function handle(string $event, array $payload): void
     {
+        $payload['event_name'] = $event;
         $notificationService = $this->container->get(\SmartAlloc\Services\NotificationService::class);
         $notificationService->send($payload);
     }
-} 
+}

--- a/src/Services/Db.php
+++ b/src/Services/Db.php
@@ -90,13 +90,14 @@ class Db
 
         $sql[] = "CREATE TABLE {$prefix}salloc_dlq (
             id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+            event_name VARCHAR(100) NOT NULL,
             payload_json LONGTEXT NOT NULL,
-            last_error TEXT NULL,
+            error_text TEXT NULL,
             attempts INT UNSIGNED NOT NULL DEFAULT 0,
             status VARCHAR(20) NOT NULL DEFAULT 'ready',
             created_at_utc DATETIME NOT NULL,
-            KEY idx_status (status),
-            KEY idx_created (created_at_utc)
+            KEY idx_retry (status, attempts),
+            KEY idx_event (event_name)
         ) $charset";
 
         $sql[] = "CREATE TABLE {$prefix}salloc_export_log (

--- a/src/Services/DlqService.php
+++ b/src/Services/DlqService.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SmartAlloc\Services;
+
+/**
+ * Dead letter queue storage service.
+ */
+final class DlqService
+{
+    private string $table;
+
+    public function __construct()
+    {
+        global $wpdb;
+        $this->table = $wpdb->prefix . 'salloc_dlq';
+    }
+
+    /**
+     * Push a payload to DLQ.
+     *
+     * @param array<string,mixed> $payload
+     */
+    public function push(string $event, array $payload, string $error, int $attempts): void
+    {
+        global $wpdb;
+        $wpdb->insert($this->table, [
+            'event_name'    => $event,
+            'payload_json'  => wp_json_encode($payload),
+            'error_text'    => $error,
+            'attempts'      => $attempts,
+            'status'        => 'ready',
+            'created_at_utc'=> gmdate('Y-m-d H:i:s'),
+        ]);
+    }
+
+    /**
+     * List last N DLQ items.
+     *
+     * @return array<int,array<string,mixed>>
+     */
+    public function list(int $limit = 200): array
+    {
+        global $wpdb;
+        $sql = $wpdb->prepare(
+            "SELECT id,event_name,payload_json,error_text,attempts,created_at_utc FROM {$this->table} WHERE status=%s ORDER BY id DESC LIMIT %d",
+            'ready',
+            $limit
+        );
+        // @security-ok-sql
+        $rows = $wpdb->get_results($sql, ARRAY_A) ?: [];
+        foreach ($rows as &$r) {
+            $r['payload'] = json_decode((string) $r['payload_json'], true);
+            unset($r['payload_json']);
+        }
+        unset($r);
+        return $rows;
+    }
+
+    /**
+     * Get single DLQ item.
+     *
+     * @return array<string,mixed>|null
+     */
+    public function get(int $id): ?array
+    {
+        global $wpdb;
+        $row = $wpdb->get_row(
+            $wpdb->prepare("SELECT * FROM {$this->table} WHERE id=%d AND status=%s", $id, 'ready'),
+            ARRAY_A
+        );
+        if (!$row) {
+            return null;
+        }
+        $row['payload'] = json_decode((string) $row['payload_json'], true);
+        unset($row['payload_json']);
+        return $row;
+    }
+
+    public function delete(int $id): void
+    {
+        global $wpdb;
+        $wpdb->delete($this->table, ['id' => $id]);
+    }
+
+    /**
+     * Retry a DLQ item.
+     */
+    public function retry(int $id): bool
+    {
+        $row = $this->get($id);
+        if (!$row || !is_array($row['payload'])) {
+            return false;
+        }
+        do_action('smartalloc_notify', ['payload' => $row['payload'], '_attempt' => 1]);
+        $this->delete($id);
+        return true;
+    }
+}

--- a/src/Services/RetryService.php
+++ b/src/Services/RetryService.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SmartAlloc\Services;
+
+/**
+ * Exponential backoff with jitter helper.
+ */
+final class RetryService
+{
+    public function __construct(private int $maxDelay = 60, private int $jitter = 3)
+    {
+    }
+
+    /**
+     * Calculate delay seconds for given attempt (1-based).
+     */
+    public function backoff(int $attempt): int
+    {
+        $base = (int) pow(2, max(0, $attempt - 1));
+        $base = min($this->maxDelay, $base);
+        $jitter = mt_rand(0, $this->jitter);
+        return $base + $jitter;
+    }
+}

--- a/tests/Integration/NotificationRetryDlqTest.php
+++ b/tests/Integration/NotificationRetryDlqTest.php
@@ -38,11 +38,11 @@ final class NotificationRetryDlqTest extends TestCase
 
         $attempt=0;
         $filters['smartalloc_notify_transport']=function($val,$payload,$a) use (&$attempt){ $attempt++; if($attempt<=3){ throw new RuntimeException('fail'); } return true; };
-        $payload=['x'=>1];
-        $service->handle($payload,1);
-        $service->handle($payload,2);
-        $service->handle($payload,3);
-        $service->handle($payload,4);
+        $payload=['x'=>1,'event_name'=>'e'];
+        $service->handle(['payload'=>$payload,'_attempt'=>1]);
+        $service->handle(['payload'=>$payload,'_attempt'=>2]);
+        $service->handle(['payload'=>$payload,'_attempt'=>3]);
+        $service->handle(['payload'=>$payload,'_attempt'=>4]);
         $this->assertCount(0,$wpdb->dlq);
     }
 
@@ -64,8 +64,8 @@ final class NotificationRetryDlqTest extends TestCase
         $metrics=new Metrics();
         $service=new NotificationService($breaker,new Logging(),$metrics);
         $filters['smartalloc_notify_transport']=function($v,$p,$a){ throw new RuntimeException('nope'); };
-        $payload=['y'=>2];
-        for($i=1;$i<=5;$i++){ $service->handle($payload,$i); }
+        $payload=['y'=>2,'event_name'=>'e'];
+        for($i=1;$i<=5;$i++){ $service->handle(['payload'=>$payload,'_attempt'=>$i]); }
         $this->assertCount(1,$wpdb->dlq);
         $this->assertSame(5,$wpdb->dlq[0]['attempts']);
     }

--- a/tests/unit/Allocation/AllocationServiceTest.php
+++ b/tests/unit/Allocation/AllocationServiceTest.php
@@ -1,0 +1,66 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use SmartAlloc\Services\AllocationService;
+use SmartAlloc\Services\Logging;
+use SmartAlloc\Services\ScoringAllocator;
+use SmartAlloc\Services\Metrics;
+use SmartAlloc\Event\EventBus;
+use SmartAlloc\Contracts\EventStoreInterface;
+use SmartAlloc\Domain\Allocation\AllocationResult;
+
+final class AllocationServiceTest extends TestCase
+{
+    private function makeService(): AllocationService
+    {
+        $GLOBALS['wpdb'] = new class {
+            public string $prefix = 'wp_';
+            public int $rows_affected = 0;
+            public array $params = [];
+            public array $mentors = [
+                2 => ['mentor_id'=>2,'gender'=>'M','center'=>'A','group_code'=>'G1','capacity'=>2,'assigned'=>1,'active'=>1,'allocations_new'=>0],
+                3 => ['mentor_id'=>3,'gender'=>'M','center'=>'A','group_code'=>'G1','capacity'=>2,'assigned'=>1,'active'=>1,'allocations_new'=>0],
+                4 => ['mentor_id'=>4,'gender'=>'M','center'=>'B','group_code'=>'G1','capacity'=>2,'assigned'=>0,'active'=>1,'allocations_new'=>0],
+                5 => ['mentor_id'=>5,'gender'=>'F','center'=>'A','group_code'=>'G1','capacity'=>2,'assigned'=>0,'active'=>1,'allocations_new'=>0],
+            ];
+            public function prepare($sql,...$args){ $this->params=$args; return $sql; }
+            public function get_results($sql,$mode){
+                [$gender,$center,$group] = $this->params;
+                $out = array_filter($this->mentors, function($m) use($gender,$center,$group){
+                    return $m['active']==1 && $m['assigned'] < $m['capacity'] && $m['gender']==$gender && $m['center']==$center && $m['group_code']==$group;
+                });
+                usort($out, fn($a,$b)=>$a['mentor_id']<=>$b['mentor_id']);
+                return $out;
+            }
+            public function query($sql){
+                if(preg_match('/mentor_id = (\d+)/',$sql,$m)){
+                    $id=(int)$m[1];
+                    if($this->mentors[$id]['assigned'] < $this->mentors[$id]['capacity']){
+                        $this->mentors[$id]['assigned']++; $this->rows_affected=1;
+                    } else { $this->rows_affected=0; }
+                }
+            }
+            public function insert($t,$d){}
+        };
+        $logger = new Logging();
+        $eventStore = new class implements EventStoreInterface {
+            public function insertEventIfNotExists(string $e,string $k,array $p): int {return 1;}
+            public function startListenerRun(int $e,string $l): int {return 1;}
+            public function finishListenerRun(int $i,string $s,?string $er): void {}
+            public function finishEvent(int $i,string $s,?string $e,int $d): void {}
+        };
+        $bus = new EventBus($logger,$eventStore);
+        $metrics = new Metrics();
+        return new AllocationService($logger,$bus,$metrics,new ScoringAllocator());
+    }
+
+    public function testFiltersRankingAndCommit(): void
+    {
+        $svc = $this->makeService();
+        $res = $svc->assign(['id'=>7,'gender'=>'M','center'=>'A','group_code'=>'G1']);
+        $this->assertInstanceOf(AllocationResult::class,$res);
+        $this->assertSame(2,$res->get('mentor_id'));
+        $this->assertSame(2,$GLOBALS['wpdb']->mentors[2]['assigned']);
+    }
+}

--- a/tests/unit/Event/EventBusTest.php
+++ b/tests/unit/Event/EventBusTest.php
@@ -1,0 +1,53 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use SmartAlloc\Event\EventBus;
+use SmartAlloc\Contracts\{EventStoreInterface,ListenerInterface,LoggerInterface};
+
+final class EventBusTest extends TestCase
+{
+    public function testDuplicateDispatchAndFailureLogging(): void
+    {
+        $store = new class implements EventStoreInterface {
+            public array $events = [];
+            public array $runs = [];
+            public int $nextId = 1;
+            public function insertEventIfNotExists(string $event, string $dedupeKey, array $payload): int {
+                if (isset($this->events[$dedupeKey])) { return 0; }
+                $id = $this->nextId++;
+                $this->events[$dedupeKey] = $id;
+                return $id;
+            }
+            public function startListenerRun(int $eventLogId, string $listener): int {
+                $this->runs[] = ['listener' => $listener];
+                return count($this->runs);
+            }
+            public function finishListenerRun(int $listenerRunId, string $status, ?string $error): void {
+                $this->runs[$listenerRunId-1]['status'] = $status;
+            }
+            public function finishEvent(int $eventLogId, string $status, ?string $error, int $durationMs): void {}
+        };
+        $logger = new class implements LoggerInterface {
+            public array $errors = [];
+            public function debug(string $m, array $c = []): void {}
+            public function info(string $m, array $c = []): void {}
+            public function warning(string $m, array $c = []): void {}
+            public function error(string $m, array $c = []): void { $this->errors[] = $m; }
+        };
+        $bus = new EventBus($logger, $store);
+        $bus->on('Evt', new class implements ListenerInterface {
+            public function handle(string $event, array $payload): void { throw new RuntimeException('boom'); }
+        });
+        $listener = new class implements ListenerInterface {
+            public bool $ran = false;
+            public function handle(string $event, array $payload): void { $this->ran = true; }
+        };
+        $bus->on('Evt', $listener);
+        $bus->dispatch('Evt', ['entry_id' => 5]);
+        $this->assertTrue($listener->ran);
+        $this->assertSame('failed', $store->runs[0]['status']);
+        $bus->dispatch('Evt', ['entry_id' => 5]);
+        $this->assertCount(2, $store->runs); // no new runs on duplicate
+    }
+}

--- a/tests/unit/Services/DlqServiceTest.php
+++ b/tests/unit/Services/DlqServiceTest.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use SmartAlloc\Services\DlqService;
+
+final class DlqServiceTest extends TestCase
+{
+    private function setupDb(): void
+    {
+        $GLOBALS['wpdb'] = new class {
+            public string $prefix = 'wp_';
+            public array $rows = [];
+            public int $auto = 1;
+            public function insert($table, $data){ $data['id']=$this->auto++; $this->rows[]=$data; }
+            public function prepare($sql,...$args){ return $sql; }
+            public function get_results($sql,$mode){ return array_map(fn($r)=>$r, $this->rows); }
+            public function get_row($sql,$mode){ return $this->rows[0]??null; }
+            public function delete($t,$w){ $this->rows=[]; }
+        };
+    }
+
+    public function testPushListGetDeleteRetry(): void
+    {
+        $this->setupDb();
+        $svc = new DlqService();
+        $svc->push('Evt',['a'=>1],'err',3);
+        $list = $svc->list();
+        $this->assertCount(1,$list);
+        $id = $list[0]['id'];
+        $item = $svc->get($id);
+        $this->assertSame('Evt',$item['event_name']);
+        $ok = $svc->retry($id);
+        $this->assertTrue($ok);
+        $this->assertCount(0,$svc->list());
+    }
+}

--- a/tests/unit/Services/RetryServiceTest.php
+++ b/tests/unit/Services/RetryServiceTest.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use SmartAlloc\Services\RetryService;
+
+final class RetryServiceTest extends TestCase
+{
+    public function testBackoffMonotonicAndBounded(): void
+    {
+        mt_srand(1);
+        $svc = new RetryService();
+        $delays = [];
+        for ($i = 1; $i <= 5; $i++) {
+            $delays[$i] = $svc->backoff($i);
+        }
+        $this->assertLessThan($delays[2], $delays[3]);
+        $this->assertLessThan($delays[3], $delays[4]);
+        foreach ($delays as $i => $d) {
+            $base = min(60, (int) pow(2, $i - 1));
+            $this->assertGreaterThanOrEqual($base, $d);
+            $this->assertLessThanOrEqual($base + 3, $d);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- ensure deterministic mentor ranking and scoring
- add retry service and durable dead letter queue with REST management
- enforce capability and structured errors on health and metrics endpoints

## Testing
- `vendor/bin/phpunit` *(fails: GA readiness warnings present)*
- `php scripts/coverage-import.php`
- `php scripts/artifact-schema-validate.php`
- `php scripts/ga-enforcer.php --profile=rc --junit`

------
https://chatgpt.com/codex/tasks/task_e_68a8139655e483219546a42c7b613527