### PR TITLE
feat: add performance scaffolding

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -32,6 +32,12 @@
         <testsuite name="PropertyBased">
             <directory>tests/Property</directory>
         </testsuite>
+        <testsuite name="Performance">
+            <directory>tests/Performance</directory>
+        </testsuite>
+        <testsuite name="Regression">
+            <directory>tests/Regression</directory>
+        </testsuite>
     </testsuites>
     <coverage>
         <include>

--- a/src/Perf/QueryCounter.php
+++ b/src/Perf/QueryCounter.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SmartAlloc\Perf;
+
+/**
+ * Simple query counter for tests. Wraps global $wpdb->queries if available.
+ */
+final class QueryCounter
+{
+    private int $start = 0;
+
+    public function start(): void
+    {
+        global $wpdb;
+        if (is_object($wpdb) && is_array($wpdb->queries ?? null)) {
+            $this->start = count($wpdb->queries);
+        } else {
+            $this->start = 0;
+        }
+    }
+
+    /**
+     * @return int Number of queries executed since start()
+     */
+    public function stop(): int
+    {
+        global $wpdb;
+        if (!is_object($wpdb) || !is_array($wpdb->queries ?? null)) {
+            return 0;
+        }
+
+        return max(0, count($wpdb->queries) - $this->start);
+    }
+}
+

--- a/src/Perf/Stopwatch.php
+++ b/src/Perf/Stopwatch.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SmartAlloc\Perf;
+
+/**
+ * Lightweight stopwatch utility using hrtime().
+ */
+final class Stopwatch
+{
+    /**
+     * Measure the execution time of a callable.
+     *
+     * @template T
+     * @param callable():T $fn
+     * @return PerfResult<T>
+     */
+    public static function measure(callable $fn): PerfResult
+    {
+        $start = hrtime(true);
+        $return = $fn();
+        $end = hrtime(true);
+
+        return new PerfResult(($end - $start) / 1_000_000, $return);
+    }
+}
+
+/**
+ * Result wrapper for Stopwatch::measure.
+ *
+ * @template T
+ */
+final class PerfResult
+{
+    /**
+     * @param float $durationMs Duration in milliseconds
+     * @param T $result Return value from the measured callable
+     */
+    public function __construct(
+        public readonly float $durationMs,
+        public readonly mixed $result,
+    ) {
+    }
+}
+

--- a/tests/Fixtures/BulkDatasetBuilder.php
+++ b/tests/Fixtures/BulkDatasetBuilder.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SmartAlloc\Tests\Fixtures;
+
+/**
+ * Deterministic bulk dataset builder for performance tests.
+ */
+final class BulkDatasetBuilder
+{
+    /**
+     * @return array<int,array<string,mixed>>
+     */
+    public static function buildStudents(int $count): array
+    {
+        $students = [];
+        for ($i = 1; $i <= $count; $i++) {
+            $students[] = [
+                'student_id' => $i,
+                'gender' => $i % 2 === 0 ? 'f' : 'm',
+                'center' => 'c' . ($i % 10),
+            ];
+        }
+        return $students;
+    }
+
+    /**
+     * @return array<int,array<string,mixed>>
+     */
+    public static function buildMentors(int $count): array
+    {
+        $mentors = [];
+        for ($i = 1; $i <= $count; $i++) {
+            $mentors[] = [
+                'mentor_id' => $i,
+                'gender' => $i % 2 === 0 ? 'f' : 'm',
+                'center' => 'c' . ($i % 10),
+                'capacity' => 5,
+                'assigned' => 0,
+            ];
+        }
+        return $mentors;
+    }
+}
+

--- a/tests/Performance/AllocationPerfTest.php
+++ b/tests/Performance/AllocationPerfTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SmartAlloc\Tests\Performance;
+
+use PHPUnit\Framework\TestCase;
+use SmartAlloc\Perf\QueryCounter;
+use SmartAlloc\Perf\Stopwatch;
+use SmartAlloc\Tests\Fixtures\BulkDatasetBuilder;
+
+final class AllocationPerfTest extends TestCase
+{
+    public function testAllocate1k(): void
+    {
+        global $wpdb;
+        if (!is_object($wpdb) || !isset($wpdb->queries)) {
+            $this->markTestSkipped('wpdb query tracking not available');
+        }
+
+        $students = BulkDatasetBuilder::buildStudents(1000);
+        $mentors = BulkDatasetBuilder::buildMentors(200);
+
+        $counter = new QueryCounter();
+        $counter->start();
+        $result = Stopwatch::measure(function () use (&$students, &$mentors): void {
+            $mentorIndex = 0;
+            $mentorCount = count($mentors);
+            foreach ($students as $_) {
+                $mentors[$mentorIndex]['assigned']++;
+                $mentorIndex = ($mentorIndex + 1) % $mentorCount;
+            }
+        });
+        $queries = $counter->stop();
+
+        $budgetMs = (float) (getenv('SMARTALLOC_PERF_BUDGET_ALLOCATE_1K_MS') ?: 2500);
+        $budgetQueries = (int) (getenv('SMARTALLOC_PERF_BUDGET_QUERIES_ALLOCATE_1K') ?: 2000);
+
+        $this->assertLessThanOrEqual($budgetMs, $result->durationMs, 'p95 allocate 1k');
+        $this->assertLessThanOrEqual($budgetQueries, $queries, 'queries per allocate 1k');
+    }
+}
+

--- a/tests/Regression/QueryPlanGuardTest.php
+++ b/tests/Regression/QueryPlanGuardTest.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SmartAlloc\Tests\Regression;
+
+use PHPUnit\Framework\TestCase;
+
+final class QueryPlanGuardTest extends TestCase
+{
+    public function testNPlusOneDetectionPlaceholder(): void
+    {
+        $this->markTestSkipped('N+1 detection not implemented');
+    }
+}
+

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -15,6 +15,7 @@ require_once __DIR__ . '/_support/Gini.php';
 require_once __DIR__ . '/Fixtures/MentorFactory.php';
 require_once __DIR__ . '/Fixtures/StudentFactory.php';
 require_once __DIR__ . '/Fixtures/CrosswalkFactory.php';
+require_once __DIR__ . '/Fixtures/BulkDatasetBuilder.php';
 
 // Ensure WP_DEBUG is enabled but errors are not displayed
 if (!defined('WP_DEBUG')) {


### PR DESCRIPTION
## Summary
- add hrtime-based `Stopwatch` and `QueryCounter`
- introduce deterministic bulk dataset builder
- scaffold performance and regression test suites

## Testing
- `vendor/bin/phpunit --testsuite Performance`
- `vendor/bin/phpunit --testsuite Regression`
- `vendor/bin/phpunit` *(fails: Cannot redeclare class WpdbStub)*
- `php scripts/coverage-import.php`
- `php scripts/artifact-schema-validate.php`
- `php scripts/ga-enforcer.php --profile=ga --junit`


------
https://chatgpt.com/codex/tasks/task_e_68a87b5a240483219fcc4db93d653f29