### PR TITLE
Add Tech Spec and Test Plan generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Codex prompt helpers (prepare_codex_prompt.sh, record_feedback.sh)
 - PowerShell dispatch script (run_ci_dispatch.ps1) with GH CLI integration
 - Documentation updates: Session Continuation Protocol, Codex handoff, CI Dispatch usage
+- Tech Spec/Test Plan generator with Codex prompt extraction
 
 ### Changed
 - CI workflow (.github/workflows/ci.yml) hardened with enforce gates and unique artifact names

--- a/scripts/generate_tech_spec.sh
+++ b/scripts/generate_tech_spec.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# scripts/generate_tech_spec.sh - build Tech Spec, Test Plan and Codex Prompt from ai_context.json
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+AI_CTX="$ROOT_DIR/ai_context.json"
+OUT_DIR="$ROOT_DIR/ai_outputs"
+OUT_FILE="$OUT_DIR/tech_spec.md"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "Error: jq is required" >&2
+  exit 1
+fi
+
+if [ ! -f "$AI_CTX" ]; then
+  echo "Error: ai_context.json not found" >&2
+  exit 1
+fi
+
+mkdir -p "$OUT_DIR"
+
+TECH_SPEC=$(jq -r '.tech_spec // ""' "$AI_CTX")
+TEST_PLAN=$(jq -r '.test_plan // ""' "$AI_CTX")
+TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+{
+  echo "<!-- Generated $TIMESTAMP -->"
+  echo "## 📐 TECH SPEC"
+  echo "$TECH_SPEC"
+  echo
+  echo "## 🧪 TEST PLAN"
+  echo "$TEST_PLAN"
+  echo
+  echo "## 📌 CODEX PROMPT"
+  echo "TECH SPEC:"; echo "$TECH_SPEC"; echo
+  echo "TEST PLAN:"; echo "$TEST_PLAN"
+} > "$OUT_FILE"
+
+printf 'Tech spec written to %s\n' "$OUT_FILE"

--- a/scripts/prepare_codex_prompt.sh
+++ b/scripts/prepare_codex_prompt.sh
@@ -15,11 +15,14 @@ if [ ! -f "$AI_CTX" ]; then
   exit 1
 fi
 
-# Extract current scores
-read -r SECURITY LOGIC PERFORMANCE READABILITY GOAL TOTAL WEIGHTED <<<"$(jq -r '.current_scores | [.security, .logic, .performance, .readability, .goal, .total, .weighted_percent] | @tsv' "$AI_CTX")"
+# Generate Tech Spec, Test Plan and Codex Prompt artifact first
+"$ROOT_DIR/scripts/generate_tech_spec.sh"
+
+# Extract current scores (defaults to empty if not present)
+read -r SECURITY LOGIC PERFORMANCE READABILITY GOAL TOTAL WEIGHTED <<<"$(jq -r '.current_scores // {} | [.security, .logic, .performance, .readability, .goal, .total, .weighted_percent] | map(. // "") | @tsv' "$AI_CTX")"
 
 # Extract red flags
-RED_FLAGS=$(jq -r '.current_scores.red_flags[] | select(length>0)' "$AI_CTX" || true)
+RED_FLAGS=$(jq -r '.current_scores.red_flags?[]? | select(length>0)' "$AI_CTX" 2>/dev/null || true)
 
 # Latest decision
 DECISION_TITLE=$(jq -r '.decisions | last | .title' "$AI_CTX")
@@ -27,8 +30,8 @@ DECISION_DATE=$(jq -r '.decisions | last | (.date // "N/A")' "$AI_CTX")
 DECISION_FILE=$(jq -r '.decisions | last | .file' "$AI_CTX")
 
 # Next feature suggestion based on lowest score or red flags
-LOWEST_KEY=$(jq -r '.current_scores | {security,logic,performance,readability,goal} | to_entries | sort_by(.value) | .[0].key' "$AI_CTX")
-LOWEST_VAL=$(jq -r --arg k "$LOWEST_KEY" '.current_scores[$k]' "$AI_CTX")
+LOWEST_KEY=$(jq -r '.current_scores // {} | {security,logic,performance,readability,goal} | to_entries | sort_by(.value) | .[0].key // ""' "$AI_CTX")
+LOWEST_VAL=$(jq -r --arg k "$LOWEST_KEY" '.current_scores[$k]' "$AI_CTX" 2>/dev/null || true)
 SUGGESTION="Focus on improving ${LOWEST_KEY} (current ${LOWEST_VAL})."
 FIRST_FLAG=$(echo "$RED_FLAGS" | head -n1)
 if [ -n "${FIRST_FLAG:-}" ]; then
@@ -62,4 +65,14 @@ fi
   echo
   echo "## Next Feature Suggestion"
   echo "$SUGGESTION"
-} 
+}
+
+# Extract final Codex Prompt section into codex_prompt.txt
+TECH_SPEC_MD="$ROOT_DIR/ai_outputs/tech_spec.md"
+CODEX_OUT="$ROOT_DIR/codex_prompt.txt"
+if [ -f "$TECH_SPEC_MD" ]; then
+  awk '/^## 📌 CODEX PROMPT/{flag=1;next}/^## /{flag=0}flag' "$TECH_SPEC_MD" > "$CODEX_OUT"
+  printf 'Codex prompt written to %s\n' "$CODEX_OUT"
+else
+  echo "Warning: $TECH_SPEC_MD not found" >&2
+fi


### PR DESCRIPTION
## Summary
- add `generate_tech_spec.sh` to build Tech Spec, Test Plan, and Codex Prompt artifacts
- extend `prepare_codex_prompt.sh` to invoke the generator, handle missing fields, and write `codex_prompt.txt`
- document the new Tech Spec/Test Plan generator in the changelog

## Testing
- `bash scripts/prepare_codex_prompt.sh`
- `cat codex_prompt.txt`


------
https://chatgpt.com/codex/tasks/task_e_68aedc941b4c83218b9bef9f7764e22b