### PR TITLE
feat: enforce deterministic artifacts and events

### DIFF
--- a/scripts/dist-manifest.php
+++ b/scripts/dist-manifest.php
@@ -28,9 +28,9 @@ $outDir = $root . '/artifacts/dist';
 if (!is_dir($outDir)) {
     mkdir($outDir, 0777, true);
 }
-$manifest = [
-    'entries' => $entries,
-    'generated_at_utc' => gmdate('c'),
-];
-file_put_contents($outDir . '/manifest.json', json_encode($manifest, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n");
+$manifest = ['entries' => $entries];
+file_put_contents(
+    $outDir . '/manifest.json',
+    json_encode($manifest, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n"
+);
 exit(0);

--- a/src/Cli/DoctorCommand.php
+++ b/src/Cli/DoctorCommand.php
@@ -56,7 +56,8 @@ final class DoctorCommand
 
         $dlqTable = $wpdb->prefix . 'salloc_dlq';
         $backlog = (int) ($wpdb->get_var("SELECT COUNT(*) FROM {$dlqTable}") ?: 0); // @security-ok-sql
-        $queueOk = $backlog < 100;
+        $threshold = (int) apply_filters('smartalloc_dlq_backlog_threshold', 100);
+        $queueOk = $backlog < $threshold;
 
         return [
             ['label' => __('DB tables', 'smartalloc'), 'status' => (bool) $exists],

--- a/src/Event/EventKey.php
+++ b/src/Event/EventKey.php
@@ -14,10 +14,10 @@ final class EventKey
      */
     public static function make(string $event, array $payload, string $version = 'v1'): string
     {
-        if (isset($payload['dedupe_key'])) {
+        if (isset($payload['dedupe_key']) && is_string($payload['dedupe_key'])) {
             return $payload['dedupe_key'];
         }
-        $entry = $payload['entry_id'] ?? ($payload['id'] ?? uniqid('', true));
+        $entry = (string)($payload['entry_id'] ?? '0');
         return $event . ':' . $entry . ':' . $version;
     }
 }

--- a/src/Http/Rest/DlqController.php
+++ b/src/Http/Rest/DlqController.php
@@ -52,12 +52,12 @@ final class DlqController
                 200
             );
             $out[] = [
-                'id'         => (int) $r['id'],
-                'event_name' => (string) $r['event_name'],
-                'attempts'   => (int) $r['attempts'],
-                'error_text' => $r['error_text'],
-                'created_at' => $r['created_at'],
-                'payload'    => $preview,
+                'id'              => (int) $r['id'],
+                'event_name'      => (string) $r['event_name'],
+                'attempts'        => (int) $r['attempts'],
+                'error_text'      => $r['error_text'],
+                'created_at'      => $r['created_at'],
+                'payload_preview' => $preview,
             ];
         }
         return new WP_REST_Response($out, 200);

--- a/tests/Http/DlqRoutesTest.php
+++ b/tests/Http/DlqRoutesTest.php
@@ -29,6 +29,7 @@ final class DlqRoutesTest extends TestCase
             public function get_row($sql,$mode){ foreach($this->dlq as $r){ if($r['id']==$this->lastId){ return $r; } } return null; }
             public function delete($t,$w){ foreach($this->dlq as $i=>$r){ if($r['id']==$w['id']){ unset($this->dlq[$i]); }} }
             public function insert($t,$d){}
+            public function query($sql){}
         };
     }
 
@@ -50,7 +51,9 @@ final class DlqRoutesTest extends TestCase
         $resp=$controller->list(new WP_REST_Request());
         $this->assertInstanceOf(WP_REST_Response::class,$resp);
         $this->assertSame(200,$resp->get_status());
-        $this->assertCount(2,$resp->get_data());
+        $data=$resp->get_data();
+        $this->assertCount(2,$data);
+        $this->assertArrayHasKey('payload_preview',$data[0]);
     }
 
     public function testRetryMissingItem(): void

--- a/tests/Integration/NotificationRetryDlqTest.php
+++ b/tests/Integration/NotificationRetryDlqTest.php
@@ -29,6 +29,7 @@ final class NotificationRetryDlqTest extends TestCase
             public function get_row($sql){ return null; }
             public function replace($t,$d){ }
             public function prepare($sql,...$args){ return $sql; }
+            public function query($sql){}
         };
         $GLOBALS['wpdb']=$wpdb;
 
@@ -58,6 +59,7 @@ final class NotificationRetryDlqTest extends TestCase
             public function get_row($sql){ return null; }
             public function replace($t,$d){ }
             public function prepare($sql,...$args){ return $sql; }
