### PR TITLE
Integrate PHPCS metrics into 5D scoring

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1,18 +1,18 @@
 # Feature Status Dashboard
 
-## 📊 Current Project Score: 110/125 (88%)
+## 📊 Current Project Score: 102/125 (81%)
 
 ### **📊 Detailed Validation Score**
 🔒 **Security Score**: 25.00/25
 🧠 **Logic Score**: 25.00/25
 ⚡ **Performance Score**: 25.00/25
-📖 **Readability Score**: 20.00/25
+📖 **Readability Score**: 12.00/25
 🎯 **Goal Achievement**: 25.00/25
 
-**🏆 Total Score**: 110/125
-**📈 Weighted Average**: 97.00%
+**🏆 Total Score**: 102/125
+**📈 Weighted Average**: 93.00%
 
 ### ✅ No Red Flags Detected
 
 ---
-Last Updated (UTC): 2025-08-27T06:22:27Z
+Last Updated (UTC): 2025-08-27T06:38:55Z

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,5 +1,5 @@
 {
-  "last_updated_utc": "2025-08-27T06:22:27Z",
+  "last_updated_utc": "2025-08-27T06:38:55Z",
   "decisions": [
     {
       "file": "docs/architecture/decisions/20250825_choose-database-library.md",
@@ -28,10 +28,13 @@
     "security": 25.00,
     "logic": 25,
     "performance": 25,
-    "readability": 20,
+    "readability": 12,
     "goal": 25,
-    "total": 110,
-    "weighted_percent": 97.00,
-    "red_flags": []
-  }
+    "total": 102,
+    "weighted_percent": 93.00,
+    "red_flags": [
+      ""
+    ]
+  },
+  "phpcs_errors": 51432
 }

--- a/composer.json
+++ b/composer.json
@@ -41,11 +41,12 @@
     }
   },
   "scripts": {
-    "score:5d": "bash scripts/update_state.sh",
+    "score:5d": ["@phpcbf", "bash scripts/update_state.sh"],
     "state": "php scripts/generate_features_md.php && php scripts/ai_context_sync.php && bash scripts/update_state.sh",
     "cs": "vendor/bin/phpcs -q --standard=phpcs.xml",
     "lint:php": "php -l $(git ls-files '*.php')",
-    "phpcs": "vendor/bin/phpcs -q --standard=phpcs.xml",
+    "phpcs": "vendor/bin/phpcs --standard=WordPress --extensions=php src tests",
+    "phpcbf": "vendor/bin/phpcbf --standard=WordPress --extensions=php src tests",
     "psalm": "vendor/bin/psalm --no-progress",
     "psalm:taint": "vendor/bin/psalm --taint-analysis",
     "test": "vendor/bin/phpunit --testsuite Unit,WordPress,VIP,Integration",

--- a/scripts/update_state.sh
+++ b/scripts/update_state.sh
@@ -15,11 +15,6 @@ if ! command -v jq >/dev/null 2>&1 || ! command -v bc >/dev/null 2>&1; then
   exit 2
 fi
 
-# Soft-fix coding style before scoring
-if [ -x "${ROOT}/vendor/bin/phpcbf" ]; then
-  "${ROOT}/vendor/bin/phpcbf" -q --standard="$ROOT/phpcs.xml" src || true
-fi
-
 score_part() { # clamp to 0..max
   local v="$1" max="$2"
   if [ "$v" -lt 0 ]; then echo 0


### PR DESCRIPTION
## Summary
- measure PHPCS errors during evaluation and store result in `ai_context.json`
- wire up composer scripts for `phpcs` and `phpcbf` and invoke fixer before scoring
- simplify score update script after moving auto-fix to composer

## Testing
- `vendor/bin/phpcbf --standard=WordPress --extensions=php src tests --parallel=8`
- `bash scripts/update_state.sh`
- `bash scripts/evaluate_scores.sh`
- `composer test` *(fails: execution terminated due to time constraints)*


------
https://chatgpt.com/codex/tasks/task_e_68aea69b82448321974e66f7d9a14863