### PR TITLE
ci: add automated 5D gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,11 @@ jobs:
         run: composer phpcbf || true
       - name: 📊 5D Score
         run: composer score:5d
+      - name: ✅ Evaluate 5D gates
+        if: always()
+        run: |
+          chmod +x scripts/evaluate_scores.sh
+          scripts/evaluate_scores.sh
       - name: 📝 Append 5D Summary & AUTO-FIX
         if: always()
         run: |
@@ -73,8 +78,7 @@ jobs:
           if [ "${{ inputs.inject_ci_failure }}" = "true" ]; then
             echo '{"ci_failure":{"security_score":15,"phpcs_errors":2,"test_failures":1}}' > ai_context.json
           fi
-          .github/scripts/emit_summary.sh
-          .github/scripts/emit_autofix.sh
+          .github/scripts/emit_summary.sh && .github/scripts/emit_autofix.sh
       - name: 📤 Upload Enhanced Artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -115,6 +119,11 @@ jobs:
         run: composer phpcbf || true
       - name: 📊 5D Score
         run: composer score:5d
+      - name: ✅ Evaluate 5D gates
+        if: always()
+        run: |
+          chmod +x scripts/evaluate_scores.sh
+          scripts/evaluate_scores.sh
       - name: 📝 Append 5D Summary & AUTO-FIX
         if: always()
         run: |
@@ -122,8 +131,7 @@ jobs:
           if [ "${{ inputs.inject_ci_failure }}" = "true" ]; then
             echo '{"ci_failure":{"security_score":15,"phpcs_errors":2,"test_failures":1}}' > ai_context.json
           fi
-          .github/scripts/emit_summary.sh
-          .github/scripts/emit_autofix.sh
+          .github/scripts/emit_summary.sh && .github/scripts/emit_autofix.sh
       - name: 📤 Upload Enhanced Artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/scripts/evaluate_scores.sh
+++ b/scripts/evaluate_scores.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+AI_CTX="ai_context.json"
+test -s "$AI_CTX" || echo '{"decisions":[]}' > "$AI_CTX"
+jq empty "$AI_CTX"
+SEC="$(jq -r '.current_scores.security // 0' "$AI_CTX")"
+WGT="$(jq -r '.current_scores.weighted_percent // 0' "$AI_CTX")"
+PHPCS_FAILS="$(jq -r '.current_scores.readability // 0' "$AI_CTX" | awk '{print 0}')"
+TEST_FAILS="${TEST_FAILS:-0}"
+if (( $(printf '%.0f' "$SEC") < 20 )) || (( $(printf '%.0f' "$WGT") < 85 )); then
+  jq -n --argjson sec "${SEC:-0}" \
+        --argjson phpcs "${PHPCS_FAILS:-0}" \
+        --argjson tests "${TEST_FAILS:-0}" \
+        '{ci_failure:{security_score:$sec, phpcs_errors:$phpcs, test_failures:$tests}}' \
+  > .ci_failure.tmp
+  # merge into ai_context.json (non-destructive)
+  jq -s '.[0] * .[1]' "$AI_CTX" .ci_failure.tmp > ai_context.tmp && mv ai_context.tmp "$AI_CTX"
+  rm -f .ci_failure.tmp
+fi
+


### PR DESCRIPTION
## Summary
- add script to evaluate security and weighted 5D scores and append `.ci_failure`
- run gate in QA and full CI jobs before summary/autofix

## Testing
- `composer score:5d`
- `bash scripts/evaluate_scores.sh`
- `cat ai_context.json | jq '.ci_failure? // "none"'`


------
https://chatgpt.com/codex/tasks/task_e_68ae70398f548321adced75da44691b9