### PR TITLE
docs: document GH CLI authentication for workflow dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,10 @@ concurrency:
   cancel-in-progress: true
 permissions:
   contents: read
+  actions: write
+
+env:
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   qa:

--- a/README.md
+++ b/README.md
@@ -432,3 +432,8 @@ ai_context.json: ADR-derived AI context
 
 PROJECT_STATE.md: snapshot summary (CI also uploads as artifact)
 
+## GitHub CLI CI dispatch
+
+To run SmartAlloc's CI jobs from your terminal, generate a Personal Access Token with **repo** and **workflow** scopes and
+authenticate the GitHub CLI. Detailed steps and a helper script are provided in [docs/GH_CLI_AUTH.md](docs/GH_CLI_AUTH.md).
+

--- a/docs/GH_CLI_AUTH.md
+++ b/docs/GH_CLI_AUTH.md
@@ -1,0 +1,48 @@
+# GH CLI AUTH
+
+This guide explains how to trigger SmartAlloc CI workflow runs via the GitHub CLI.
+
+## Create a Personal Access Token
+
+1. Visit https://github.com/settings/tokens and generate a token.
+2. Select **repo** and **workflow** scopes.
+3. Copy the token value.
+
+## Authenticate the GitHub CLI
+
+Export the token as `GH_TOKEN`:
+
+```bash
+export GH_TOKEN=YOUR_TOKEN
+```
+
+Or log in with the token:
+
+```bash
+printf '%s\n' "$GH_TOKEN" | gh auth login --with-token
+```
+
+Verify access:
+
+```bash
+gh auth status --show-token
+```
+
+## Dispatch the CI workflow
+
+After authentication you can trigger jobs:
+
+```bash
+gh workflow run ci.yml -f job=qa --repo rezahh107/SmartAlloc --json runNumber -q '.runNumber'
+```
+
+Replace `qa` with `full` to run the full job.
+
+## Script example
+
+The repository includes `scripts/gh-workflow-run-example.sh` which dispatches a job and prints the run number:
+
+```bash
+./scripts/gh-workflow-run-example.sh qa
+```
+

--- a/scripts/gh-workflow-run-example.sh
+++ b/scripts/gh-workflow-run-example.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+job="${1:-qa}"
+
+if [ -z "${GH_TOKEN:-}" ]; then
+  echo "GH_TOKEN is required" >&2
+  exit 1
+fi
+
+if ! gh auth status >/dev/null 2>&1; then
+  printf '%s\n' "$GH_TOKEN" | gh auth login --with-token >/dev/null 2>&1
+fi
+
+run_number=$(gh workflow run ci.yml -f job="$job" --repo rezahh107/SmartAlloc --json runNumber -q '.runNumber')
+
+echo "Triggered run #${run_number}"


### PR DESCRIPTION
## Summary
- allow gh to reuse `secrets.GITHUB_TOKEN` by exposing it as `GH_TOKEN` with actions write permission
- document creating a PAT and logging in for CLI-based workflow dispatch
- add helper script to trigger qa/full jobs and print the run number

## Testing
- `php scripts/coverage-import.php`
- `php scripts/artifact-schema-validate.php`
- `php scripts/ga-enforcer.php --profile=rc --junit`


------
https://chatgpt.com/codex/tasks/task_e_68ae769c22dc8321a612359a27f1e1c9