### PR TITLE
Add allocation contract and architecture tests

### DIFF
--- a/src/Services/ErrorResponse.php
+++ b/src/Services/ErrorResponse.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+
+namespace SmartAlloc\Services;
+
+use InvalidArgumentException;
+use WP_Error;
+
+/**
+ * Helper to normalize error responses for external consumers.
+ */
+final class ErrorResponse
+{
+    /**
+     * @param \Throwable|WP_Error $error
+     * @return array{error: array{code:string,message:string,details:array}}
+     */
+    public static function from($error): array
+    {
+        if ($error instanceof WP_Error) {
+            $code = strtoupper($error->get_error_code());
+            $message = method_exists($error, 'get_error_message') ? $error->get_error_message() : ($error->message ?? '');
+            $details = self::mask((array) $error->get_error_data());
+            return ['error' => ['code' => $code, 'message' => $message, 'details' => $details]];
+        }
+
+        if ($error instanceof InvalidArgumentException) {
+            return ['error' => ['code' => 'INVALID_INPUT', 'message' => $error->getMessage(), 'details' => []]];
+        }
+
+        return ['error' => ['code' => 'INTERNAL_ERROR', 'message' => $error->getMessage(), 'details' => []]];
+    }
+
+    /**
+     * @param array<string,mixed> $details
+     * @return array<string,mixed>
+     */
+    private static function mask(array $details): array
+    {
+        $masked = [];
+        foreach ($details as $key => $value) {
+            $masked[$key] = is_scalar($value) ? '***' : $value;
+        }
+        return $masked;
+    }
+}

--- a/tests/Architecture/ArchitectureTest.php
+++ b/tests/Architecture/ArchitectureTest.php
@@ -1,0 +1,109 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class ArchitectureTest extends TestCase
+{
+    private function scanFiles(string $path, callable $filter): array
+    {
+        $rii = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($path));
+        $offenders = [];
+        foreach ($rii as $file) {
+            if (!$file->isFile() || $file->getExtension() !== 'php') {
+                continue;
+            }
+            $content = file_get_contents($file->getPathname()) ?: '';
+            if ($filter($content)) {
+                $offenders[] = $file->getPathname();
+            }
+        }
+        return $offenders;
+    }
+
+    public function test_domain_layer_independence(): void
+    {
+        $paths = [
+            __DIR__.'/../../src/Command',
+            __DIR__.'/../../src/Event',
+            __DIR__.'/../../src/Contracts',
+        ];
+        $offenders = [];
+        foreach ($paths as $p) {
+            if (!is_dir($p)) { continue; }
+            $offenders = array_merge($offenders, $this->scanFiles($p, function(string $c){
+                return (bool) preg_match('/global \$wpdb|wp_\w+\(|get_option\(/i', $c);
+            }));
+        }
+        // check Allocation services separately
+        foreach (glob(__DIR__.'/../../src/Services/Allocation*.php') as $file) {
+            $c = file_get_contents($file) ?: '';
+            if (preg_match('/global \$wpdb|wp_\w+\(|get_option\(/i', $c)) {
+                $offenders[] = $file;
+            }
+        }
+        $this->assertSame([], $offenders, 'WP globals used: '.implode(', ', $offenders));
+    }
+
+    public function test_service_layer_database_independence(): void
+    {
+        $paths = [__DIR__.'/../../src/Domain'];
+        foreach (glob(__DIR__.'/../../src/Services/Allocation*.php') as $f) { $paths[] = $f; }
+        $offenders = [];
+        foreach ($paths as $p) {
+            if (is_dir($p)) {
+                $offenders = array_merge($offenders, $this->scanFiles($p, function(string $c){
+                    return (bool) preg_match('/mysqli_|new\s+PDO/i', $c);
+                }));
+            } else {
+                $c = file_get_contents($p) ?: '';
+                if (preg_match('/mysqli_|new\s+PDO/i', $c)) {
+                    $offenders[] = $p;
+                }
+            }
+        }
+        $this->assertSame([], $offenders, 'Raw DB usage: '.implode(', ', $offenders));
+    }
+
+    public function test_naming_conventions(): void
+    {
+        $files = glob(__DIR__.'/../../src/Services/Allocation*.php');
+        $bad = [];
+        foreach ($files as $file) {
+            $content = file_get_contents($file) ?: '';
+            if (preg_match('/class\s+(\w+)/', $content, $m)) {
+                $class = $m[1];
+                if (!preg_match('/(Service|Controller|Listener|Command)$/', $class)) {
+                    $bad[] = $file;
+                }
+            }
+            if (preg_match_all('/function\s+(\w+)\s*\(/', $content, $m)) {
+                foreach ($m[1] as $method) {
+                    if ($method[0] !== '_' && !preg_match('/^[a-z][A-Za-z0-9]*$/', $method)) {
+                        $bad[] = $file."::{$method}";
+                    }
+                }
+            }
+            if (preg_match_all('/const\s+(\w+)/', $content, $m)) {
+                foreach ($m[1] as $const) {
+                    if ($const !== strtoupper($const)) {
+                        $bad[] = $file."::{$const}";
+                    }
+                }
+            }
+        }
+        $this->assertSame([], $bad, 'Naming violations: '.implode(', ', $bad));
+    }
+
+    public function test_dependency_direction(): void
+    {
+        $scanDirs = [__DIR__.'/../../src/Contracts', __DIR__.'/../../src/Services'];
+        $offenders = [];
+        foreach ($scanDirs as $dir) {
+            $offenders = array_merge($offenders, $this->scanFiles($dir, function(string $c){
+                return (bool) preg_match('/SmartAlloc\\\\(Integration|Http|Admin)\\\\/i', $c) && preg_match('/namespace\s+SmartAlloc\\\\(?!Integration|Http|Admin)/', $c);
+            }));
+        }
+        $this->assertSame([], $offenders, 'Dependency violations: '.implode(', ', $offenders));
+    }
+}

