### PR TITLE
feat: add feature scoring & ADR context sync scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,10 @@ jobs:
             tests/Unit/BrainMonkeySmokeTest.php \
             tests/WordPress/Smoke/BootTest.php
 
+      - name: 🔐 Ensure scripts executable (defensive)
+        if: always()
+        run: chmod +x scripts/*.php || true
+
       - name: 🔄 Generate FEATURES.md
         if: always()
         run: php scripts/generate_features_md.php

--- a/features.json
+++ b/features.json
@@ -1,0 +1,4 @@
+{
+  "schema": 1,
+  "features": []
+}

--- a/scripts/ai_context_sync.php
+++ b/scripts/ai_context_sync.php
@@ -1,4 +1,52 @@
-#!/usr/bin/env php
 <?php
-$context = ['decisions' => []];
-file_put_contents(__DIR__ . '/../ai_context.json', json_encode($context, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . PHP_EOL);
+declare(strict_types=1);
+
+/**
+ * Build ai_context.json by scanning docs/architecture/decisions for ADRs.
+ * Extract title from first markdown heading, date from filename prefix YYYYMMDD if present.
+ */
+
+$root = dirname(__DIR__);
+$adrDir = $root . '/docs/architecture/decisions';
+$out   = $root . '/ai_context.json';
+
+$decisions = [];
+if (is_dir($adrDir)) {
+    foreach (new DirectoryIterator($adrDir) as $f) {
+        if ($f->isDot() || !$f->isFile()) continue;
+        $name = $f->getFilename();
+        if (!preg_match('/\.md$/i', $name)) continue;
+
+        $path = $f->getPathname();
+        $title = null;
+        $content = @file_get_contents($path) ?: '';
+        if (preg_match('/^#\s*(.+)$/m', $content, $m)) {
+            $title = trim($m[1]);
+        }
+        $date = null;
+        if (preg_match('/^(\d{8})[_-]/', $name, $m)) {
+            $y = substr($m[1], 0, 4);
+            $mo= substr($m[1], 4, 2);
+            $d = substr($m[1], 6, 2);
+            $date = "$y-$mo-$d";
+        }
+
+        $decisions[] = [
+            'file' => "docs/architecture/decisions/$name",
+            'title'=> $title ?: pathinfo($name, PATHINFO_FILENAME),
+            'date' => $date,
+        ];
+    }
+}
+
+$result = [
+    'last_updated_utc' => gmdate('Y-m-d\TH:i:s\Z'),
+    'decisions'        => $decisions,
+    'notes'            => [
+        'source' => 'ADR markdown files',
+        'policy' => 'No auto-commit; artifacts uploaded in CI'
+    ],
+];
+
+file_put_contents($out, json_encode($result, JSON_PRETTY_PRINT|JSON_UNESCAPED_SLASHES));
+echo "Generated ai_context.json with " . count($decisions) . " decisions\n";

--- a/scripts/generate_features_md.php
+++ b/scripts/generate_features_md.php
@@ -1,4 +1,90 @@
-#!/usr/bin/env php
 <?php
-$features = "# Feature Scores\n\n";
-file_put_contents(__DIR__ . '/../FEATURES.md', $features);
+declare(strict_types=1);
+
+/**
+ * Generate FEATURES.md from features.json with simple scoring:
+ * +40 if all code_paths exist
+ * +30 if all test_paths exist
+ * +30 if security signals found in code (nonce/permission_callback/prepare)
+ * Score caps at 100; color: 🟢 90-100, 🟠 70-89, 🔴 <70
+ */
+
+$root = dirname(__DIR__);
+$featuresFile = $root . '/features.json';
+$outFile = $root . '/FEATURES.md';
+
+$features = [
+    'schema' => 1,
+    'features' => []
+];
+
+if (file_exists($featuresFile)) {
+    $json = json_decode(file_get_contents($featuresFile), true);
+    if (is_array($json) && isset($json['features']) && is_array($json['features'])) {
+        $features = $json;
+    }
+}
+
+function paths_exist(array $paths): bool {
+    foreach ($paths as $p) {
+        if (!file_exists($p)) return false;
+    }
+    return true;
+}
+
+function scan_security(array $paths): int {
+    $signals = ['wp_verify_nonce', 'permission_callback', 'DbSafe::mustPrepare', '$wpdb->prepare('];
+    $hits = 0;
+    foreach ($paths as $p) {
+        if (!file_exists($p)) continue;
+        $content = is_dir($p) ? '' : @file_get_contents($p);
+        if ($content === false) continue;
+        foreach ($signals as $sig) {
+            if (strpos($content, $sig) !== false) { $hits++; break; }
+        }
+    }
+    return $hits;
+}
+
+$rows = [];
+foreach ($features['features'] as $f) {
+    $name   = $f['name'] ?? 'Unnamed';
+    $key    = $f['key'] ?? strtolower(preg_replace('/\s+/', '_', $name));
+    $codes  = $f['code_paths'] ?? [];
+    $tests  = $f['test_paths'] ?? [];
+    $score  = 0;
+
+    $codeOk = !empty($codes) && paths_exist($codes);
+    $testOk = !empty($tests) && paths_exist($tests);
+    $secOk  = scan_security($codes) > 0;
+
+    $score += $codeOk ? 40 : 0;
+    $score += $testOk ? 30 : 0;
+    $score += $secOk  ? 30 : 0;
+    if ($score > 100) $score = 100;
+
+    $badge = $score >= 90 ? '🟢' : ($score >= 70 ? '🟠' : '🔴');
+    $rows[] = [
+        'name' => $name,
+        'key'  => $key,
+        'score'=> $score,
+        'badge'=> $badge,
+        'code' => $codeOk ? '✅' : '⚪',
+        'test' => $testOk ? '✅' : '⚠️',
+        'sec'  => $secOk  ? '✅' : '❌',
+    ];
+}
+
+ob_start();
+echo "# 📌 FEATURES\n\n";
+echo "> Auto-generated. Do not edit manually. Source: features.json\n\n";
+echo "| Feature | Key | Score | Impl | Tests | Security |\n";
+echo "|---|---|---:|:---:|:---:|:---:|\n";
+foreach ($rows as $r) {
+    printf("| %s | `%s` | %s %d | %s | %s | %s |\n",
+        $r['name'], $r['key'], $r['badge'], $r['score'], $r['code'], $r['test'], $r['sec']
+    );
+}
+echo "\n**Legend:** 🟢 90–100 (Ready), 🟠 70–89 (Testing), 🔴 <70 (In progress)\n";
+file_put_contents($outFile, ob_get_clean());
+echo "Generated FEATURES.md\n";


### PR DESCRIPTION
## Summary
- run defensive chmod before generating state artifacts in CI
- add feature scoring generator and ADR context sync scripts
- seed features.json for feature metrics

## Testing
- `composer install --no-interaction --prefer-dist --ansi`
- `vendor/bin/phpunit tests/WordPress/Smoke/BootTest.php -v`
- `vendor/bin/phpunit tests/Unit/BrainMonkeySmokeTest.php -v`
- `php scripts/generate_features_md.php`
- `php scripts/ai_context_sync.php`


------
https://chatgpt.com/codex/tasks/task_e_68ac719fc93883219e5e8c74cf852bbe