### PR TITLE
feat(ci,score): add 5D scoring system + enhanced summary & artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,13 +84,26 @@ jobs:
           chmod +x scripts/*.php || true
           chmod +x scripts/new_adr.sh || true
 
-      - name: 🔄 Generate FEATURES.md
-        if: always()
-        run: php scripts/generate_features_md.php
+      - name: 📊 Generate Enhanced 5D Scores
+        run: composer score:5d
 
-      - name: 🔁 Sync AI context (ADRs → ai_context.json)
-        if: always()
-        run: php scripts/ai_context_sync.php
+      - name: 📤 Upload Enhanced Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: project-state-enhanced
+          path: |
+            FEATURES.md
+            ai_context.json
+
+      - name: 🧾 Enhanced Summary (5D)
+        run: |
+          echo "## 📊 Enhanced 5D Feature Scores" >> "$GITHUB_STEP_SUMMARY"
+          cat FEATURES.md >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "## 🤖 AI Context (current_scores)" >> "$GITHUB_STEP_SUMMARY"
+          echo '```json' >> "$GITHUB_STEP_SUMMARY"
+          jq '.current_scores' ai_context.json >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
 
       - name: 📝 Append project state to summary
         if: always()

--- a/composer.json
+++ b/composer.json
@@ -1,73 +1,73 @@
 {
-    "name": "smartalloc\/wordpress-plugin",
-    "description": "Event-driven student support allocation with Gravity Forms + Exporter",
-    "type": "wordpress-plugin",
-    "version": "1.0.0-rc.2",
-    "license": "MIT",
-    "authors": [
-        {
-            "name": "رضا هاشمی حسینی",
-            "email": "developer@smartalloc.com"
-        }
-    ],
-    "require": {
-        "php": ">=8.1",
-        "phpoffice\/phpspreadsheet": "~1.29.0",
-        "maennchen\/zipstream-php": "^2.2.1"
-    },
-    "conflict": {
-        "maennchen\/zipstream-php": ">=3.0"
-    },
-    "require-dev": {
-        "phpunit\/phpunit": "^9.6",
-        "yoast\/phpunit-polyfills": "^2.0",
-        "brain\/monkey": "^2.6",
-        "wp-coding-standards\/wpcs": "^3.0",
-        "automattic\/vipwpcs": "^3.0",
-        "phpcompatibility\/php-compatibility": "^9.3",
-        "phpcompatibility\/phpcompatibility-wp": "^2.1",
-        "phpcompatibility\/phpcompatibility-paragonie": "^1.0",
-        "dealerdirect\/phpcodesniffer-composer-installer": "^1.0",
-        "phpcsstandards\/phpcsextra": "^1.2",
-        "phpcsstandards\/phpcsutils": "^1.0",
-        "sirbrillig\/phpcs-variable-analysis": "^2.11",
-        "vimeo\/psalm": "^5.18",
-        "php-stubs\/wordpress-stubs": "^6.6",
-        "giorgiosironi\/eris": "^1.0"
-    },
-    "autoload": {
-        "psr-4": {
-            "SmartAlloc\\": "src\/"
-        }
-    },
-    "scripts": {
-        "lint:php": "php -l $(git ls-files '*.php')",
-        "phpcs": "vendor/bin/phpcs -q --standard=phpcs.xml",
-        "psalm": "vendor/bin/psalm --no-progress",
-        "psalm:taint": "vendor/bin/psalm --taint-analysis",
-        "test": "vendor/bin/phpunit --testsuite Unit,WordPress,VIP,Integration",
-        "test:smoke": "vendor/bin/phpunit tests/Unit/BrainMonkeySmokeTest.php tests/WordPress/Smoke/BootTest.php",
-        "gen:features": "php scripts/generate_features_md.php",
-        "gen:context": "php scripts/ai_context_sync.php",
-        "state": "php scripts/generate_features_md.php && php scripts/ai_context_sync.php && bash scripts/update_state.sh",
-        "cs": "vendor/bin/phpcs -q --standard=phpcs.xml"
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "SmartAlloc\\Tests\\": "tests\/"
-        },
-        "files": [
-            "stubs\/wp-stubs.php"
-        ]
-    },
-    "config": {
-        "allow-plugins": {
-            "dealerdirect\/phpcodesniffer-composer-installer": true,
-            "infection\/extension-installer": true
-        },
-        "platform": {
-            "php": "8.1.0"
-        }
+  "name": "smartalloc/wordpress-plugin",
+  "description": "Event-driven student support allocation with Gravity Forms + Exporter",
+  "type": "wordpress-plugin",
+  "version": "1.0.0-rc.2",
+  "license": "MIT",
+  "authors": [
+    {
+      "name": "رضا هاشمی حسینی",
+      "email": "developer@smartalloc.com"
     }
+  ],
+  "require": {
+    "php": ">=8.1",
+    "phpoffice/phpspreadsheet": "~1.29.0",
+    "maennchen/zipstream-php": "^2.2.1"
+  },
+  "conflict": {
+    "maennchen/zipstream-php": ">=3.0"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "^9.6",
+    "yoast/phpunit-polyfills": "^2.0",
+    "brain/monkey": "^2.6",
+    "wp-coding-standards/wpcs": "^3.0",
+    "automattic/vipwpcs": "^3.0",
+    "phpcompatibility/php-compatibility": "^9.3",
+    "phpcompatibility/phpcompatibility-wp": "^2.1",
+    "phpcompatibility/phpcompatibility-paragonie": "^1.0",
+    "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+    "phpcsstandards/phpcsextra": "^1.2",
+    "phpcsstandards/phpcsutils": "^1.0",
+    "sirbrillig/phpcs-variable-analysis": "^2.11",
+    "vimeo/psalm": "^5.18",
+    "php-stubs/wordpress-stubs": "^6.6",
+    "giorgiosironi/eris": "^1.0"
+  },
+  "autoload": {
+    "psr-4": {
+      "SmartAlloc\\": "src/"
+    }
+  },
+  "scripts": {
+    "lint:php": "php -l $(git ls-files '*.php')",
+    "phpcs": "vendor/bin/phpcs -q --standard=phpcs.xml",
+    "psalm": "vendor/bin/psalm --no-progress",
+    "psalm:taint": "vendor/bin/psalm --taint-analysis",
+    "test": "vendor/bin/phpunit --testsuite Unit,WordPress,VIP,Integration",
+    "test:smoke": "vendor/bin/phpunit tests/Unit/BrainMonkeySmokeTest.php tests/WordPress/Smoke/BootTest.php",
+    "gen:features": "php scripts/generate_features_md.php",
+    "gen:context": "php scripts/ai_context_sync.php",
+    "state": "php scripts/generate_features_md.php && php scripts/ai_context_sync.php && bash scripts/update_state.sh",
+    "cs": "vendor/bin/phpcs -q --standard=phpcs.xml",
+    "score:5d": "bash scripts/update_state.sh"
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "SmartAlloc\\Tests\\": "tests/"
+    },
+    "files": [
+      "stubs/wp-stubs.php"
+    ]
+  },
+  "config": {
+    "allow-plugins": {
+      "dealerdirect/phpcodesniffer-composer-installer": true,
+      "infection/extension-installer": true
+    },
+    "platform": {
+      "php": "8.1.0"
+    }
+  }
 }
-

--- a/docs/SCORING.md
+++ b/docs/SCORING.md
@@ -1,0 +1,6 @@
+# 5D Scoring (Security, Logic, Performance, Readability, Goal)
+
+- Automated via `scripts/update_state.sh`
+- Red Flags: direct superglobals, raw SQL without prepare
+- Total: /125, plus Weighted %
+- Outputs: `FEATURES.md` + `ai_context.json.current_scores`

--- a/scripts/update_state.sh
+++ b/scripts/update_state.sh
@@ -1,69 +1,132 @@
 #!/usr/bin/env bash
+# scripts/update_state.sh — 5D scoring for SmartAlloc
 set -euo pipefail
 
-# Ensure common bins are reachable in CI and local shells
-export PATH="/usr/local/bin:/usr/bin:/bin:$PATH"
-
-have() { command -v "$1" >/dev/null 2>&1; }
-
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-cd "$ROOT"
+SRC_DIR="${SRC_DIR:-$ROOT/src}"
+TESTS_DIR="${TESTS_DIR:-$ROOT/tests}"
+FEATURES_MD="$ROOT/FEATURES.md"
+AI_CTX="$ROOT/ai_context.json"
 
-# Inputs (optional): PHP version and WP version hints for display
-PHP_HINT="${1:-}"
-WP_HINT="${2:-}"
+phpcs_cmd="${PHPCS_CMD:-$ROOT/vendor/bin/phpcs}"
+phpunit_cmd="${PHPUNIT_CMD:-$ROOT/vendor/bin/phpunit}"
 
-# Generate feature scores and ADR context (never fail pipeline)
-if have php; then
-  php scripts/generate_features_md.php || true
-  php scripts/ai_context_sync.php || true
+exists() { command -v "$1" >/dev/null 2>&1; }
+
+jget() { jq -r "$1" 2>/dev/null || true; }
+
+score_part() { # clamp to 0..max
+  local v="$1" max="$2"
+  if [ "$v" -lt 0 ]; then echo 0
+  elif [ "$v" -gt "$max" ]; then echo "$max"
+  else echo "$v"; fi
+}
+
+# ---------- Security (25 = 4×6.25) ----------
+sec_nonce=0 sec_prepare=0 sec_utc=0 sec_typed=0
+if [ -d "$SRC_DIR" ]; then
+  grep -R -E "wp_verify_nonce|check_admin_referer" "$SRC_DIR" >/dev/null 2>&1 && sec_nonce=1
+  grep -R -E "DbSafe::mustPrepare|\$wpdb->prepare\(|->prepare\(" "$SRC_DIR" >/dev/null 2>&1 && sec_prepare=1
+  grep -R -E "current_time\s*\(\s*['\"]mysql['\"]\s*,\s*1\s*\)" "$SRC_DIR" >/dev/null 2>&1 && sec_utc=1
+  grep -R -E "throw\s+new\s+[A-Z][A-Za-z0-9_]*Exception" "$SRC_DIR" >/dev/null 2>&1 && sec_typed=1
+fi
+SECURITY_SCORE=$(echo "scale=2; ($sec_nonce+$sec_prepare+$sec_utc+$sec_typed)*6.25" | bc)
+
+# ---------- Logic (25 = 8+8+9) ----------
+# Heuristics: edge cases (if/elseif/default), error handling (try/catch), input validation (sanitize_/esc_/filter_var)
+edge_cnt=$( (grep -R -E "elseif|else if|default\s*:" "$SRC_DIR" 2>/dev/null || true) | wc -l | tr -d ' ' )
+edge_score=$(( edge_cnt >= 3 ? 8 : edge_cnt*3 )) # 0..8
+try_cnt=$( (grep -R -E "\btry\b" "$SRC_DIR" 2>/dev/null || true) | wc -l | tr -d ' ' )
+err_score=$(( try_cnt > 0 ? 8 : 0 ))            # 0/8
+val_cnt=$( (grep -R -E "sanitize_|esc_|filter_var\(" "$SRC_DIR" 2>/dev/null || true) | wc -l | tr -d ' ' )
+val_score=$(( val_cnt >= 3 ? 9 : val_cnt*3 ))   # 0..9
+LOGIC_SCORE=$(echo "$edge_score+$err_score+$val_score" | bc)
+
+# ---------- Performance (25 = 10 + 15) ----------
+db_q=$( (grep -R -E "\$wpdb->(get_var|get_row|get_results|query)\(" "$SRC_DIR" 2>/dev/null || true) | wc -l | tr -d ' ' )
+if   [ "$db_q" -le 5 ];  then db_score=10
+elif [ "$db_q" -le 15 ]; then db_score=8
+elif [ "$db_q" -le 30 ]; then db_score=5
+else db_score=3; fi
+cache_cnt=$( (grep -R -E "wp_cache_(get|set)|get_transient|set_transient" "$SRC_DIR" 2>/dev/null || true) | wc -l | tr -d ' ' )
+cache_score=$(( cache_cnt > 0 ? 15 : 0 ))
+PERF_SCORE=$(echo "$db_score + $cache_score" | bc)
+
+# ---------- Readability (25) ----------
+READABILITY_SCORE=20
+if [ -x "$phpcs_cmd" ]; then
+  sum_json="$ROOT/.phpcs-sum.json"
+  "$phpcs_cmd" -q --standard="$ROOT/phpcs.xml" --report=json > "$sum_json" || true
+  warn=$(jq -r '.totals.warnings // 0' "$sum_json" 2>/dev/null || echo 0)
+  # Map warnings to 25: 0→25, 1..5→22..18, 6..10→17..13, >10→12
+  if [ "$warn" -eq 0 ]; then READABILITY_SCORE=25
+  elif [ "$warn" -le 5 ]; then READABILITY_SCORE=$((25 - warn*1))
+  elif [ "$warn" -le 10 ]; then READABILITY_SCORE=$((20 - (warn-5)))
+  else READABILITY_SCORE=12; fi
 fi
 
-# Metadata (guard when git/php/jq are missing)
-BRANCH="unknown"; LAST_COMMIT="none"
-if have git; then
-  BRANCH="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)"
-  LAST_COMMIT="$(git log -1 --pretty='%h %s' 2>/dev/null || echo none)"
-fi
+# ---------- Goal Achievement (25 = 15 + 10) ----------
+req_score=0 integ_score=0
+[ -d "$SRC_DIR" ]   && [ "$(ls -A "$SRC_DIR" 2>/dev/null | wc -l)" -gt 0 ] && req_score=15
+[ -d "$TESTS_DIR" ] && [ "$(find "$TESTS_DIR" -name '*.php' | wc -l)" -gt 0 ] && integ_score=10
+GOAL_SCORE=$(echo "$req_score + $integ_score" | bc)
 
-PHP_VER="unknown"
-if have php; then
-  PHP_VER="$(php -r 'echo PHP_VERSION;' 2>/dev/null || echo unknown)"
-fi
+# ---------- Red Flags ----------
+flags=()
+grep -R "\$_POST\|\$_GET" "$SRC_DIR" 2>/dev/null | grep -v "sanitize_\|filter_input" >/dev/null 2>&1 && flags+=("Direct superglobal access (-10)")
+grep -R -E "[^p]query\s*\(" "$SRC_DIR" 2>/dev/null | grep -v "prepare\(" >/dev/null 2>&1 && flags+=("Raw SQL without prepare (-10)")
+rf_deduction=0
+for f in "${flags[@]:-}"; do rf_deduction=$((rf_deduction+10)); done
+TOTAL_SCORE_INT=$(printf "%0.f" "$(echo "$SECURITY_SCORE + $LOGIC_SCORE + $PERF_SCORE + $READABILITY_SCORE + $GOAL_SCORE - $rf_deduction" | bc)")
+TOTAL_SCORE_INT=$(score_part "$TOTAL_SCORE_INT" 125)
 
-UTC_NOW="$(date -u '+%Y-%m-%d %H:%M:%S UTC' 2>/dev/null || echo unknown)"
+# Weighted Average: (Sec×2 + Log×2 + Perf×1 + Read×1 + Goal×2) / 200
+weighted=$(echo "scale=2; ( ($SECURITY_SCORE*2)+($LOGIC_SCORE*2)+($PERF_SCORE)+($READABILITY_SCORE)+($GOAL_SCORE*2) ) / 200 * 100" | bc)
 
-# Build PROJECT_STATE.md deterministically
+# ---------- Update ai_context.json ----------
+if [ ! -f "$AI_CTX" ]; then echo '{"decisions":[]}' > "$AI_CTX"; fi
+tmp="$AI_CTX.tmp"
+jq --argjson sec "$SECURITY_SCORE" \
+   --argjson log "$LOGIC_SCORE" \
+   --argjson perf "$PERF_SCORE" \
+   --argjson read "$READABILITY_SCORE" \
+   --argjson goal "$GOAL_SCORE" \
+   --arg total "$TOTAL_SCORE_INT" \
+   --arg weighted "$weighted" \
+   --argjson flags "$(printf '%s\n' "${flags[@]:-}" | jq -R . | jq -s .)" \
+   '
+   .current_scores = {
+     security:$sec, logic:$log, performance:$perf, readability:$read, goal:$goal,
+     total: ($total|tonumber), weighted_percent: ($weighted|tonumber), red_flags: $flags
+   }' "$AI_CTX" > "$tmp" && mv "$tmp" "$AI_CTX"
+
+# ---------- Write FEATURES.md (summary block at top) ----------
 {
-  echo "# 📊 SmartAlloc Project State"
-  echo ""
-  echo "**Last Update (UTC):** ${UTC_NOW}"
-  echo "**Branch:** ${BRANCH}"
-  echo "**Last Commit:** ${LAST_COMMIT}"
-  echo "**PHP:** ${PHP_VER}${PHP_HINT:+ (hint: $PHP_HINT)}"
-  echo "**WordPress:** ${WP_HINT:-unknown}"
-  echo ""
-
-  echo "## 📌 Features Snapshot"
-  if [ -f "FEATURES.md" ]; then
-    # show only the first 20 lines to keep the file short
-    head -n 20 FEATURES.md || true
+  echo "# Feature Status Dashboard"
+  echo
+  perc=$(echo "$TOTAL_SCORE_INT*100/125" | bc)
+  echo "## 📊 Current Project Score: ${TOTAL_SCORE_INT}/125 (${perc}%)"
+  echo
+  echo "### **📊 Detailed Validation Score**"
+  printf "🔒 **Security Score**: %.2f/25\n" "$SECURITY_SCORE"
+  printf "🧠 **Logic Score**: %.2f/25\n"    "$LOGIC_SCORE"
+  printf "⚡ **Performance Score**: %.2f/25\n" "$PERF_SCORE"
+  printf "📖 **Readability Score**: %.2f/25\n" "$READABILITY_SCORE"
+  printf "🎯 **Goal Achievement**: %.2f/25\n"  "$GOAL_SCORE"
+  echo
+  echo "**🏆 Total Score**: ${TOTAL_SCORE_INT}/125"
+  printf "**📈 Weighted Average**: %.2f%%\n" "$weighted"
+  if [ "${#flags[@]}" -gt 0 ]; then
+    echo
+    echo "### ⛔ Red Flags:"
+    for f in "${flags[@]}"; do echo "- $f"; done
   else
-    echo "_FEATURES.md not available_"
+    echo
+    echo "### ✅ No Red Flags Detected"
   fi
-  echo ""
+  echo
+  echo "---"
+  echo "*Last updated: $(date -u +"%Y-%m-%d %H:%M UTC")*"
+} > "$FEATURES_MD"
 
-  echo "## 🤖 AI Context (decisions)"
-  if [ -f "ai_context.json" ]; then
-    if have jq; then
-      jq '.decisions | {count: (length), sample: .[0:5]}' ai_context.json || echo "_ai_context.json present (jq parse failed)_"
-    else
-      echo "_ai_context.json present (jq not installed)_"
-    fi
-  else
-    echo "_ai_context.json not available_"
-  fi
-  echo ""
-} > PROJECT_STATE.md
-
-echo "PROJECT_STATE.md generated."
+echo "✅ 5D scoring completed."


### PR DESCRIPTION
## Summary
- add `scripts/update_state.sh` for 5D scoring and red flag reporting
- expose composer script `score:5d`
- run scoring in CI, upload artifacts, and print enhanced summary
- document scoring workflow

## Testing
- `composer install`
- `composer score:5d`


------
https://chatgpt.com/codex/tasks/task_e_68adbd87fdf483218be13a4a473cb726