--- a/tests/Contract/AllocationContractTest.php
+++ b/tests/Contract/AllocationContractTest.php
@@ -1,0 +1,153 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use SmartAlloc\Services\AllocationService;
+use SmartAlloc\Services\Logging;
+use SmartAlloc\Services\Metrics;
+use SmartAlloc\Services\ScoringAllocator;
+use SmartAlloc\Event\EventBus;
+use SmartAlloc\Contracts\EventStoreInterface;
+use SmartAlloc\Domain\Allocation\AllocationResult;
+use SmartAlloc\Services\ErrorResponse;
+require_once __DIR__.'/../Helpers/AssertArrayShape.php';
+use SmartAlloc\Tests\Helpers\AssertArrayShape;
+
+if (!class_exists('WP_Error')) {
+    class WP_Error {
+        public function __construct(public string $code = '', public string $message = '', public array $data = []) {}
+        public function get_error_data(): array { return $this->data; }
+        public function get_error_code(): string { return $this->code; }
+        public function get_error_message(): string { return $this->message; }
+    }
+}
+
+if (!class_exists('wpdb')) {
+    class wpdb {
+        public string $prefix = 'wp_';
+        public int $rows_affected = 0;
+        public array $mentors = [
+            2 => ['mentor_id'=>2,'gender'=>'M','center'=>1,'group_code'=>'G1','capacity'=>2,'assigned'=>1,'active'=>1],
+        ];
+        public function get_results($sql,$mode){ return array_values($this->mentors); }
+        public function query(string $sql){ $this->rows_affected = 1; }
+        public function insert(string $t, array $d){}
+        public function prepare(string $sql, ...$args): string {
+            $params = is_array($args[0] ?? null) ? $args[0] : $args;
+            foreach ($params as $p) {
+                $sql = preg_replace('/%d/', (string) (int) $p, $sql, 1);
+                $sql = preg_replace('/%s/', "'" . $p . "'", $sql, 1);
+                $sql = preg_replace('/%f/', (string) (float) $p, $sql, 1);
+            }
+            return $sql;
+        }
+    }
+}
+
+final class AllocationContractTest extends TestCase
+{
+    use AssertArrayShape;
+
+    private function makeService(): AllocationService
+    {
+        $wpdb = new wpdb();
+        $GLOBALS['wpdb'] = $wpdb;
+
+        $logger = new Logging();
+        $eventStore = new class implements EventStoreInterface {
+            public array $events = [];
+            public function insertEventIfNotExists(string $e,string $k,array $p): int { $this->events[]=$e; return count($this->events); }
+            public function startListenerRun(int $e,string $l): int {return 1;}
+            public function finishListenerRun(int $i,string $s,?string $er,int $d): void {}
+            public function finishEvent(int $i,string $s,?string $e,int $d): void {}
+        };
+        $bus = new EventBus($logger,$eventStore);
+        $metrics = new Metrics();
+        return new AllocationService($logger,$bus,$metrics,new ScoringAllocator(),$wpdb);
+    }
+
+    public static function allocationInputProvider(): array
+    {
+        return [
+            'valid fixture' => [include __DIR__.'/../fixtures/allocation/valid.php', true],
+            'missing field' => [include __DIR__.'/../fixtures/allocation/invalid_missing.php', false],
+            'extra field' => [include __DIR__.'/../fixtures/allocation/invalid_extra.php', false],
+            'invalid gender' => [[ 'student_id'=>1,'center_id'=>1,'gender'=>'X'], false],
+        ];
+    }
+
+    /** @dataProvider allocationInputProvider */
+    public function test_allocation_input_contract(array $payload, bool $ok): void
+    {
+        $service = $this->makeService();
+        $ref = new ReflectionClass($service);
+        $method = $ref->getMethod('validateInput');
+        $method->setAccessible(true);
+        if (!$ok) {
+            $this->expectException(InvalidArgumentException::class);
+        }
+        $normalized = $method->invoke($service,$payload);
+        if ($ok) {
+            self::assertSame('M', $normalized['gender']);
+            self::assertIsInt($normalized['student_id']);
+            self::assertIsInt($normalized['center_id']);
+        }
+    }
+
+    public function test_allocation_output_contract(): void
+    {
+        $service = $this->makeService();
+        $payload = include __DIR__.'/../fixtures/allocation/valid.php';
+        $result = $service->assign($payload);
+        $this->assertInstanceOf(AllocationResult::class,$result);
+        $data = $result->to_array();
+        self::assertArrayShape([
+            'mentor_id' => 'int',
+            'committed' => 'bool',
+            'metadata' => 'array',
+        ], $data);
+        $this->assertGreaterThan(0,$data['mentor_id']);
+        $this->assertTrue($data['committed']);
+        self::assertArrayShape([
+            'score'=>'float',
+            'selected_strategy'=>'string',
+            'tie_breaker'=>'string',
+        ], $data['metadata']);
+
+        // no capacity path
+        $GLOBALS['wpdb']->mentors = []; // empty mentors
+        $result2 = $service->assign($payload);
+        $data2 = $result2->to_array();
+        self::assertArrayShape([
+            'mentor_id' => 'int',
+            'committed' => 'bool',
+            'metadata' => 'array',
+        ], $data2);
+        $this->assertSame(0,$data2['mentor_id']);
+        $this->assertFalse($data2['committed']);
+    }
+
+    public function test_error_response_contract(): void
+    {
+        $err = new WP_Error('no_capacity','No mentors',['student_id'=>99]);
+        $arr = ErrorResponse::from($err);
+        self::assertArrayShape([
+            'error'=>'array',
+        ], $arr);
+        self::assertArrayShape([
+            'code'=>'string',
+            'message'=>'string',
+            'details'=>'array',
+        ], $arr['error']);
+        $this->assertSame('NO_CAPACITY',$arr['error']['code']);
+        $this->assertSame('***',$arr['error']['details']['student_id']);
+
+        $ex = new InvalidArgumentException('bad');
+        $arr2 = ErrorResponse::from($ex);
+        $this->assertSame('INVALID_INPUT',$arr2['error']['code']);
+
+        $ex2 = new RuntimeException('boom');
+        $arr3 = ErrorResponse::from($ex2);
+        $this->assertSame('INTERNAL_ERROR',$arr3['error']['code']);
+    }
+}

