### PR TITLE
ci(qa): use matrix php-version and PHP-scoped Composer cache key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,15 +56,15 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Setup PHP using matrix and install dependencies before smoke tests
-      - name: 🐘 Setup PHP
+      # Use matrix PHP versions; install dependencies before smoke tests
+      - name: 🐘 Setup PHP ${{ matrix.php }}
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
           tools: composer, phpunit
           coverage: none
 
-      - name: ♻️ Composer cache
+      - name: ♻️ Composer cache (PHP scoped)
         uses: actions/cache@v4
         with:
           path: ~/.composer/cache/files


### PR DESCRIPTION
## Summary
- emphasize matrix PHP setup and PHP-scoped Composer cache in QA workflow
- keep setup→cache→install→smoke order

## Testing
- `python - <<'PY'
import yaml; yaml.safe_load(open('.github/workflows/ci.yml')); print('YAML OK')
PY`


------
https://chatgpt.com/codex/tasks/task_e_68ada728c6a0832180e539dfc154c378