### PR TITLE
Introduce AllocationService interface with service container

### DIFF
--- a/src/Contracts/AllocationServiceInterface.php
+++ b/src/Contracts/AllocationServiceInterface.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace SmartAlloc\Contracts;
+
+use SmartAlloc\Core\FormContext;
+use SmartAlloc\Services\Exceptions\DuplicateAllocationException;
+use SmartAlloc\Services\Exceptions\InsufficientCapacityException;
+use SmartAlloc\Services\Exceptions\InvalidFormContextException;
+
+interface AllocationServiceInterface
+{
+    /**
+     * @param array<string,mixed> $payload
+     * @return array<string,mixed>
+     * @throws DuplicateAllocationException
+     * @throws InsufficientCapacityException
+     * @throws InvalidFormContextException
+     */
+    public function allocateWithContext(FormContext $ctx, array $payload): array;
+
+    /**
+     * Legacy entrypoint: delegates to form 150.
+     * @param array<string,mixed> $payload
+     * @return array<string,mixed>
+     */
+    public function allocate(array $payload): array;
+}

--- a/src/REST/Controllers/AllocationController.php
+++ b/src/REST/Controllers/AllocationController.php
@@ -4,15 +4,21 @@ declare(strict_types=1);
 
 namespace SmartAlloc\REST\Controllers;
 
+use SmartAlloc\Contracts\AllocationServiceInterface;
 use SmartAlloc\Core\FormContext;
-use SmartAlloc\Services\AllocationService;
 use SmartAlloc\Services\Exceptions\DuplicateAllocationException;
 use SmartAlloc\Services\Exceptions\InsufficientCapacityException;
 use SmartAlloc\Services\Exceptions\InvalidFormContextException;