--- a/tests/Helpers/AssertArrayShape.php
+++ b/tests/Helpers/AssertArrayShape.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+namespace SmartAlloc\Tests\Helpers;
+
+use PHPUnit\Framework\Assert;
+
+/**
+ * Simple assertion helper for array shapes.
+ */
+trait AssertArrayShape
+{
+    /**
+     * Assert that array has expected keys and value types.
+     *
+     * @param array<string,string> $shape key => type
+     * @param array<string,mixed> $actual
+     */
+    public static function assertArrayShape(array $shape, array $actual): void
+    {
+        foreach ($shape as $key => $type) {
+            Assert::assertArrayHasKey($key, $actual, "Missing key '{$key}'");
+            $value = $actual[$key];
+            switch ($type) {
+                case 'int':
+                    Assert::assertIsInt($value, "Key '{$key}' is not int");
+                    break;
+                case 'bool':
+                    Assert::assertIsBool($value, "Key '{$key}' is not bool");
+                    break;
+                case 'array':
+                    Assert::assertIsArray($value, "Key '{$key}' is not array");
+                    break;
+                case 'string':
+                    Assert::assertIsString($value, "Key '{$key}' is not string");
+                    break;
+                case 'float':
+                    Assert::assertIsFloat($value, "Key '{$key}' is not float");
+                    break;
+                default:
+                    Assert::fail("Unsupported type assertion '{$type}' for key '{$key}'");
+            }
+        }
+    }
+}

--- a/tests/fixtures/allocation/invalid_extra.php
+++ b/tests/fixtures/allocation/invalid_extra.php
@@ -1,0 +1,7 @@
+<?php
+return [
+    'student_id' => 1,
+    'center_id' => 2,
+    'gender' => 'M',
+    'unknown' => 'x',
+];

--- a/tests/fixtures/allocation/invalid_missing.php
+++ b/tests/fixtures/allocation/invalid_missing.php
@@ -1,0 +1,5 @@
+<?php
+return [
+    'student_id' => 1,
+    'gender' => 'F',
+];

--- a/tests/fixtures/allocation/valid.php
+++ b/tests/fixtures/allocation/valid.php
@@ -1,0 +1,8 @@
+<?php
+return [
+    'student_id' => 10,
+    'center_id' => 1,
+    'gender' => 'm',
+    'group_code' => 'G1',
+    'preferences' => ['math','science'],
+];


### PR DESCRIPTION
## Summary
- add input validator and metadata structure to AllocationService
- normalize API error responses via new ErrorResponse helper
- add PHPUnit contract and architecture tests with array shape helper and fixtures

## Testing
- `vendor/bin/phpunit --filter AllocationContractTest`
- `vendor/bin/phpunit --filter ArchitectureTest`


------
https://chatgpt.com/codex/tasks/task_e_68a833b408c083219a123569c4a75c0b