+            public function query($sql){}
         };
         $GLOBALS['wpdb']=$wpdb;
         $breaker = new CircuitBreaker();

--- a/tests/unit/Release/DistManifestCanonicalTest.php
+++ b/tests/unit/Release/DistManifestCanonicalTest.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class DistManifestCanonicalTest extends TestCase
+{
+    public function test_manifest_only_has_canonical_entries(): void
+    {
+        $root = dirname(__DIR__,3);
+        $tmp = sa_tests_temp_dir('manifest2');
+        file_put_contents($tmp.'/one.txt','1');
+        exec(sprintf('%s %s %s',
+            escapeshellarg(PHP_BINARY),
+            escapeshellarg($root.'/scripts/dist-manifest.php'),
+            escapeshellarg($tmp)
+        ), $_, $rc);
+        $this->assertSame(0,$rc);
+        $manifest = json_decode((string)file_get_contents($root.'/artifacts/dist/manifest.json'), true);
+        $this->assertSame(['entries'], array_keys($manifest));
+        foreach ($manifest['entries'] as $e) {
+            $this->assertSame(['path','sha256','size'], array_keys($e));
+            $this->assertSame(64, strlen($e['sha256']));
+        }
+    }
+}

--- a/tests/unit/Release/DistManifestTest.php
+++ b/tests/unit/Release/DistManifestTest.php
@@ -22,7 +22,6 @@ final class DistManifestTest extends TestCase
         $this->assertFileExists($manifestPath);
         $m = json_decode((string)file_get_contents($manifestPath), true);
         $this->assertIsArray($m['entries'] ?? null);
-        $this->assertArrayHasKey('generated_at_utc',$m);
         $this->assertSame('a.txt', $m['entries'][0]['path'] ?? '');
         $this->assertSame('b.txt', $m['entries'][1]['path'] ?? '');
         foreach ($m['entries'] as $e) {

--- a/tests/unit/Release/GAEnforcerCoverageTest.php
+++ b/tests/unit/Release/GAEnforcerCoverageTest.php
@@ -36,6 +36,15 @@ final class GAEnforcerCoverageTest extends TestCase
             ],
         ];
         file_put_contents($rootArtifacts . '/dist/manifest.json', json_encode($clean));
+        $stubScripts = ['scan-sql-prepare.php','dist-manifest.php'];
+        $backups = [];
+        foreach ($stubScripts as $s) {
+            $orig = __DIR__ . '/../../../scripts/' . $s;
+            $bak = $orig . '.bak';
+            $backups[$orig] = $bak;
+            rename($orig, $bak);
+            file_put_contents($orig, "<?php\nexit(0);\n");
+        }
 
         putenv('RUN_ENFORCE');
         $cmd = PHP_BINARY . ' '
@@ -67,5 +76,7 @@ final class GAEnforcerCoverageTest extends TestCase
 
         $report = json_decode((string)file_get_contents($rootArtifacts . '/ga/GA_ENFORCER.json'), true);
         $this->assertGreaterThan(0, $report['signals']['schema_warnings'] ?? 0);
+        putenv('RUN_ENFORCE');
+        foreach ($backups as $orig => $bak) { rename($bak, $orig); }
     }
 }

--- a/tests/unit/Release/GAEnforcerDistTest.php
+++ b/tests/unit/Release/GAEnforcerDistTest.php
@@ -9,6 +9,7 @@ final class GAEnforcerDistTest extends TestCase
 
     protected function setUp(): void
     {
+        putenv('RUN_ENFORCE');
         $this->origReadme = (string)file_get_contents('readme.txt');
         @mkdir('artifacts/ga', 0777, true);
         @mkdir('artifacts/dist', 0777, true);

--- a/tests/unit/Release/GAEnforcerI18nWporgTest.php
+++ b/tests/unit/Release/GAEnforcerI18nWporgTest.php
@@ -43,5 +43,6 @@ class GAEnforcerI18nWporgTest extends TestCase
         $this->assertStringContainsString('i18n lint warnings present', $xml);
         $this->assertStringContainsString('<testcase name="WPOrg.Preflight"', $xml);
         $this->assertStringContainsString('wporg preflight warnings present', $xml);
+        putenv('RUN_ENFORCE');
     }
 }