+use SmartAlloc\Services\ServiceContainer;
 
 final class AllocationController
 {
-    public function __construct(private AllocationService $svc) {}
+    private AllocationServiceInterface $svc;
+
+    public function __construct(?AllocationServiceInterface $svc = null)
+    {
+        $this->svc = $svc ?: ServiceContainer::allocation();
+    }
 
     public function register(): void
     {

--- a/src/Services/AllocationService.php
+++ b/src/Services/AllocationService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace SmartAlloc\Services;
 
+use SmartAlloc\Contracts\AllocationServiceInterface;
 use SmartAlloc\Core\FormContext;
 use SmartAlloc\Infra\DB\TableResolver;
 use SmartAlloc\Services\DbSafe;
@@ -11,7 +12,7 @@ use SmartAlloc\Services\Exceptions\DuplicateAllocationException;
 use SmartAlloc\Services\Exceptions\InsufficientCapacityException;
 use SmartAlloc\Services\Exceptions\InvalidFormContextException;
 
-final class AllocationService
+final class AllocationService implements AllocationServiceInterface
 {
     public function __construct(private TableResolver $tables) {}
 

--- a/src/Services/ServiceContainer.php
+++ b/src/Services/ServiceContainer.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+namespace SmartAlloc\Services;
+
+use SmartAlloc\Contracts\AllocationServiceInterface;
+use SmartAlloc\Infra\DB\TableResolver;
+
+/**
+ * Minimal DI accessor with WP filter override for tests.
+ */
+final class ServiceContainer
+{
+    private static ?AllocationServiceInterface $allocation = null;
+
+    public static function allocation(): AllocationServiceInterface
+    {
+        if (!self::$allocation) {
+            /** @var AllocationServiceInterface $svc */
+            $svc = apply_filters('smartalloc_service_allocation', null);
+            if ($svc instanceof AllocationServiceInterface) {
+                self::$allocation = $svc;
+            } else {
+                global $wpdb;
+                self::$allocation = new AllocationService(
+                    new TableResolver($wpdb)
+                );
+            }
+        }
+        return self::$allocation;
+    }
+
+    /** For tests only. */
+    public static function setAllocation(AllocationServiceInterface $svc): void
+    {
+        self::$allocation = $svc;
+    }
+}

--- a/tests/REST/AllocationControllerTest.php
+++ b/tests/REST/AllocationControllerTest.php
@@ -4,58 +4,37 @@ namespace SmartAlloc\Tests\REST;
 
 use Brain\Monkey;
 use Brain\Monkey\Functions;
-use SmartAlloc\Infra\DB\TableResolver;
 use SmartAlloc\REST\Controllers\AllocationController;
-use SmartAlloc\Services\AllocationService;
+use SmartAlloc\Contracts\AllocationServiceInterface;
+use SmartAlloc\Core\FormContext;
+use SmartAlloc\Services\Exceptions\DuplicateAllocationException;
 use SmartAlloc\Tests\BaseTestCase;
 
 final class AllocationControllerTest extends BaseTestCase
 {
     private AllocationController $controller;
+    private AllocationServiceInterface $svc;
     private $cb;
 
     protected function setUp(): void
     {
         parent::setUp();
         Monkey\setUp();
-        global $wpdb;
-        $wpdb = new class extends \wpdb {
-            public string $prefix = 'wp_';
-            public array $data = [];
-            public function __construct() {}
-            public function prepare(string $query, ...$args): string {
-                if (isset($args[0]) && is_array($args[0])) { $args = $args[0]; }
-                foreach ($args as &$a) { if (is_string($a)) { $a = "'" . addslashes($a) . "'"; } }
-                return vsprintf($query, $args);
-            }
-            public function get_var($query) {
-                if (preg_match('/FROM\s+(\w+)/', $query, $m)) { $table = $m[1]; } else { return 0; }
-                $rows = $this->data[$table] ?? [];
-                if (str_contains($query, 'WHERE')) {
-                    if (preg_match("/student_id = (\d+) OR email = \\'([^']*)\'/", $query, $n)) {
-                        $sid = (int) $n[1]; $email = stripslashes($n[2]);
-                        foreach ($rows as $r) { if ($r['student_id'] === $sid || $r['email'] === $email) { return 1; } }
-                    }
-                    return 0;
+        $svc = new class implements AllocationServiceInterface {
+            public array $keys = [];
+            public ?FormContext $lastCtx = null;
+            public function allocateWithContext(FormContext $ctx, array $payload): array {
+                $this->lastCtx = $ctx;
+                $key = $ctx->formId . ':' . ($payload['student_id'] ?? '') . ':' . ($payload['email'] ?? '');
+                if (in_array($key, $this->keys, true)) {
+                    throw new DuplicateAllocationException('duplicate allocation');
                 }
-                return count($rows);
+                $this->keys[] = $key;
+                return ['summary' => ['form_id' => $ctx->formId, 'count' => 1], 'allocations' => []];
             }
-            public function query($query) {
-                if (preg_match("/INTO\s+(\w+).*VALUES\s*\((\d+),'([^']*)','([^']*)','([^']*)','([^']*)'\)/", $query, $m)) {
-                    $this->data[$m[1]][] = [
-                        'student_id' => (int) $m[2],
-                        'email' => stripslashes($m[3]),
-                        'mobile' => stripslashes($m[4]),
-                        'national_id' => stripslashes($m[5]),
-                        'created_at' => stripslashes($m[6]),
-                    ];
-                    return 1;
-                }
-                return 0;
-            }
+            public function allocate(array $payload): array { return []; }
         };
-        $tables = new TableResolver($wpdb);
-        $svc = new AllocationService($tables);
+        $this->svc = $svc;
         $this->controller = new AllocationController($svc);
         $this->cb = null;
     }
@@ -141,7 +120,6 @@ final class AllocationControllerTest extends BaseTestCase
         $req = new \WP_REST_Request(['form_id' => 123, '_wpnonce' => 'n']);
         $req->set_body(json_encode(['student_id'=>5,'email'=>'x@a.com']));
         ($this->cb)($req);
-        global $wpdb;
-        $this->assertArrayHasKey('wp_smartalloc_allocations_f123', $wpdb->data);
+        $this->assertSame(123, $this->svc->lastCtx->formId);
     }
 }


### PR DESCRIPTION
## Summary
- add `AllocationServiceInterface` and implement in `AllocationService`
- provide `ServiceContainer` for swap-able allocation service
- refactor REST controller and Sabt submission handler to use interface
- update tests to mock the new interface

## Testing
- `SMARTALLOC_TESTS=1 vendor/bin/phpunit --testsuite Unit`
- `SMARTALLOC_TESTS=1 vendor/bin/phpunit --testsuite Integration`
- `SMARTALLOC_TESTS=1 vendor/bin/phpunit --testsuite REST`


------
https://chatgpt.com/codex/tasks/task_e_68a9912006b48321a645ea1b35955067