### PR TITLE
Add script to dispatch CI workflows via GitHub CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,3 +457,9 @@ This stores your decision with a UTC timestamp in ai_context.json.
 To run SmartAlloc's CI jobs from your terminal, generate a Personal Access Token with **repo** and **workflow** scopes and
 authenticate the GitHub CLI. Detailed steps and a helper script are provided in [docs/GH_CLI_AUTH.md](docs/GH_CLI_AUTH.md).
 
+Example:
+
+```bash
+GH_TOKEN=yourtoken bash scripts/run_ci_dispatch.sh
+```
+

--- a/scripts/run_ci_dispatch.sh
+++ b/scripts/run_ci_dispatch.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "GitHub CLI (gh) is required" >&2
+  exit 1
+fi
+
+if [ -z "${GH_TOKEN:-}" ]; then
+  echo "GH_TOKEN is required" >&2
+  exit 1
+fi
+
+if ! gh auth status >/dev/null 2>&1; then
+  printf '%s\n' "$GH_TOKEN" | gh auth login --with-token >/dev/null 2>&1
+fi
+
+run_ci() {
+  local job=$1
+  shift || true
+  local info
+  info=$(gh workflow run ci.yml -f job="$job" "$@" --json runNumber,url -q '.')
+  local number url
+  number=$(jq -r '.runNumber' <<<"$info")
+  url=$(jq -r '.url' <<<"$info")
+  echo "$job run: #$number $url"
+}
+
+run_ci qa
+run_ci full -f inject_ci_failure=true


### PR DESCRIPTION
## Summary
- add `run_ci_dispatch.sh` to trigger qa and full CI workflows using GH_TOKEN
- document CLI usage in README

## Testing
- `composer test`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aec682e2a08321bf9a58568f6cbf44