### PR TITLE
ci: enforce 5D gates in full job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,11 @@ jobs:
             echo '{"ci_failure":{"security_score":15,"phpcs_errors":2,"test_failures":1}}' > ai_context.json
           fi
           .github/scripts/emit_summary.sh && .github/scripts/emit_autofix.sh
+      - name: ❌ Enforce 5D gates (full only)
+        if: always()
+        run: |
+          chmod +x scripts/fail_on_ci_failure.sh
+          scripts/fail_on_ci_failure.sh
       - name: 📤 Upload Enhanced Artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/scripts/fail_on_ci_failure.sh
+++ b/scripts/fail_on_ci_failure.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+AI_CTX="ai_context.json"
+# ensure AI_CTX exists with default structure
+if ! test -s "$AI_CTX"; then
+  echo '{"decisions":[]}' > "$AI_CTX"
+fi
+# if ci_failure key not present, exit successfully
+if ! jq -e '.ci_failure' "$AI_CTX" >/dev/null 2>&1; then
+  exit 0
+fi
+SEC="$(jq -r '.ci_failure.security_score // "?"' "$AI_CTX")"
+PHPCS="$(jq -r '.ci_failure.phpcs_errors // "?"' "$AI_CTX")"
+TESTS="$(jq -r '.ci_failure.test_failures // "?"' "$AI_CTX")"
+echo "::error title=5D Gate Failed::security=${SEC}/25 phpcs=${PHPCS} tests=${TESTS}"
+exit 1


### PR DESCRIPTION
## Summary
- add fail_on_ci_failure.sh to exit with error when 5D gate fails
- run fail_on_ci_failure.sh in full CI job only to enforce 5D gates

## Testing
- `bash scripts/fail_on_ci_failure.sh && echo "pass"`
- `jq '.current_scores.security=15' ai_context.json > t && mv t ai_context.json && bash scripts/evaluate_scores.sh && bash scripts/fail_on_ci_failure.sh && echo "should not see" || echo "failed as expected"`


------
https://chatgpt.com/codex/tasks/task_e_68ae728cf1748321909e0abef2b275f6