### PR TITLE
Add PowerShell script to dispatch CI workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,9 +457,14 @@ This stores your decision with a UTC timestamp in ai_context.json.
 To run SmartAlloc's CI jobs from your terminal, generate a Personal Access Token with **repo** and **workflow** scopes and
 authenticate the GitHub CLI. Detailed steps and a helper script are provided in [docs/GH_CLI_AUTH.md](docs/GH_CLI_AUTH.md).
 
-Example:
+Examples:
 
 ```bash
 GH_TOKEN=yourtoken bash scripts/run_ci_dispatch.sh
+```
+
+```powershell
+$env:GH_TOKEN="ghp_xxx"
+.\run_ci_dispatch.ps1
 ```
 

--- a/run_ci_dispatch.ps1
+++ b/run_ci_dispatch.ps1
@@ -1,0 +1,36 @@
+$ErrorActionPreference = 'Stop'
+
+if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
+    Write-Error 'GitHub CLI (gh) is required'
+    exit 1
+}
+
+if (-not $env:GH_TOKEN) {
+    Write-Error 'GH_TOKEN is required'
+    exit 1
+}
+
+try {
+    gh auth status *> $null
+} catch {
+    $LASTEXITCODE = 1
+}
+
+if ($LASTEXITCODE -ne 0) {
+    Write-Output $env:GH_TOKEN | gh auth login --with-token *> $null
+}
+
+function Run-CI {
+    param(
+        [Parameter(Mandatory=$true)][string]$Job,
+        [string[]]$ExtraArgs
+    )
+    $args = @('workflow','run','ci.yml','-f',"job=$Job")
+    if ($ExtraArgs) { $args += $ExtraArgs }
+    $args += @('--repo','rezahh107/SmartAlloc','--json','runNumber,url','-q','.')
+    $info = gh @args | ConvertFrom-Json
+    Write-Output "$Job run: #$($info.runNumber) $($info.url)"
+}
+
+Run-CI -Job 'qa'
+Run-CI -Job 'full' -ExtraArgs @('-f','inject_ci_failure=true')


### PR DESCRIPTION
## Summary
- add run_ci_dispatch.ps1 to trigger qa and full workflows via GitHub CLI
- document PowerShell usage example in README

## Testing
- `npm test`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68aeca6b09c88321b1acb2f28b943693