### PR TITLE
test: enforce BaseTestCase via AST meta-test

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
         "wp-phpunit/wp-phpunit": "^5.7",
         "mikey179/vfsstream": "^1.6",
         "infection/infection": "^0.27",
-        "giorgiosironi/eris": "^1.0"
+        "giorgiosironi/eris": "^1.0",
+        "nikic/php-parser": "^4.18"
     },
     "suggest": {
         "patchstack/security-scanner": "Run composer update when you have access to Patchstack repo to enable local scanning"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "84ab06059f6447bcc4e40c0ca971a41f",
+    "content-hash": "7140f8c49fd62edce3ec744b80ecb513",
     "packages": [
         {
             "name": "composer/pcre",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -27,6 +27,8 @@
     <testsuite name="Regression">
       <directory>tests/Regression</directory>
     </testsuite>
-    <!-- existing suites (SecurityAdvanced, Observability, BusinessLogic, PropertyBased, etc.) -->
+    <testsuite name="Meta">
+      <directory>tests/Meta</directory>
+    </testsuite>
   </testsuites>
 </phpunit>

--- a/tests/Architecture/ArchitectureTest.php
+++ b/tests/Architecture/ArchitectureTest.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 
-final class ArchitectureTest extends TestCase
+final class ArchitectureTest extends BaseTestCase
 {
     private function scanFiles(string $path, callable $filter): array
     {

--- a/tests/Business/AllocationRulesTest.php
+++ b/tests/Business/AllocationRulesTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 use SmartAlloc\Services\AllocationRules;
 use SmartAlloc\Services\ScoringAllocator;
 use SmartAlloc\Tests\Fixtures\{MentorFactory, StudentFactory, CrosswalkFactory};
 
-final class AllocationRulesTest extends TestCase
+final class AllocationRulesTest extends BaseTestCase
 {
     public function test_filters_and_ranking_with_default_capacity(): void
     {

--- a/tests/Business/FuzzySchoolMatchTest.php
+++ b/tests/Business/FuzzySchoolMatchTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 use SmartAlloc\Services\AllocationRules;
 use SmartAlloc\Tests\Fixtures\{MentorFactory, StudentFactory, CrosswalkFactory};
 use SmartAlloc\Utils\Fuzzy;
 
-final class FuzzySchoolMatchTest extends TestCase
+final class FuzzySchoolMatchTest extends BaseTestCase
 {
     public function test_similarity_decisions(): void
     {

--- a/tests/Business/PostalAliasRuleTest.php
+++ b/tests/Business/PostalAliasRuleTest.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 use SmartAlloc\Infra\GF\SabtEntryMapper;
 use SmartAlloc\Services\ExportService;
 use org\bovigo\vfs\vfsStream;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
-final class PostalAliasRuleTest extends TestCase
+final class PostalAliasRuleTest extends BaseTestCase
 {
     protected function setUp(): void
     {

--- a/tests/Business/RankingAndTieBreakTest.php
+++ b/tests/Business/RankingAndTieBreakTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 use SmartAlloc\Services\ScoringAllocator;
 use SmartAlloc\Tests\Fixtures\{MentorFactory, StudentFactory};
 
-final class RankingAndTieBreakTest extends TestCase
+final class RankingAndTieBreakTest extends BaseTestCase
 {
     public function test_tie_breaking_by_allocations_new_then_id(): void
     {

--- a/tests/ChaosEngineering/ChaosEngineeringTest.php
+++ b/tests/ChaosEngineering/ChaosEngineeringTest.php
@@ -1,11 +1,11 @@
 <?php
 namespace SmartAlloc\Tests\ChaosEngineering;
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 use SmartAlloc\Testing\Chaos\FaultFlags;
 require_once __DIR__ . '/ChaosTestHelpers.php';
 
-final class ChaosEngineeringTest extends TestCase
+final class ChaosEngineeringTest extends BaseTestCase
 {
     protected function setUp(): void
     {

--- a/tests/Cli/CommandsTest.php
+++ b/tests/Cli/CommandsTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 
-final class CommandsTest extends TestCase
+final class CommandsTest extends BaseTestCase
 {
     public function test_wp_cli_available_or_skipped(): void
     {

--- a/tests/Contract/AllocationContractTest.php
+++ b/tests/Contract/AllocationContractTest.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 use SmartAlloc\Services\AllocationService;
 use SmartAlloc\Services\Logging;
 use SmartAlloc\Services\Metrics;
@@ -24,7 +24,7 @@ if (!class_exists('WP_Error')) {
 
 // wpdb stub provided by tests bootstrap
 
-final class AllocationContractTest extends TestCase
+final class AllocationContractTest extends BaseTestCase
 {
     use AssertArrayShape;
 

--- a/tests/DataQuality/DataQualityTest.php
+++ b/tests/DataQuality/DataQualityTest.php
@@ -1,10 +1,10 @@
 <?php
 namespace SmartAlloc\Tests\DataQuality;
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 use function SmartAlloc\Testing\Support\gini;
 
-final class DataQualityTest extends TestCase
+final class DataQualityTest extends BaseTestCase
 {
     private array $students;
     private array $mentors;

--- a/tests/Domain/AllocatorThresholdsTest.php
+++ b/tests/Domain/AllocatorThresholdsTest.php
@@ -6,10 +6,10 @@ namespace SmartAlloc\Tests\Domain;
 
 use Brain\Monkey;
 use Brain\Monkey\Functions;
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 use SmartAlloc\Domain\Allocation\StudentAllocator;
 
-final class AllocatorThresholdsTest extends TestCase
+final class AllocatorThresholdsTest extends BaseTestCase
 {
     protected function setUp(): void
     {

--- a/tests/GF/ComplexFormTest.php
+++ b/tests/GF/ComplexFormTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 
-final class ComplexFormTest extends TestCase
+final class ComplexFormTest extends BaseTestCase
 {
     public function test_large_form_with_nested_conditionals_is_rendered_or_skip(): void
     {

--- a/tests/GF/FlowPerksIntegrationTest.php
+++ b/tests/GF/FlowPerksIntegrationTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 
-final class FlowPerksIntegrationTest extends TestCase
+final class FlowPerksIntegrationTest extends BaseTestCase
 {
     public function test_flow_perks_loops_and_conditional_routing_or_skip(): void
     {

--- a/tests/GF/Form150ValidationTest.php
+++ b/tests/GF/Form150ValidationTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace SmartAlloc\Tests;
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 use SmartAlloc\Integration\GravityForms\Form150;
 
-final class Form150ValidationTest extends TestCase
+final class Form150ValidationTest extends BaseTestCase
 {
     public function testNationalCodeAlgorithm(): void
     {

--- a/tests/GF/SabtEntryMapperTest.php
+++ b/tests/GF/SabtEntryMapperTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 use SmartAlloc\Infra\GF\SabtEntryMapper;
 
-final class SabtEntryMapperTest extends TestCase
+final class SabtEntryMapperTest extends BaseTestCase
 {
     private SabtEntryMapper $mapper;
 

--- a/tests/GF/SabtSubmissionHandlerTest.php
+++ b/tests/GF/SabtSubmissionHandlerTest.php
@@ -10,8 +10,9 @@ use SmartAlloc\Infra\GF\SabtEntryMapper;
 use SmartAlloc\Infra\GF\SabtSubmissionHandler;
 use SmartAlloc\Infra\Repository\AllocationsRepository;
 use SmartAlloc\Services\AllocationService;
+use SmartAlloc\Tests\BaseTestCase;
 
-final class SabtSubmissionHandlerTest extends \PHPUnit\Framework\TestCase
+final class SabtSubmissionHandlerTest extends BaseTestCase
 {
     private array $options;
 

--- a/tests/GF/SubmissionFlowE2E.php
+++ b/tests/GF/SubmissionFlowE2E.php
@@ -10,8 +10,9 @@ use SmartAlloc\Infra\GF\SabtSubmissionHandler;
 use SmartAlloc\Infra\Repository\AllocationsRepository;
 use SmartAlloc\Services\AllocationService;
 use SmartAlloc\Domain\Allocation\AllocationResult;
+use SmartAlloc\Tests\BaseTestCase;
 
-final class SubmissionFlowE2E extends \PHPUnit\Framework\TestCase
+final class SubmissionFlowE2E extends BaseTestCase
 {
     private array $options;
 

--- a/tests/Helpers/AdminTest.php
+++ b/tests/Helpers/AdminTest.php
@@ -102,8 +102,10 @@ if (!function_exists('renderPage')) {
     }
 }
 
+use SmartAlloc\Tests\BaseTestCase;
+
 if (!class_exists('AdminTest')) {
-    class AdminTest extends \PHPUnit\Framework\TestCase {
+    class AdminTest extends BaseTestCase {
         public function test_placeholder(): void {
             $this->assertTrue(true);
         }

--- a/tests/Helpers/HttpTestCase.php
+++ b/tests/Helpers/HttpTestCase.php
@@ -18,8 +18,10 @@ if (!function_exists('stub_header')) {
     }
 }
 
+use SmartAlloc\Tests\BaseTestCase;
+
 if (!class_exists('HttpTest')) {
-    abstract class HttpTest extends \PHPUnit\Framework\TestCase {
+    abstract class HttpTest extends BaseTestCase {
         /**
          * Run callback within an output buffer and ensure cleanup.
          */

--- a/tests/Http/DlqRoutesTest.php
+++ b/tests/Http/DlqRoutesTest.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 use SmartAlloc\Http\Rest\DlqController;
 use SmartAlloc\Services\DlqService;
 
@@ -16,7 +16,7 @@ if (!function_exists('do_action')) { function do_action($h,$a){ if(isset($GLOBAL
 }
 if (!function_exists('current_user_can')) { function current_user_can($cap){ return $GLOBALS['can']??false; } }
 
-final class DlqRoutesTest extends TestCase
+final class DlqRoutesTest extends BaseTestCase
 {
     private function setupWpdb(): void
     {

--- a/tests/I18n/DomainLoadTest.php
+++ b/tests/I18n/DomainLoadTest.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 
 use Brain\Monkey;
 use Brain\Monkey\Functions;
+use SmartAlloc\Tests\BaseTestCase;
 
-final class DomainLoadTest extends \PHPUnit\Framework\TestCase
+final class DomainLoadTest extends BaseTestCase
 {
     protected function setUp(): void
     {

--- a/tests/I18n/PersianRtlTest.php
+++ b/tests/I18n/PersianRtlTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 
-final class PersianRtlTest extends TestCase
+final class PersianRtlTest extends BaseTestCase
 {
     public function test_persian_digits_rendering_and_not_corrupted_in_exports(): void
     {

--- a/tests/Infra/AllocationsRepositoryTest.php
+++ b/tests/Infra/AllocationsRepositoryTest.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 use Brain\Monkey;
 use Brain\Monkey\Functions;
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 use SmartAlloc\Contracts\LoggerInterface;
 use SmartAlloc\Domain\Allocation\AllocationStatus;
 use SmartAlloc\Infra\Repository\AllocationsRepository;
 
-final class AllocationsRepositoryTest extends TestCase
+final class AllocationsRepositoryTest extends BaseTestCase
 {
     protected function setUp(): void
     {

--- a/tests/Integration/AllocationHappyPathTest.php
+++ b/tests/Integration/AllocationHappyPathTest.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 use SmartAlloc\Services\AllocationService;
 use SmartAlloc\Services\Logging;
 use SmartAlloc\Services\ScoringAllocator;
@@ -12,7 +12,7 @@ use SmartAlloc\Domain\Allocation\AllocationResult;
 
 if (!class_exists('WP_Error')) { class WP_Error { public function __construct(public string $code = '', public string $message = '', public array $data = []) {} public function get_error_data(): array { return $this->data; } } }
 
-final class AllocationHappyPathTest extends TestCase
+final class AllocationHappyPathTest extends BaseTestCase
 {
     public function testStudentAllocatedAndEventsEmitted(): void
     {

--- a/tests/Integration/GFDateExportTest.php
+++ b/tests/Integration/GFDateExportTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace SmartAlloc\Tests\Integration;
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 
-final class GFDateExportTest extends TestCase
+final class GFDateExportTest extends BaseTestCase
 {
     public function test_gf_date_export_or_skip(): void
     {

--- a/tests/Integration/NotificationRetryDlqTest.php
+++ b/tests/Integration/NotificationRetryDlqTest.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 use SmartAlloc\Services\NotificationService;
 use SmartAlloc\Services\Logging;
 use SmartAlloc\Services\Metrics;
@@ -15,7 +15,7 @@ if (!function_exists('wp_next_scheduled')) { function wp_next_scheduled($h,$a){ 
 if (!function_exists('as_enqueue_async_action')) { function as_enqueue_async_action(){ return false; } }
 if (!function_exists('as_next_scheduled_action')) { function as_next_scheduled_action(){ return false; } }
 
-final class NotificationRetryDlqTest extends TestCase
+final class NotificationRetryDlqTest extends BaseTestCase
 {
     public function testRetriesThenSucceeds(): void
     {

--- a/tests/Meta/NoRawTestCaseUsageTest.php
+++ b/tests/Meta/NoRawTestCaseUsageTest.php
@@ -3,22 +3,111 @@ declare(strict_types=1);
 
 namespace SmartAlloc\Tests\Meta;
 
+use PhpParser\Error;
+use PhpParser\Node;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\NameResolver;
+use PhpParser\ParserFactory;
 use PHPUnit\Framework\TestCase;
 
-final class NoRawTestCaseUsageTest extends TestCase {
-    public function test_all_tests_extend_base_testcase(): void {
+final class NoRawTestCaseUsageTest extends TestCase
+{
+    /** @test */
+    public function all_tests_must_extend_base_testcase(): void
+    {
         $bad = [];
-        $it = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator(__DIR__.'/..'));
+        $parser = (new ParserFactory())->create(ParserFactory::PREFER_PHP7);
+
+        $it = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator(\dirname(__DIR__), \FilesystemIterator::SKIP_DOTS)
+        );
+
         foreach ($it as $file) {
-            if (!$file->isFile() || $file->getExtension() !== 'php') continue;
-            $code = \file_get_contents($file->getPathname());
-            if (\preg_match('/class\s+\w+\s+extends\s+\\\\?PHPUnit\\\\Framework\\\\TestCase\b/', $code)) {
-                // Allow our own BaseTestCase
-                if (strpos($code, 'extends SmartAlloc\\\\Tests\\\\BaseTestCase') === false) {
-                    $bad[] = $file->getPathname();
+            if (!$file->isFile() || $file->getExtension() !== 'php') {
+                continue;
+            }
+            $path = $file->getPathname();
+
+            // Optional exemptions (keep narrow)
+            if ($path === __FILE__ || \basename($path) === 'BaseTestCase.php' || \str_contains($path, \DIRECTORY_SEPARATOR . 'Fixtures' . \DIRECTORY_SEPARATOR)) {
+                continue;
+            }
+
+            $code = \file_get_contents($path);
+            if ($code === false) {
+                continue;
+            }
+
+            try {
+                $ast = $parser->parse($code);
+                if (!$ast) { continue; }
+
+                $traverser = new NodeTraverser();
+                $traverser->addVisitor(new NameResolver());
+                $ast = $traverser->traverse($ast);
+
+                foreach ($ast as $node) {
+                    $this->scanNode($node, $path, $bad);
+                }
+            } catch (Error $e) {
+                $bad[] = $path . ' (parse error: ' . $e->getMessage() . ')';
+            }
+        }
+
+        $this->assertSame(
+            [],
+            $bad,
+            "These test files extend raw PHPUnit TestCase (directly or via alias) instead of SmartAlloc\\Tests\\BaseTestCase:\n" .
+            \implode("\n", $bad)
+        );
+    }
+
+    private function scanNode(Node $node, string $path, array &$bad): void
+    {
+        // Recurse into statements that can contain classes/namespaces
+        if ($node instanceof Node\Stmt\Namespace_) {
+            foreach ($node->stmts as $stmt) {
+                $this->scanNode($stmt, $path, $bad);
+            }
+            return;
+        }
+
+        if ($node instanceof Node\Stmt\Class_) {
+            // Skip anonymous classes
+            if ($node->name === null) {
+                return;
+            }
+
+            $extends = $node->extends;
+            if (!$extends instanceof Node\Name) {
+                return;
+            }
+
+            $fqn = $extends->toString(); // NameResolver makes this fully qualified
+
+            // Allow only our shared base test
+            if ($fqn === 'SmartAlloc\\Tests\\BaseTestCase') {
+                return;
+            }
+
+            // Flag any PHPUnit\Framework\TestCase usage (direct or aliased)
+            if ($fqn === 'PHPUnit\\Framework\\TestCase') {
+                $bad[] = $path;
+            }
+        }
+
+        // Recurse into child nodes
+        foreach ($node->getSubNodeNames() as $name) {
+            $sub = $node->$name ?? null;
+            if ($sub instanceof Node) {
+                $this->scanNode($sub, $path, $bad);
+            } elseif (\is_array($sub)) {
+                foreach ($sub as $s) {
+                    if ($s instanceof Node) {
+                        $this->scanNode($s, $path, $bad);
+                    }
                 }
             }
         }
-        $this->assertSame([], $bad, "These tests extend raw PHPUnit TestCase instead of BaseTestCase:\n".implode("\n", $bad));
     }
 }

--- a/tests/Multisite/MigrationRunnerTest.php
+++ b/tests/Multisite/MigrationRunnerTest.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 use Brain\Monkey;
 use Brain\Monkey\Functions;
 use SmartAlloc\Infra\Upgrade\MigrationRunner;
+use SmartAlloc\Tests\BaseTestCase;
 
-final class MigrationRunnerTest extends \PHPUnit\Framework\TestCase
+final class MigrationRunnerTest extends BaseTestCase
 {
     protected function setUp(): void
     {

--- a/tests/Observability/ObservabilityTest.php
+++ b/tests/Observability/ObservabilityTest.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace SmartAlloc\Tests\Observability;
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 use SmartAlloc\Services\StatsService;
 use SmartAlloc\Logging\Logger;
 use SmartAlloc\Observability\Tracer;
 use SmartAlloc\Observability\AlertService;
 
-class ObservabilityTest extends TestCase
+class ObservabilityTest extends BaseTestCase
 {
     protected function setUp(): void
     {

--- a/tests/Perf/BudgetTest.php
+++ b/tests/Perf/BudgetTest.php
@@ -2,13 +2,13 @@
 declare(strict_types=1);
 
 use Brain\Monkey\Functions;
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 use SmartAlloc\Http\Rest\ReportsMetricsController;
 use SmartAlloc\Infra\Export\ExcelExporter;
 use SmartAlloc\Tests\Helpers\WpdbSpy as Spy;
 use SmartAlloc\Tests\Helpers\EnvReset as Env;
 
-final class BudgetTest extends TestCase
+final class BudgetTest extends BaseTestCase
 {
     protected function setUp(): void
     {

--- a/tests/Performance/AllocationPerfTest.php
+++ b/tests/Performance/AllocationPerfTest.php
@@ -3,12 +3,12 @@ declare(strict_types=1);
 
 namespace SmartAlloc\Tests\Performance;
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 use SmartAlloc\Perf\Stopwatch;
 use SmartAlloc\Perf\QueryCounter;
 use SmartAlloc\Tests\Fixtures\BulkDatasetBuilder;
 
-final class AllocationPerfTest extends TestCase
+final class AllocationPerfTest extends BaseTestCase
 {
     /**
      * @dataProvider provideScales

--- a/tests/Property/AllocationInvariantsTest.php
+++ b/tests/Property/AllocationInvariantsTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 use SmartAlloc\Services\{AllocationRules, ScoringAllocator};
 use SmartAlloc\Tests\Fixtures\{MentorFactory, StudentFactory};
 
-final class AllocationInvariantsTest extends TestCase
+final class AllocationInvariantsTest extends BaseTestCase
 {
     public function test_assigned_never_exceeds_capacity(): void
     {

--- a/tests/Regression/QueryPlanGuardTest.php
+++ b/tests/Regression/QueryPlanGuardTest.php
@@ -3,11 +3,11 @@ declare(strict_types=1);
 
 namespace SmartAlloc\Tests\Regression;
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 use SmartAlloc\Perf\QueryCounter;
 use SmartAlloc\Tests\Fixtures\BulkDatasetBuilder;
 
-final class QueryPlanGuardTest extends TestCase
+final class QueryPlanGuardTest extends BaseTestCase
 {
     public function test_allocation_does_not_exhibit_n_plus_1(): void
     {

--- a/tests/Security/CsvInjectionTest.php
+++ b/tests/Security/CsvInjectionTest.php
@@ -1,11 +1,11 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 
 require_once dirname(__DIR__) . '/Support/DataProviders.php';
 
-final class CsvInjectionTest extends TestCase
+final class CsvInjectionTest extends BaseTestCase
 {
     /**
      * Run CSV export with given value.

--- a/tests/Security/ReportsCsvInjectionTest.php
+++ b/tests/Security/ReportsCsvInjectionTest.php
@@ -1,11 +1,11 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 use Brain\Monkey;
 use Brain\Monkey\Functions;
 
-final class ReportsCsvInjectionTest extends TestCase
+final class ReportsCsvInjectionTest extends BaseTestCase
 {
     private $hMetrics;
     private $hHeader;

--- a/tests/Security/SpreadsheetInjectionTest.php
+++ b/tests/Security/SpreadsheetInjectionTest.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 use PhpOffice\PhpSpreadsheet\Cell\DataType;
 use PhpOffice\PhpSpreadsheet\IOFactory;
 use SmartAlloc\Infra\Export\ExcelExporter;
@@ -9,7 +9,7 @@ use SmartAlloc\Infra\Export\CountersRepository;
 
 require_once dirname(__DIR__) . '/Support/DataProviders.php';
 
-final class SpreadsheetInjectionTest extends TestCase
+final class SpreadsheetInjectionTest extends BaseTestCase
 {
     private function createExporter(): ExcelExporter
     {

--- a/tests/Security/WebhookSignatureTest.php
+++ b/tests/Security/WebhookSignatureTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 
-final class WebhookSignatureTest extends TestCase
+final class WebhookSignatureTest extends BaseTestCase
 {
     public function test_placeholder(): void
     {

--- a/tests/Security/WpDebugTest.php
+++ b/tests/Security/WpDebugTest.php
@@ -1,8 +1,8 @@
 <?php
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 
-class WpDebugTest extends TestCase
+class WpDebugTest extends BaseTestCase
 {
     public function test_wp_debug_and_display_errors(): void
     {

--- a/tests/SecurityAdvanced/SecurityAdvancedTest.php
+++ b/tests/SecurityAdvanced/SecurityAdvancedTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace SmartAlloc\Tests\SecurityAdvanced;
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 use Brain\Monkey\Functions;
 use SmartAlloc\Security\RateLimiter;
 use SmartAlloc\Logging\Logger;
@@ -13,7 +13,7 @@ use SmartAlloc\Http\Rest\MetricsController;
 use WP_Error;
 use WP_REST_Request;
 
-class SecurityAdvancedTest extends TestCase
+class SecurityAdvancedTest extends BaseTestCase
 {
     protected function setUp(): void
     {

--- a/tests/Tools/PreflightSmokeTest.php
+++ b/tests/Tools/PreflightSmokeTest.php
@@ -3,9 +3,9 @@ declare(strict_types=1);
 
 namespace SmartAlloc\Tests\Tools;
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 
-final class PreflightSmokeTest extends TestCase
+final class PreflightSmokeTest extends BaseTestCase
 {
     public function testPreflight(): void
     {

--- a/tests/WordPress/AllocationPropertiesTest.php
+++ b/tests/WordPress/AllocationPropertiesTest.php
@@ -9,10 +9,10 @@ use SmartAlloc\Services\Metrics;
 use SmartAlloc\Services\ScoringAllocator;
 use SmartAlloc\Event\EventBus;
 use SmartAlloc\Contracts\EventStoreInterface;
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 
 if (!class_exists('WP_UnitTestCase')) {
-    abstract class WP_UnitTestCase extends TestCase {}
+    abstract class WP_UnitTestCase extends BaseTestCase {}
 }
 
 final class AllocationPropertiesTest extends WP_UnitTestCase

--- a/tests/WordPress/UninstallMultisiteTest.php
+++ b/tests/WordPress/UninstallMultisiteTest.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 
-final class UninstallMultisiteTest extends TestCase
+final class UninstallMultisiteTest extends BaseTestCase
 {
     protected function setUp(): void
     {

--- a/tests/WordPress/UninstallTightTest.php
+++ b/tests/WordPress/UninstallTightTest.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 
-final class UninstallTightTest extends TestCase
+final class UninstallTightTest extends BaseTestCase
 {
     protected function setUp(): void
     {

--- a/tests/_tools/NoConflictMarkersTest.php
+++ b/tests/_tools/NoConflictMarkersTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace SmartAlloc\Tests\Tools;
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 
-final class NoConflictMarkersTest extends TestCase
+final class NoConflictMarkersTest extends BaseTestCase
 {
     public function test_no_conflict_markers_left(): void
     {

--- a/tests/chaos/DbOutageTest.php
+++ b/tests/chaos/DbOutageTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 use SmartAlloc\Testing\TestFilters;
 use SmartAlloc\Services\Db;
 
 
-final class DbOutageTest extends TestCase
+final class DbOutageTest extends BaseTestCase
 {
     protected function tearDown(): void
     {

--- a/tests/chaos/MemoryPressureTest.php
+++ b/tests/chaos/MemoryPressureTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 use SmartAlloc\Testing\TestFilters;
 use SmartAlloc\Services\AllocationService;
 use SmartAlloc\Services\Logging;
@@ -12,7 +12,7 @@ use SmartAlloc\Contracts\EventStoreInterface;
 use SmartAlloc\Contracts\ScoringAllocatorInterface;
 
 
-final class MemoryPressureTest extends TestCase
+final class MemoryPressureTest extends BaseTestCase
 {
     protected function tearDown(): void
     {

--- a/tests/data_quality/FairnessGiniTest.php
+++ b/tests/data_quality/FairnessGiniTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 use SmartAlloc\Services\StatsService;
 
-final class FairnessGiniTest extends TestCase
+final class FairnessGiniTest extends BaseTestCase
 {
     public function testBalancedLoadsHaveLowGini(): void
     {

--- a/tests/e2e/BlockEditorSmokeTest.php
+++ b/tests/e2e/BlockEditorSmokeTest.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 
-final class BlockEditorSmokeTest extends TestCase
+final class BlockEditorSmokeTest extends BaseTestCase
 {
     public function test_block_json_api_v3_or_skip(): void
     {

--- a/tests/integration/FailureInjection/CircuitBreakerOpenTest.php
+++ b/tests/integration/FailureInjection/CircuitBreakerOpenTest.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 
-final class CircuitBreakerOpenTest extends TestCase {
+final class CircuitBreakerOpenTest extends BaseTestCase {
     public function test_breaker_opens_after_consecutive_failures_or_skip(): void {
         if (getenv('RUN_FAILURE_TESTS') !== '1') {
             $this->markTestSkipped('failure tests opt-in');

--- a/tests/integration/FailureInjection/DBOutageTest.php
+++ b/tests/integration/FailureInjection/DBOutageTest.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 
-final class FailureDBOutageTest extends TestCase {
+final class FailureDBOutageTest extends BaseTestCase {
     public function test_db_error_on_allocate_is_graceful_or_skip(): void {
         if (getenv('RUN_FAILURE_TESTS') !== '1') {
             $this->markTestSkipped('failure tests opt-in');

--- a/tests/integration/FailureInjection/RedisOutageTest.php
+++ b/tests/integration/FailureInjection/RedisOutageTest.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 
-final class RedisOutageTest extends TestCase {
+final class RedisOutageTest extends BaseTestCase {
     protected function setUp(): void {
         if (getenv('RUN_FAILURE_TESTS') !== '1') {
             $this->markTestSkipped('failure tests opt-in');

--- a/tests/integration/GFSecurityHooksTest.php
+++ b/tests/integration/GFSecurityHooksTest.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 
-final class GFSecurityHooksTest extends TestCase
+final class GFSecurityHooksTest extends BaseTestCase
 {
     protected function setUp(): void
     {

--- a/tests/integration/Performance/RequestBudgetTest.php
+++ b/tests/integration/Performance/RequestBudgetTest.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 
-final class RequestBudgetTest extends TestCase
+final class RequestBudgetTest extends BaseTestCase
 {
     public function test_request_budget_opt_in(): void
     {

--- a/tests/integration/QAOrchestratorTest.php
+++ b/tests/integration/QAOrchestratorTest.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 
-final class QAOrchestratorTest extends TestCase
+final class QAOrchestratorTest extends BaseTestCase
 {
     public function test_index_generated_with_rtl(): void
     {

--- a/tests/integration/Release/GARehearsalSmokeTest.php
+++ b/tests/integration/Release/GARehearsalSmokeTest.php
@@ -1,9 +1,9 @@
 <?php
 namespace Release;
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 
-class GARehearsalSmokeTest extends TestCase
+class GARehearsalSmokeTest extends BaseTestCase
 {
     public function testRun(): void
     {

--- a/tests/performance/AllocationPerformanceTest.php
+++ b/tests/performance/AllocationPerformanceTest.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 
-final class AllocationPerformanceTest extends TestCase {
+final class AllocationPerformanceTest extends BaseTestCase {
     public function test_throughput_p95_and_memory_budget_or_skip(): void {
         if (getenv('RUN_PERFORMANCE_TESTS') !== '1') {
             $this->markTestSkipped('performance tests opt-in');

--- a/tests/unit/Allocation/AllocationServiceConcurrencyTest.php
+++ b/tests/unit/Allocation/AllocationServiceConcurrencyTest.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 if (!class_exists('WP_Error')) { class WP_Error { public function __construct(public string $code = '', public string $message = '', public array $data = []) {} public function get_error_data(): array { return $this->data; } } }
 
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 use SmartAlloc\Services\AllocationService;
 use SmartAlloc\Services\Logging;
 use SmartAlloc\Services\ScoringAllocator;
@@ -12,7 +12,7 @@ use SmartAlloc\Event\EventBus;
 use SmartAlloc\Contracts\EventStoreInterface;
 use SmartAlloc\Domain\Allocation\AllocationResult;
 
-class AllocationServiceConcurrencyTest extends TestCase
+class AllocationServiceConcurrencyTest extends BaseTestCase
 {
     private function makeService(&$wpdb): AllocationService
     {

--- a/tests/unit/Allocation/AllocationServiceTest.php
+++ b/tests/unit/Allocation/AllocationServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 use SmartAlloc\Services\AllocationService;
 use SmartAlloc\Services\Logging;
 use SmartAlloc\Services\ScoringAllocator;
@@ -10,7 +10,7 @@ use SmartAlloc\Event\EventBus;
 use SmartAlloc\Contracts\EventStoreInterface;
 use SmartAlloc\Domain\Allocation\AllocationResult;
 
-final class AllocationServiceTest extends TestCase
+final class AllocationServiceTest extends BaseTestCase
 {
     /**
      * @return array{0:AllocationService,1:object}

--- a/tests/unit/Allocation/GuardedUpdateTest.php
+++ b/tests/unit/Allocation/GuardedUpdateTest.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 if (!class_exists('WP_Error')) { class WP_Error { public function __construct(public string $code = '', public string $message = '', public array $data = []) {} public function get_error_data(): array { return $this->data; } } }
 
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 use SmartAlloc\Services\AllocationService;
 use SmartAlloc\Services\Logging;
 use SmartAlloc\Services\ScoringAllocator;
@@ -12,7 +12,7 @@ use SmartAlloc\Event\EventBus;
 use SmartAlloc\Contracts\EventStoreInterface;
 use SmartAlloc\Domain\Allocation\AllocationResult;
 
-final class GuardedUpdateTest extends TestCase
+final class GuardedUpdateTest extends BaseTestCase
 {
     private function service(&$wpdb): AllocationService
     {

--- a/tests/unit/Allocation/MultiStagePriorityTest.php
+++ b/tests/unit/Allocation/MultiStagePriorityTest.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 
-final class MultiStagePriorityTest extends TestCase {
+final class MultiStagePriorityTest extends BaseTestCase {
     public function test_multistage_gender_then_fallback_or_skip(): void {
         if (getenv('RUN_ALLOC_SCENARIOS') !== '1') {
             $this->markTestSkipped('alloc scenarios opt-in');

--- a/tests/unit/Allocation/ScoringAllocatorTest.php
+++ b/tests/unit/Allocation/ScoringAllocatorTest.php
@@ -1,10 +1,10 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 use SmartAlloc\Services\ScoringAllocator;
 
-final class ScoringAllocatorTest extends TestCase
+final class ScoringAllocatorTest extends BaseTestCase
 {
     public function testRanksByScoreAndTiesById(): void
     {

--- a/tests/unit/Autoload/AutoloadTest.php
+++ b/tests/unit/Autoload/AutoloadTest.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 
-final class AutoloadTest extends TestCase
+final class AutoloadTest extends BaseTestCase
 {
     public function test_plugin_classes_autoload(): void
     {

--- a/tests/unit/Compliance/LicenseAuditTest.php
+++ b/tests/unit/Compliance/LicenseAuditTest.php
@@ -1,12 +1,12 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 use org\bovigo\vfs\vfsStream;
 
 require_once dirname(__DIR__, 3) . '/scripts/license-audit.php';
 
-final class LicenseAuditTest extends TestCase
+final class LicenseAuditTest extends BaseTestCase
 {
     private function mirror(string $src, string $dst): void
     {

--- a/tests/unit/Event/EventBusTest.php
+++ b/tests/unit/Event/EventBusTest.php
@@ -1,11 +1,11 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 use SmartAlloc\Event\EventBus;
 use SmartAlloc\Contracts\{EventStoreInterface,ListenerInterface,LoggerInterface};
 
-final class EventBusTest extends TestCase
+final class EventBusTest extends BaseTestCase
 {
     public function testDuplicateDispatchAndFailureLogging(): void
     {

--- a/tests/unit/Event/EventKeyTest.php
+++ b/tests/unit/Event/EventKeyTest.php
@@ -1,10 +1,10 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 use SmartAlloc\Event\EventKey;
 
-final class EventKeyTest extends TestCase
+final class EventKeyTest extends BaseTestCase
 {
     public function testFormatAndOverride(): void
     {

--- a/tests/unit/I18N/I18nLintTest.php
+++ b/tests/unit/I18N/I18nLintTest.php
@@ -1,7 +1,7 @@
 <?php
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 
-class I18nLintTest extends TestCase
+class I18nLintTest extends BaseTestCase
 {
     private string $fixture;
 

--- a/tests/unit/I18N/PotDiffTest.php
+++ b/tests/unit/I18N/PotDiffTest.php
@@ -1,7 +1,7 @@
 <?php
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 
-class PotDiffTest extends TestCase
+class PotDiffTest extends BaseTestCase
 {
     private string $dir;
 

--- a/tests/unit/I18N/PotFreshnessTest.php
+++ b/tests/unit/I18N/PotFreshnessTest.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 
-final class PotFreshnessTest extends TestCase {
+final class PotFreshnessTest extends BaseTestCase {
     public function test_pot_refresh_or_skip(): void {
         if (getenv('RUN_I18N_POT') !== '1') {
             $this->markTestSkipped('pot refresh opt-in');

--- a/tests/unit/Packaging/DistAuditTest.php
+++ b/tests/unit/Packaging/DistAuditTest.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 
-final class DistAuditTest extends TestCase {
+final class DistAuditTest extends BaseTestCase {
     public function test_dist_package_audit(): void {
         if (getenv('RUN_DIST_AUDIT') !== '1') {
             $this->markTestSkipped('dist audit opt-in');

--- a/tests/unit/Packaging/VersionCoherenceTest.php
+++ b/tests/unit/Packaging/VersionCoherenceTest.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 
-final class VersionCoherenceTest extends TestCase {
+final class VersionCoherenceTest extends BaseTestCase {
     public function test_version_coherence(): void {
         if (getenv('RUN_RELEASE_GATES') !== '1') {
             $this->markTestSkipped('release gates opt-in');

--- a/tests/unit/Release/ChangelogGuardTest.php
+++ b/tests/unit/Release/ChangelogGuardTest.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 
-final class ChangelogGuardTest extends TestCase {
+final class ChangelogGuardTest extends BaseTestCase {
     public function test_changelog_guard(): void {
         if (getenv('RUN_RELEASE_GATES') !== '1') {
             $this->markTestSkipped('release gates opt-in');

--- a/tests/unit/Release/CoverageImportTest.php
+++ b/tests/unit/Release/CoverageImportTest.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 
-final class CoverageImportTest extends TestCase
+final class CoverageImportTest extends BaseTestCase
 {
     public function test_import_normalizes_clover_fixture(): void
     {

--- a/tests/unit/Release/CoverageImporterIntegrationTest.php
+++ b/tests/unit/Release/CoverageImporterIntegrationTest.php
@@ -3,9 +3,9 @@ declare(strict_types=1);
 
 namespace SmartAlloc\Tests\Release;
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 
-final class CoverageImporterIntegrationTest extends TestCase
+final class CoverageImporterIntegrationTest extends BaseTestCase
 {
     private string $root;
 

--- a/tests/unit/Release/DistBuildTest.php
+++ b/tests/unit/Release/DistBuildTest.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 
-final class DistBuildTest extends TestCase
+final class DistBuildTest extends BaseTestCase
 {
     public function test_build_excludes_and_normalises(): void
     {

--- a/tests/unit/Release/DistManifestCanonicalTest.php
+++ b/tests/unit/Release/DistManifestCanonicalTest.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 
-final class DistManifestCanonicalTest extends TestCase
+final class DistManifestCanonicalTest extends BaseTestCase
 {
     public function test_manifest_only_has_canonical_entries(): void
     {

--- a/tests/unit/Release/DistManifestTest.php
+++ b/tests/unit/Release/DistManifestTest.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 
-final class DistManifestTest extends TestCase
+final class DistManifestTest extends BaseTestCase
 {
     public function test_manifest_entries_sorted_and_shaped(): void
     {

--- a/tests/unit/Release/FinalizerSmokeTest.php
+++ b/tests/unit/Release/FinalizerSmokeTest.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 
-final class FinalizerSmokeTest extends TestCase {
+final class FinalizerSmokeTest extends BaseTestCase {
     public function test_release_finalizer_artifacts_exist(): void {
         if (getenv('RUN_RELEASE_FINAL') !== '1') {
             $this->markTestSkipped('release finalizer opt-in');

--- a/tests/unit/Release/GAEnforcerCoverageTest.php
+++ b/tests/unit/Release/GAEnforcerCoverageTest.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 
-final class GAEnforcerCoverageTest extends TestCase
+final class GAEnforcerCoverageTest extends BaseTestCase
 {
     public function test_artifacts_schema_junit_behavior(): void
     {

--- a/tests/unit/Release/GAEnforcerDistTest.php
+++ b/tests/unit/Release/GAEnforcerDistTest.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 
-final class GAEnforcerDistTest extends TestCase
+final class GAEnforcerDistTest extends BaseTestCase
 {
     private string $origReadme = '';
 

--- a/tests/unit/Release/GAEnforcerI18nWporgTest.php
+++ b/tests/unit/Release/GAEnforcerI18nWporgTest.php
@@ -1,7 +1,7 @@
 <?php
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 
-class GAEnforcerI18nWporgTest extends TestCase
+class GAEnforcerI18nWporgTest extends BaseTestCase
 {
     private string $badFile;
     private string $wporgDir;

--- a/tests/unit/Release/GAEnforcerProfilesTest.php
+++ b/tests/unit/Release/GAEnforcerProfilesTest.php
@@ -3,9 +3,9 @@ declare(strict_types=1);
 
 namespace SmartAlloc\Tests\Release;
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 
-final class GAEnforcerProfilesTest extends TestCase
+final class GAEnforcerProfilesTest extends BaseTestCase
 {
     private string $root;
     private string $schemaScriptBak;

--- a/tests/unit/Release/GAEnforcerRestTest.php
+++ b/tests/unit/Release/GAEnforcerRestTest.php
@@ -3,9 +3,9 @@ declare(strict_types=1);
 
 namespace SmartAlloc\Tests\Release;
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 
-final class GAEnforcerRestTest extends TestCase
+final class GAEnforcerRestTest extends BaseTestCase
 {
     private string $dir;
 

--- a/tests/unit/Release/GAEnforcerSchemaTest.php
+++ b/tests/unit/Release/GAEnforcerSchemaTest.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 
-final class GAEnforcerSchemaTest extends TestCase
+final class GAEnforcerSchemaTest extends BaseTestCase
 {
     protected function setUp(): void
     {

--- a/tests/unit/Release/GAEnforcerSqlPrepareTest.php
+++ b/tests/unit/Release/GAEnforcerSqlPrepareTest.php
@@ -3,12 +3,12 @@ declare(strict_types=1);
 
 namespace SmartAlloc\Tests\Release;
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 use SmartAlloc\Services\{AllocationService,Logging,Metrics,ScoringAllocator,DlqService,EventStoreWp};
 use SmartAlloc\Event\EventBus;
 use SmartAlloc\Contracts\EventStoreInterface;
 
-final class GAEnforcerSqlPrepareTest extends TestCase
+final class GAEnforcerSqlPrepareTest extends BaseTestCase
 {
     private string $dir;
 

--- a/tests/unit/Release/GAEnforcerTest.php
+++ b/tests/unit/Release/GAEnforcerTest.php
@@ -3,9 +3,9 @@ declare(strict_types=1);
 
 namespace SmartAlloc\Tests\Release;
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 
-class GAEnforcerTest extends TestCase
+class GAEnforcerTest extends BaseTestCase
 {
     /** @var array<string> */
     private array $files = [];

--- a/tests/unit/Release/ReadmeLintTest.php
+++ b/tests/unit/Release/ReadmeLintTest.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 
-final class ReadmeLintTest extends TestCase
+final class ReadmeLintTest extends BaseTestCase
 {
     public function test_valid_readme(): void
     {

--- a/tests/unit/Release/RehearsalScriptTest.php
+++ b/tests/unit/Release/RehearsalScriptTest.php
@@ -3,9 +3,9 @@ declare(strict_types=1);
 
 namespace SmartAlloc\Tests\Release;
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 
-final class RehearsalScriptTest extends TestCase
+final class RehearsalScriptTest extends BaseTestCase
 {
     private string $root;
 

--- a/tests/unit/Release/TagReleaseTest.php
+++ b/tests/unit/Release/TagReleaseTest.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 
-final class TagReleaseTest extends TestCase
+final class TagReleaseTest extends BaseTestCase
 {
     private string $root;
 

--- a/tests/unit/Release/VersionReadmeCoherenceTest.php
+++ b/tests/unit/Release/VersionReadmeCoherenceTest.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 
-final class VersionReadmeCoherenceTest extends TestCase
+final class VersionReadmeCoherenceTest extends BaseTestCase
 {
     public function test_mismatch_emits_warning(): void
     {

--- a/tests/unit/Security/HeadersGuardTest.php
+++ b/tests/unit/Security/HeadersGuardTest.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 
 require_once dirname(__DIR__, 3) . '/scripts/headers-guard.php';
 
@@ -10,7 +10,7 @@ require_once dirname(__DIR__, 3) . '/scripts/headers-guard.php';
  * Test is advisory and skipped if the plugin does not expose the
  * expected hook/function.
  */
-final class HeadersGuardTest extends TestCase
+final class HeadersGuardTest extends BaseTestCase
 {
     public function test_security_headers_present(): void
     {

--- a/tests/unit/Security/NonceVerificationTest.php
+++ b/tests/unit/Security/NonceVerificationTest.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 
-final class NonceVerificationTest extends TestCase
+final class NonceVerificationTest extends BaseTestCase
 {
     public function test_nonce_usage_is_present_or_allowlisted(): void
     {

--- a/tests/unit/Security/RestPermissionsScanTest.php
+++ b/tests/unit/Security/RestPermissionsScanTest.php
@@ -1,12 +1,12 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 use org\bovigo\vfs\vfsStream;
 
 require_once dirname(__DIR__, 3) . '/scripts/scan-rest-permissions.php';
 
-final class RestPermissionsScanTest extends TestCase
+final class RestPermissionsScanTest extends BaseTestCase
 {
     private function mirror(string $src, string $dst): void
     {

--- a/tests/unit/Security/RestPermissionsTest.php
+++ b/tests/unit/Security/RestPermissionsTest.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 
-final class RestPermissionsTest extends TestCase
+final class RestPermissionsTest extends BaseTestCase
 {
     public function test_rest_routes_have_permissions(): void
     {

--- a/tests/unit/Security/SQLInjectionTest.php
+++ b/tests/unit/Security/SQLInjectionTest.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 
-final class SQLInjectionTest extends TestCase
+final class SQLInjectionTest extends BaseTestCase
 {
     public function test_wpdb_usage_is_prepared_or_allowlisted(): void
     {

--- a/tests/unit/Security/SQLPrepareGuardTest.php
+++ b/tests/unit/Security/SQLPrepareGuardTest.php
@@ -1,11 +1,11 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 
 require_once dirname(__DIR__, 3) . '/scripts/scan-sql-prepare.php';
 
-final class SQLPrepareGuardTest extends TestCase
+final class SQLPrepareGuardTest extends BaseTestCase
 {
     public function test_sql_queries_are_prepared(): void
     {

--- a/tests/unit/Security/SecretsScanTest.php
+++ b/tests/unit/Security/SecretsScanTest.php
@@ -1,12 +1,12 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 use org\bovigo\vfs\vfsStream;
 
 require_once dirname(__DIR__, 3) . '/scripts/scan-secrets.php';
 
-final class SecretsScanTest extends TestCase
+final class SecretsScanTest extends BaseTestCase
 {
     private function mirror(string $src, string $dst): void
     {

--- a/tests/unit/Security/SqlPrepareScannerTest.php
+++ b/tests/unit/Security/SqlPrepareScannerTest.php
@@ -1,12 +1,12 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 use org\bovigo\vfs\vfsStream;
 
 require_once dirname(__DIR__, 3) . '/scripts/scan-sql-prepare.php';
 
-final class SqlPrepareScannerTest extends TestCase
+final class SqlPrepareScannerTest extends BaseTestCase
 {
     /** Mirror vfs directory to real filesystem for CLI execution. */
     private function mirror(string $src, string $dst): void

--- a/tests/unit/Services/DbSafeTest.php
+++ b/tests/unit/Services/DbSafeTest.php
@@ -1,10 +1,10 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 use SmartAlloc\Services\DbSafe;
 
-final class DbSafeTest extends TestCase
+final class DbSafeTest extends BaseTestCase
 {
     public function test_mismatch_throws(): void
     {

--- a/tests/unit/Services/DlqServiceTest.php
+++ b/tests/unit/Services/DlqServiceTest.php
@@ -1,10 +1,10 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 use SmartAlloc\Services\DlqService;
 
-final class DlqServiceTest extends TestCase
+final class DlqServiceTest extends BaseTestCase
 {
     private function setupDb(): void
     {

--- a/tests/unit/Services/RetryServiceTest.php
+++ b/tests/unit/Services/RetryServiceTest.php
@@ -1,10 +1,10 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 use SmartAlloc\Services\RetryService;
 
-final class RetryServiceTest extends TestCase
+final class RetryServiceTest extends BaseTestCase
 {
     public function testBackoffMonotonicAndBounded(): void
     {

--- a/tests/unit/Validation/PersianValidatorTest.php
+++ b/tests/unit/Validation/PersianValidatorTest.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 
-final class PersianValidatorTest extends TestCase
+final class PersianValidatorTest extends BaseTestCase
 {
     public function test_national_id_and_card_validation_or_skip(): void
     {

--- a/tests/unit/WPOrg/DeployChecklistTest.php
+++ b/tests/unit/WPOrg/DeployChecklistTest.php
@@ -1,7 +1,7 @@
 <?php
-use PHPUnit\Framework\TestCase;
+use SmartAlloc\Tests\BaseTestCase;
 
-class DeployChecklistTest extends TestCase
+class DeployChecklistTest extends BaseTestCase
 {
     private string $dir;
 


### PR DESCRIPTION
## Summary
- add nikic/php-parser for AST scanning
- enforce SmartAlloc\Tests\BaseTestCase across test suite via AST meta-test
- configure phpunit to include Meta suite and load testing env

## Testing
- `vendor/bin/phpunit --testsuite Meta`
- `vendor/bin/phpunit --testsuite Performance`
- `vendor/bin/phpunit --testsuite Regression`
- `vendor/bin/phpunit` *(fails: Allowed memory size exhausted)*
- `php scripts/artifact-schema-validate.php`
- `php scripts/ga-enforcer.php --profile=ga --junit`


------
https://chatgpt.com/codex/tasks/task_e_68a890d0b3f8832196b06bac0ab40362