### PR TITLE
ci: add failure injection toggle and DRY summary scripts

### DIFF
--- a/.github/scripts/emit_autofix.sh
+++ b/.github/scripts/emit_autofix.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+test -s ai_context.json || echo '{"decisions":[]}' > ai_context.json
+jq empty ai_context.json
+if jq -e '.ci_failure' ai_context.json >/dev/null 2>&1; then
+  SEC="$(jq -r '.ci_failure.security_score // "?"' ai_context.json)"
+  PHPCS="$(jq -r '.ci_failure.phpcs_errors // "?"' ai_context.json)"
+  TESTS="$(jq -r '.ci_failure.test_failures // "?"' ai_context.json)"
+  {
+    echo '```'
+    echo '🚨 CI Failure Detected'
+    echo "🔍 مشکل: امنیت پایین (${SEC}/25) + ${TESTS} تست شکست"
+    echo '💡 پرامپت تولیدشده برای Codex:'
+    echo
+    echo '[AUTO-FIX REQUEST]'
+    echo 'بر اساس خطاهای CI زیر، یک راه‌حل فوری ارائه بده:'
+    echo
+    echo "🔒 امنیت: ${SEC}/25"
+    echo "⚠️ خطاهای PHPCS: ${PHPCS}"
+    echo "🧪 تست‌های شکست‌خورده: ${TESTS}"
+    echo
+    echo '[RULES FOR CODEX]'
+    echo 'فقط یک گزینه ارائه بده (نه ۴ گزینه)'
+    echo 'حتماً بر روی رفع خطاهای بالا تمرکز کن'
+    echo 'خروجی حتماً شامل این موارد باشد:'
+    echo '• 📊 5D Score با امتیاز امنیت ≥ 20/25'
+    echo '• ✅ تست‌های شکست‌خورده پاس شوند'
+    echo '• 📦 Patchset با diff کمینه'
+    echo '• 📌 دستور پوش آماده (git push origin fix/...)'
+    echo '```'
+  } >> "$GITHUB_STEP_SUMMARY"
+fi

--- a/.github/scripts/emit_summary.sh
+++ b/.github/scripts/emit_summary.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+test -s ai_context.json || echo '{"decisions":[]}' > ai_context.json
+jq empty ai_context.json
+ts="$(jq -r '.last_updated_utc // ""' ai_context.json)"
+{
+  echo '### Enhanced 5D Feature Scores'
+  echo
+  echo '**Timestamp (UTC):**' "$ts"
+  echo
+  echo '```json'
+  jq -c '.current_scores // {}' ai_context.json || echo '{}'
+  echo '```'
+} >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,11 @@ on:
       - 'src/**'
       - 'tests/**'
   workflow_dispatch:
+    inputs:
+      inject_ci_failure:
+        description: "Inject dummy ci_failure for AUTO-FIX test"
+        type: boolean
+        default: false
   schedule:
     - cron: '0 6 * * 0'
 
@@ -61,58 +66,15 @@ jobs:
         run: composer phpcbf || true
       - name: 📊 5D Score
         run: composer score:5d
-      - name: 📝 Append 5D Summary
+      - name: 📝 Append 5D Summary & AUTO-FIX
         if: always()
         run: |
