### PR TITLE
Ensure memory files enforce RAG table and changelog sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,10 @@ Added a comprehensive log entry capturing completion of the CI Hardening & Dispa
 ### Changed
 - Updated memory files with latest project status.
 
-### Security/Quality
+### Security
+- 5D CI gate enforces security checks.
+
+### Quality
 - 5D CI gate ensures baseline quality.
 
 ### Housekeeping

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1,4 +1,5 @@
-<!-- AUTO-GEN:FEATURES START -->
+
+<!-- AUTO-GEN:RAG START -->
 # Feature Status Dashboard
 
 | Feature | Status | Notes |
@@ -16,4 +17,4 @@
 | CI/CD | 🟢 Green | 5D gate with AUTO-FIX loop |
 
 _Last Updated (UTC): 2025-08-27_
-<!-- AUTO-GEN:FEATURES END -->
+<!-- AUTO-GEN:RAG END -->

--- a/scripts/sync_memory_files.sh
+++ b/scripts/sync_memory_files.sh
@@ -100,8 +100,8 @@ EOF2
 )
 write_file ai_context.json "$AI_CONTEXT"
 
-FEATURES_CONTENT=$(cat <<EOF2
-<!-- AUTO-GEN:FEATURES START -->
+RAG_BLOCK=$(cat <<EOF2
+<!-- AUTO-GEN:RAG START -->
 # Feature Status Dashboard
 
 | Feature | Status | Notes |
@@ -119,10 +119,13 @@ FEATURES_CONTENT=$(cat <<EOF2
 | CI/CD | 🟢 Green | 5D gate with AUTO-FIX loop |
 
 _Last Updated (UTC): ${TODAY}_
-<!-- AUTO-GEN:FEATURES END -->
+<!-- AUTO-GEN:RAG END -->
 EOF2
 )
-write_file FEATURES.md "$FEATURES_CONTENT"
+if [ -f FEATURES.md ]; then
+  sed -e '/<!-- AUTO-GEN:FEATURES START -->/,/<!-- AUTO-GEN:FEATURES END -->/d' FEATURES.md > FEATURES.md.tmp && mv FEATURES.md.tmp FEATURES.md
+fi
+replace_block FEATURES.md "<!-- AUTO-GEN:RAG START -->" "<!-- AUTO-GEN:RAG END -->" "$RAG_BLOCK"
 
 STATE_BLOCK=$(cat <<EOF2
 <!-- AUTO-GEN:STATE START -->
@@ -218,7 +221,10 @@ CHANGELOG_BLOCK=$(cat <<EOF2
 ### Changed
 - Updated memory files with latest project status.
 
-### Security/Quality
+### Security
+- 5D CI gate enforces security checks.
+
+### Quality
 - 5D CI gate ensures baseline quality.
 
 ### Housekeeping

--- a/scripts/validate_memory_files.sh
+++ b/scripts/validate_memory_files.sh
@@ -138,7 +138,7 @@ fi
 # Validate FEATURES.md
 if [ -f FEATURES.md ]; then
   ok=1
-  grep -q '<!-- AUTO-GEN:FEATURES START -->' FEATURES.md && grep -q '<!-- AUTO-GEN:FEATURES END -->' FEATURES.md || ok=0
+  grep -q '<!-- AUTO-GEN:RAG START -->' FEATURES.md && grep -q '<!-- AUTO-GEN:RAG END -->' FEATURES.md || ok=0
   for row in "DB Safety" "Logging" "Exporter" "Gravity Forms" "Allocation Core" "Rule Engine" "Notifications" "Circuit Breaker" "Observability" "Performance Budgets" "CI/CD"; do
     grep -q "$row" FEATURES.md || { ok=0; break; }
   done
@@ -171,7 +171,14 @@ fi
 
 # Validate CHANGELOG.md
 if [ -f CHANGELOG.md ]; then
-  if grep -q '<!-- AUTO-GEN:CHANGELOG START -->' CHANGELOG.md && grep -q '<!-- AUTO-GEN:CHANGELOG END -->' CHANGELOG.md && grep -q '\[Unreleased\]' CHANGELOG.md && grep -q '### Added' CHANGELOG.md && grep -q '### Changed' CHANGELOG.md && grep -q '### Security/Quality' CHANGELOG.md && grep -q '### Housekeeping' CHANGELOG.md; then
+  if grep -q '<!-- AUTO-GEN:CHANGELOG START -->' CHANGELOG.md \
+    && grep -q '<!-- AUTO-GEN:CHANGELOG END -->' CHANGELOG.md \
+    && grep -q '\[Unreleased\]' CHANGELOG.md \
+    && grep -q '### Added' CHANGELOG.md \
+    && grep -q '### Changed' CHANGELOG.md \
+    && grep -q '### Security' CHANGELOG.md \
+    && grep -q '### Quality' CHANGELOG.md \
+    && grep -q '### Housekeeping' CHANGELOG.md; then
     pass "CHANGELOG.md"
   else
     fail "CHANGELOG.md" "markers or sections missing"


### PR DESCRIPTION
## Summary
- keep FEATURES.md resilient by regenerating required RAG table markers
- auto-create `[Unreleased]` with Added/Changed/Security/Quality/Housekeeping sections
- update validation to guard new markers and sections

## Testing
- `bash scripts/validate_memory_files.sh`


------
https://chatgpt.com/codex/tasks/task_e_68af4bceb2848321a3f8752d3095b965