### PR TITLE
ci: bootstrap ai context and unify timestamps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,10 +68,11 @@ jobs:
           set -euo pipefail
           test -s ai_context.json || echo '{"decisions":[]}' > ai_context.json
           jq empty ai_context.json
+          ts=$(jq -r '.last_updated_utc // ""' ai_context.json)
           {
             echo '### Enhanced 5D Feature Scores'
             echo
-            echo '**Timestamp (UTC):**' "$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+            echo '**Timestamp (UTC):**' "$ts"
             echo
             echo '```json'
             jq -c '.current_scores // {}' ai_context.json || echo '{}'
@@ -161,10 +162,11 @@ jobs:
           set -euo pipefail
           test -s ai_context.json || echo '{"decisions":[]}' > ai_context.json
           jq empty ai_context.json
+          ts=$(jq -r '.last_updated_utc // ""' ai_context.json)
           {
             echo '### Enhanced 5D Feature Scores'
             echo
-            echo '**Timestamp (UTC):**' "$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+            echo '**Timestamp (UTC):**' "$ts"
             echo
             echo '```json'
             jq -c '.current_scores // {}' ai_context.json || echo '{}'

--- a/scripts/update_state.sh
+++ b/scripts/update_state.sh
@@ -10,14 +10,14 @@ AI_CTX="$ROOT/ai_context.json"
 phpcs_cmd="${PHPCS_CMD:-$ROOT/vendor/bin/phpcs}"
 UTC_NOW="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
 
-# Soft-fix coding style before scoring
-if [ -x "${ROOT}/vendor/bin/phpcbf" ]; then
-  "${ROOT}/vendor/bin/phpcbf" -q --standard="$ROOT/phpcs.xml" src || true
-fi
-
 if ! command -v jq >/dev/null 2>&1 || ! command -v bc >/dev/null 2>&1; then
   echo "Missing required tools: jq and bc. Please install them." >&2
   exit 2
+fi
+
+# Soft-fix coding style before scoring
+if [ -x "${ROOT}/vendor/bin/phpcbf" ]; then
+  "${ROOT}/vendor/bin/phpcbf" -q --standard="$ROOT/phpcs.xml" src || true
 fi
 
 score_part() { # clamp to 0..max


### PR DESCRIPTION
## Summary
- ensure update_state.sh checks jq/bc before running phpcbf
- draw workflow summary timestamp from ai_context.json for consistent UTC

## Testing
- `composer score:5d && composer test:smoke`


------
https://chatgpt.com/codex/tasks/task_e_68ae0cc2f2d08321a365053d2d033cbd