### PR TITLE
ci: honor matrix php-version in QA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,11 +56,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Setup PHP 8.2 and install dependencies before smoke tests
+      # Setup PHP (use matrix) and install dependencies before smoke tests
       - name: 🐘 Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: ${{ matrix.php }}
           tools: composer, phpunit
           coverage: none
 


### PR DESCRIPTION
## Summary
- use matrix php version in QA job
- retain setup → cache → install → smoke order

## Testing
- `python - <<'PY'
import yaml
yaml.safe_load(open('.github/workflows/ci.yml'))
print('YAML load OK')
PY`


------
https://chatgpt.com/codex/tasks/task_e_68ad95b4f6988321870842fdb489e5f9