### PR TITLE
ci: harden workflows and skip wp smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,12 +59,6 @@ jobs:
         uses: actions/checkout@v4
         with: { fetch-depth: 0 }
 
-      - name: 🛠️ System tools
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y unzip zip subversion curl tar mysql-client
-          sudo apt-get install -y jq
-
       - name: 🐘 Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -72,6 +66,11 @@ jobs:
           extensions: mbstring, xml, json, mysqli, curl, dom
           tools: composer, phpunit
           coverage: xdebug
+
+      - name: 🛠️ System tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y unzip zip subversion curl tar mysql-client jq
 
       - name: 🗄️ Cache Composer
         uses: actions/cache@v4
@@ -107,6 +106,10 @@ jobs:
           vendor/bin/psalm --no-progress --output-format=github --stats || true
           vendor/bin/psalm --taint-analysis || true
 
+      - name: 🔐 Ensure scripts executable (defensive)
+        if: always()
+        run: chmod +x scripts/*.php || true
+
       - name: 🧪 PHPUnit (smoke only, temporary)
         env:
           XDEBUG_MODE: coverage
@@ -114,10 +117,6 @@ jobs:
           vendor/bin/phpunit \
             tests/Unit/BrainMonkeySmokeTest.php \
             tests/WordPress/Smoke/BootTest.php
-
-      - name: 🔐 Ensure scripts executable (defensive)
-        if: always()
-        run: chmod +x scripts/*.php || true
 
       - name: 🔄 Generate FEATURES.md
         if: always()

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,5 +1,9 @@
 name: E2E (optional)
-on: [workflow_dispatch, push, pull_request]
+on:
+  workflow_dispatch:
+  # optional:
+  # schedule:
+  #   - cron: '0 4 * * 6'
 jobs:
   e2e:
     if: ${{ env.PLAYWRIGHT_E2E == '1' }}

--- a/tests/WordPress/Smoke/BootTest.php
+++ b/tests/WordPress/Smoke/BootTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 use PHPUnit\Framework\TestCase;
 
 class BootTest extends TestCase
@@ -8,7 +10,6 @@ class BootTest extends TestCase
     {
         if (!class_exists('WP_UnitTestCase')) {
             $this->markTestSkipped('WP test suite not available locally; skipping WordPress smoke test.');
-            return;
         }
         $this->assertTrue(function_exists('do_action'), 'WordPress did not boot (do_action missing).');
     }


### PR DESCRIPTION
## Summary
- ensure jq and other tools are installed for QA job
- defensively chmod PHP scripts and keep smoke tests
- make e2e workflow manual-only to avoid auto failures

## Testing
- `vendor/bin/phpunit tests/WordPress/Smoke/BootTest.php --testdox`
- `php scripts/generate_features_md.php`
- `php scripts/ai_context_sync.php`

------
https://chatgpt.com/codex/tasks/task_e_68ac7aed28408321b9e72bd1f869e2eb