--- a/tests/unit/Release/GAEnforcerProfilesTest.php
+++ b/tests/unit/Release/GAEnforcerProfilesTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 final class GAEnforcerProfilesTest extends TestCase
 {
     private string $root;
+    private string $schemaScriptBak;
 
     protected function setUp(): void
     {
@@ -17,7 +18,9 @@ final class GAEnforcerProfilesTest extends TestCase
         @mkdir($this->root . '/artifacts/dist', 0777, true);
         @mkdir($this->root . '/artifacts/ga', 0777, true);
         file_put_contents($this->root . '/artifacts/coverage/coverage.json', json_encode(['totals' => ['pct' => 50]]) );
-        file_put_contents($this->root . '/artifacts/schema/schema-validate.json', json_encode(['count' => 5]));
+        $this->schemaScriptBak = $this->root . '/scripts/artifact-schema-validate.php.bak';
+        rename($this->root . '/scripts/artifact-schema-validate.php', $this->schemaScriptBak);
+        file_put_contents($this->root . '/scripts/artifact-schema-validate.php', "<?php\nfile_put_contents(__DIR__.'/../../artifacts/schema/schema-validate.json', json_encode(['count'=>5]));\n");
     }
 
     public function test_rc_profile_skips_failures(): void
@@ -40,6 +43,13 @@ final class GAEnforcerProfilesTest extends TestCase
         $this->assertNotEmpty($cov->failure);
         $schema = $xml->xpath('//testcase[@name="Artifacts.Schema"]')[0];
         $this->assertNotEmpty($schema->failure);
+    }
+
+    protected function tearDown(): void
+    {
+        if (isset($this->schemaScriptBak)) {
+            rename($this->schemaScriptBak, $this->root . '/scripts/artifact-schema-validate.php');
+        }
     }
 }
 

--- a/tests/unit/Release/GAEnforcerRestTest.php
+++ b/tests/unit/Release/GAEnforcerRestTest.php
@@ -11,6 +11,7 @@ final class GAEnforcerRestTest extends TestCase
 
     protected function setUp(): void
     {
+        putenv('RUN_ENFORCE');
         $this->dir = sys_get_temp_dir() . '/ga-rest-' . uniqid();
         mkdir($this->dir, 0777, true);
         mkdir($this->dir . '/scripts', 0777, true);

--- a/tests/unit/Release/GAEnforcerSchemaTest.php
+++ b/tests/unit/Release/GAEnforcerSchemaTest.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class GAEnforcerSchemaTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        @mkdir('artifacts/schema',0777,true);
+        @mkdir('artifacts/ga',0777,true);
+        file_put_contents('artifacts/schema/schema-validate.json', json_encode(['count'=>5]));
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink('scripts/.ga-enforce.json');
+    }
+
+    public function test_schema_warning_gates(): void
+    {
+        file_put_contents('scripts/.ga-enforce.json', json_encode([
+            'schema_warnings' => 0,
+        ]));
+        exec('RUN_ENFORCE=0 php scripts/ga-enforcer.php --profile=rc --junit', $_, $rc);
+        $this->assertSame(0,$rc);
+        $xml = (string)file_get_contents('artifacts/ga/GA_ENFORCER.junit.xml');
+        $this->assertStringContainsString('<testcase name="Artifacts.Schema"', $xml);
+        $this->assertStringContainsString('<skipped', $xml);
+
+        exec('RUN_ENFORCE=1 php scripts/ga-enforcer.php --profile=ga --enforce --junit', $_, $rc2);
+        $this->assertNotSame(0,$rc2);
+        $xml = (string)file_get_contents('artifacts/ga/GA_ENFORCER.junit.xml');
+        $this->assertStringContainsString('<testcase name="Artifacts.Schema"', $xml);
+        $this->assertStringContainsString('<failure', $xml);
+    }
+}

--- a/tests/unit/Release/GAEnforcerSqlPrepareTest.php
+++ b/tests/unit/Release/GAEnforcerSqlPrepareTest.php
@@ -11,6 +11,7 @@ final class GAEnforcerSqlPrepareTest extends TestCase
 
     protected function setUp(): void
     {
+        putenv('RUN_ENFORCE');
         $this->dir = sys_get_temp_dir() . '/ga-sql-' . uniqid();
         mkdir($this->dir, 0777, true);
         mkdir($this->dir . '/scripts', 0777, true);


### PR DESCRIPTION
## Summary
- normalize dist manifest to canonical entries only
- harden DLQ/health checks and event key generation
- add GA enforcer schema coverage and manifest tests

## Testing
- `php vendor/phpunit/phpunit/phpunit tests/unit/Services/DlqServiceTest.php`
- `php scripts/coverage-import.php`
- `php scripts/artifact-schema-validate.php`
- `php scripts/ga-enforcer.php --profile=rc --junit`


------
https://chatgpt.com/codex/tasks/task_e_68a81e4af0648321b97b0580ac8b5e36