### PR TITLE
chore: add fast repo push helper and CI smoke step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
       - name: 🔎 PHP syntax lint
         run: composer lint:php
 
-      - name: 🧪 PHPUnit (smoke only)
+      - name: 🧪 Smoke tests (Composer script)
         run: composer test:smoke
 
       - name: 🔐 Ensure scripts executable (defensive)

--- a/scripts/fast_repo_push.sh
+++ b/scripts/fast_repo_push.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Detect repo & branch
+git rev-parse --is-inside-work-tree >/dev/null
+BRANCH="$(git branch --show-current)"
+: "${BRANCH:?No current branch}"
+echo "• Branch: $BRANCH"
+
+# Ensure remote origin
+if ! git remote get-url origin >/dev/null 2>&1; then
+  if [ -n "${GIT_ORIGIN_URL:-}" ]; then
+    echo "• Adding origin: $GIT_ORIGIN_URL"
+    git remote add origin "$GIT_ORIGIN_URL"
+  else
+    echo "!! No 'origin' remote. Set it, e.g.:"
+    echo "   git remote add origin https://github.com/<OWNER>/<REPO>.git"
+    echo "   GIT_ORIGIN_URL=https://github.com/<OWNER>/<REPO>.git bash scripts/fast_repo_push.sh"
+    exit 2
+  fi
+fi
+
+# Push branch
+echo "• Pushing $BRANCH to origin..."
+git push -u origin "$BRANCH"
+
+# Try to create PR with gh (if available), else show compare URL
+if command -v gh >/dev/null 2>&1; then
+  echo "• Creating PR via gh..."
+  gh pr create --fill --base main --head "$BRANCH" || gh pr create --fill --base master --head "$BRANCH" || true
+else
+  REPO_URL="$(git remote get-url origin | sed -E 's/\.git$//')"
+  echo "Open PR via:"
+  echo "$REPO_URL/compare/main...${BRANCH}?expand=1"
+fi
+


### PR DESCRIPTION
## Summary
- add `scripts/fast_repo_push.sh` for quick push and PR creation
- rename CI smoke test step for clarity

## Testing
- `composer lint:php`
- `composer phpcs || true`
- `composer psalm || true`
- `composer test:smoke`


------
https://chatgpt.com/codex/tasks/task_e_68ad7284f79883219486c4cdcba58141