### PR TITLE
test: load WP stubs via autoload-dev + Eris trait for property tests

### DIFF
--- a/stubs/wp-stubs.php
+++ b/stubs/wp-stubs.php
@@ -25,11 +25,6 @@ if (!function_exists('add_filter')) {
     }
 }
 
-if (!function_exists('do_action')) {
-    function do_action($hook, ...$args) {
-        return true;
-    }
-}
 
 if (!function_exists('get_option')) {
     function get_option($key, $default = false) {
@@ -69,6 +64,14 @@ if (!class_exists('wpdb')) {
         public function query($query) { return 0; }
         public function get_var($query) { return 0; }
     }
+    // make a global instance like WordPress does
+    $GLOBALS['wpdb'] = new wpdb();
+}
+if (!function_exists('do_action')) {
+    function do_action(string $hook, ...$args): void { /* no-op stub */ }
+}
+if (!function_exists('__return_true')) {
+    function __return_true() { return true; }
 }
 
 if (!function_exists('rest_get_server')) {

--- a/tests/WordPress/AllocationPropertiesTest.php
+++ b/tests/WordPress/AllocationPropertiesTest.php
@@ -61,19 +61,18 @@ final class AllocationPropertiesTest extends WP_UnitTestCase
             $this->markTestSkipped('Assignment API not available');
         }
 
-        $this
-            ->forAll(
-                Generator\seq(
-                    Generator\associative([
-                        'id' => Generator\int(),
-                        'gender' => Generator\elements(['M', 'F']),
-                        'center' => Generator\elements(['1']),
-                    ]),
-                    1,
-                    20
-                )
+        $this->forAll(
+            Generator\seq(
+                Generator\associative([
+                    'id' => Generator\int(),
+                    'gender' => Generator\elements(['M', 'F']),
+                    'center' => Generator\elements(['1']),
+                ]),
+                1,
+                20
             )
-            ->then(function ($students): void {
+        )
+        ->then(function ($students): void {
                 $this->processAllocations($students);
                 foreach ($this->getAllMentors() as $mentor) {
                     $this->assertLessThanOrEqual(
@@ -90,8 +89,7 @@ final class AllocationPropertiesTest extends WP_UnitTestCase
             $this->markTestSkipped('Assignment API not available');
         }
 
-        $this
-            ->forAll(Generator\int())
+        $this->forAll(Generator\int())
             ->then(function ($seed): void {
                 $student = $this->makeStudentFromSeed($seed);
                 $engine1 = $this->makeAllocationEngine();

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,13 +1,4 @@
 <?php
+declare(strict_types=1);
 require_once __DIR__ . '/../vendor/autoload.php';
-
-require_once __DIR__ . '/../vendor/giorgiosironi/eris/src/Generator/SequenceGenerator.php';
-require_once __DIR__ . '/../vendor/giorgiosironi/eris/src/Generator/IntegerGenerator.php';
-require_once __DIR__ . '/../vendor/giorgiosironi/eris/src/Generator/AssociativeArrayGenerator.php';
-require_once __DIR__ . '/../vendor/giorgiosironi/eris/src/Generator/ElementsGenerator.php';
-
-$wpTestsDir = getenv('WP_TESTS_DIR') ?: '/tmp/wordpress-tests-lib';
-if (file_exists($wpTestsDir . '/includes/functions.php')) {
-    require_once $wpTestsDir . '/includes/functions.php';
-    require_once $wpTestsDir . '/includes/bootstrap.php';
-}
+require_once __DIR__ . '/../stubs/wp-stubs.php';


### PR DESCRIPTION
## Summary
- bootstrap tests by loading Composer autoload and custom WordPress stubs
- create global `$wpdb` plus `do_action` and `__return_true` stubs for property testing
- use Eris `TestTrait` and generators in `AllocationPropertiesTest`

## Testing
- `composer dump-autoload -o`
- `vendor/bin/phpunit tests/Unit/BrainMonkeySmokeTest.php`
- `vendor/bin/phpunit tests/WordPress/Smoke/BootTest.php -v`
- `vendor/bin/phpunit tests/WordPress/AllocationPropertiesTest.php -v` *(skipped: Assignment API not available)*


------
https://chatgpt.com/codex/tasks/task_e_68ad6ea87a2c8321bfc9f8def3a29e92