-          set -euo pipefail
-          test -s ai_context.json || echo '{"decisions":[]}' > ai_context.json
-          jq empty ai_context.json
-          ts=$(jq -r '.last_updated_utc // ""' ai_context.json)
-          {
-            echo '### Enhanced 5D Feature Scores'
-            echo
-            echo '**Timestamp (UTC):**' "$ts"
-            echo
-            echo '```json'
-            jq -c '.current_scores // {}' ai_context.json || echo '{}'
-            echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
-      - name: 🚨 AUTO-FIX Prompt (if ci_failure)
-        if: always()
-        run: |
-          set -euo pipefail
-          test -s ai_context.json || echo '{"decisions":[]}' > ai_context.json
-          jq empty ai_context.json
-          if jq -e '.ci_failure' ai_context.json >/dev/null 2>&1; then
-            SEC=$(jq -r '.ci_failure.security_score // "?"' ai_context.json)
-            PHPCS=$(jq -r '.ci_failure.phpcs_errors // "?"' ai_context.json)
-            TESTS=$(jq -r '.ci_failure.test_failures // "?"' ai_context.json)
-            {
-              echo '```'
-              echo '🚨 CI Failure Detected'
-              echo "🔍 مشکل: امنیت پایین (${SEC}/25) + ${TESTS} تست شکست"
-              echo '💡 پرامپت تولیدشده برای Codex:'
-              echo
-              echo '[AUTO-FIX REQUEST]'
-              echo 'بر اساس خطاهای CI زیر، یک راه‌حل فوری ارائه بده:'
-              echo
-              echo "🔒 امنیت: ${SEC}/25"
-              echo
-              echo "⚠️ خطاهای PHPCS: ${PHPCS}"
-              echo
-              echo "🧪 تست‌های شکست‌خورده: ${TESTS}"
-              echo
-              echo '[RULES FOR CODEX]'
-              echo 'فقط یک گزینه ارائه بده (نه ۴ گزینه)'
-              echo 'حتماً بر روی رفع خطاهای بالا تمرکز کن'
-              echo 'خروجی حتماً شامل این موارد باشد:'
-              echo '• 📊 5D Score با امتیاز امنیت ≥ 20/25'
-              echo '• ✅ تست‌های شکست‌خورده پاس شوند'
-              echo '• 📦 Patchset با diff کمینه'
-              echo '• 📌 دستور پوش آماده (git push origin fix/...)'
-              echo '```'
-            } >> "$GITHUB_STEP_SUMMARY"
+          chmod +x .github/scripts/emit_summary.sh .github/scripts/emit_autofix.sh
+          if [ "${{ inputs.inject_ci_failure }}" = "true" ]; then
+            echo '{"ci_failure":{"security_score":15,"phpcs_errors":2,"test_failures":1}}' > ai_context.json
           fi
+          .github/scripts/emit_summary.sh
+          .github/scripts/emit_autofix.sh
       - name: 📤 Upload Enhanced Artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -153,58 +115,15 @@ jobs:
         run: composer phpcbf || true
       - name: 📊 5D Score
         run: composer score:5d
-      - name: 📝 Append 5D Summary
+      - name: 📝 Append 5D Summary & AUTO-FIX
         if: always()
         run: |
-          set -euo pipefail
-          test -s ai_context.json || echo '{"decisions":[]}' > ai_context.json
-          jq empty ai_context.json
-          ts=$(jq -r '.last_updated_utc // ""' ai_context.json)
-          {
-            echo '### Enhanced 5D Feature Scores'
-            echo
-            echo '**Timestamp (UTC):**' "$ts"
-            echo
-            echo '```json'
-            jq -c '.current_scores // {}' ai_context.json || echo '{}'
-            echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
-      - name: 🚨 AUTO-FIX Prompt (if ci_failure)
-        if: always()
-        run: |
-          set -euo pipefail
-          test -s ai_context.json || echo '{"decisions":[]}' > ai_context.json
-          jq empty ai_context.json
-          if jq -e '.ci_failure' ai_context.json >/dev/null 2>&1; then
-            SEC=$(jq -r '.ci_failure.security_score // "?"' ai_context.json)
-            PHPCS=$(jq -r '.ci_failure.phpcs_errors // "?"' ai_context.json)
-            TESTS=$(jq -r '.ci_failure.test_failures // "?"' ai_context.json)
-            {
-              echo '```'
-              echo '🚨 CI Failure Detected'
-              echo "🔍 مشکل: امنیت پایین (${SEC}/25) + ${TESTS} تست شکست"
-              echo '💡 پرامپت تولیدشده برای Codex:'
-              echo
-              echo '[AUTO-FIX REQUEST]'
-              echo 'بر اساس خطاهای CI زیر، یک راه‌حل فوری ارائه بده:'
-              echo
-              echo "🔒 امنیت: ${SEC}/25"
-              echo
-              echo "⚠️ خطاهای PHPCS: ${PHPCS}"
-              echo
-              echo "🧪 تست‌های شکست‌خورده: ${TESTS}"
-              echo
-              echo '[RULES FOR CODEX]'
-              echo 'فقط یک گزینه ارائه بده (نه ۴ گزینه)'
-              echo 'حتماً بر روی رفع خطاهای بالا تمرکز کن'
-              echo 'خروجی حتماً شامل این موارد باشد:'
-              echo '• 📊 5D Score با امتیاز امنیت ≥ 20/25'
-              echo '• ✅ تست‌های شکست‌خورده پاس شوند'
-              echo '• 📦 Patchset با diff کمینه'
-              echo '• 📌 دستور پوش آماده (git push origin fix/...)'
-              echo '```'
-            } >> "$GITHUB_STEP_SUMMARY"
+          chmod +x .github/scripts/emit_summary.sh .github/scripts/emit_autofix.sh
+          if [ "${{ inputs.inject_ci_failure }}" = "true" ]; then
+            echo '{"ci_failure":{"security_score":15,"phpcs_errors":2,"test_failures":1}}' > ai_context.json
           fi
+          .github/scripts/emit_summary.sh
+          .github/scripts/emit_autofix.sh
       - name: 📤 Upload Enhanced Artifacts
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- allow manually injecting dummy ci_failure via workflow_dispatch input
- centralize summary and AUTO-FIX steps through reusable scripts

## Testing
- `composer score:5d`
- `composer test:smoke`


------
https://chatgpt.com/codex/tasks/task_e_68ae2322b8d0832190b6c31231fd1bc3