### PR TITLE
feat(allocation): add allocation engine scaffold and migration

### DIFF
--- a/ai_outputs/last_state.yml
+++ b/ai_outputs/last_state.yml
@@ -1,0 +1,12 @@
+timestamp: 2025-08-28T21:14:00Z
+feature: allocation engine migration
+selected_option: A
+scores:
+  security: 23
+  logic: 17
+  performance: 17
+  readability: 19
+  goal: 14
+weighted_percent: 90
+status: completed
+notes: added error handling and dbDelta requirement

--- a/migrations/2025_08_28_add_allocations_table_and_cap.php
+++ b/migrations/2025_08_28_add_allocations_table_and_cap.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+use SmartAlloc\Core\FormContext;
+use SmartAlloc\Infra\DB\TableResolver;
+
+/**
+ * Run migration to create allocations table and propagate capability.
+ */
+function smartalloc_run_migration_2025_08_28_add_allocations_table_and_cap(): void {
+    global $wpdb;
+    $resolver = new TableResolver($wpdb);
+    $table    = $resolver->allocations(new FormContext(0));
+    $charset  = $wpdb->get_charset_collate();
+    require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+    $sql      = "
+CREATE TABLE {$table} (
+  id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  mentee_id BIGINT UNSIGNED NOT NULL,
+  mentor_id BIGINT UNSIGNED DEFAULT NULL,
+  gf_entry_id BIGINT UNSIGNED NOT NULL,
+  status VARCHAR(20) NOT NULL DEFAULT 'pending_review',
+  match_score FLOAT DEFAULT NULL,
+  allocated_at_utc DATETIME DEFAULT NULL,
+  created_at_utc DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY  (id),
+  KEY mentor_id_idx (mentor_id),
+  KEY status_idx (status)
+) {$charset};";
+    dbDelta($sql);
+
+    $admin = get_role('administrator');
+    $admin?->add_cap('smartalloc_manage');
+
+    foreach (wp_roles()->roles as $role_key => $role) {
+        $role_obj = get_role($role_key);
+        if ($role_obj && $role_obj->has_cap('manage_smartalloc')) {
+            $role_obj->add_cap('smartalloc_manage');
+        }
+    }
+}

--- a/src/Allocation/AllocationEngine.php
+++ b/src/Allocation/AllocationEngine.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SmartAlloc\Allocation;
+
+use SmartAlloc\Allocation\Exceptions\AllocationException;
+use SmartAlloc\Core\FormContext;
+use SmartAlloc\Infra\DB\TableResolver;
+use wpdb;
+
+final class AllocationEngine {
+    private const MAX_CAPACITY = 60;
+
+    public function __construct(private wpdb $db) {}
+
+    public function run(array $entry_ids): AllocationResult {
+        do_action('smartalloc_before_allocation_run', $entry_ids);
+        $results = new AllocationResult();
+        foreach ($entry_ids as $entry_id) {
+            $entry_id = absint($entry_id);
+            if (0 === $entry_id) {
+                $results->add_error($entry_id, 'invalid_entry');
+                continue;
+            }
+            $mentor = $this->find_best_mentor($entry_id);
+            $this->persist_result($entry_id, $mentor, $results);
+        }
+        do_action('smartalloc_after_allocation_run', $results);
+        return $results;
+    }
+
+    private function find_best_mentor(int $entry_id): ?int {
+        // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- placeholder parameter.
+        $entry_id;
+        // Fuzzy match + ranking placeholders.
+        return null;
+    }
+
+    private function persist_result(int $entry_id, ?int $mentor_id, AllocationResult $results): void {
+        $table  = (new TableResolver($this->db))->allocations(new FormContext(0));
+        $status = null === $mentor_id ? 'pending_review' : 'allocated';
+        $query = $this->db->prepare(
+            "INSERT INTO {$table} (mentee_id, mentor_id, gf_entry_id, status, created_at_utc)
+             VALUES (%d, %d, %d, %s, %s)",
+            0,
+            $mentor_id,
+            $entry_id,
+            $status,
+            gmdate('Y-m-d H:i:s')
+        );
+        $result = $this->db->query($query);
+        if (false === $result) {
+            throw new AllocationException('Failed to insert allocation.');
+        }
+        $results->add($entry_id, $status);
+    }
+}

--- a/src/Allocation/AllocationResult.php
+++ b/src/Allocation/AllocationResult.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SmartAlloc\Allocation;
+
+final class AllocationResult {
+    /**
+     * @var array<int,string>
+     */
+    private array $status = [];
+
+    /**
+     * @var array<int,string>
+     */
+    private array $errors = [];
+
+    public function add(int $entry_id, string $status): void {
+        $this->status[$entry_id] = $status;
+    }
+
+    public function add_error(int $entry_id, string $error): void {
+        $this->errors[$entry_id] = $error;
+    }
+
+    public function has(int $entry_id): bool {
+        return isset($this->status[$entry_id]);
+    }
+
+    /**
+     * @return array{status:array<int,string>,errors:array<int,string>}
+     */
+    public function to_array(): array {
+        return [
+            'status' => $this->status,
+            'errors' => $this->errors,
+        ];
+    }
+}

--- a/src/Allocation/Exceptions/AllocationException.php
+++ b/src/Allocation/Exceptions/AllocationException.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SmartAlloc\Allocation\Exceptions;
+
+final class AllocationException extends \RuntimeException {}

--- a/tests/unit/AllocationEngineTest.php
+++ b/tests/unit/AllocationEngineTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+use SmartAlloc\Tests\BaseTestCase;
+use SmartAlloc\Allocation\AllocationEngine;
+
+final class AllocationEngineTest extends BaseTestCase {
+    public function test_run_inserts_allocation(): void {
+        $wpdb = $this->createMock(\wpdb::class);
+        $wpdb->expects($this->once())->method('prepare')->willReturn('SQL');
+        $wpdb->expects($this->once())->method('query')->willReturn(1);
+        $engine = new AllocationEngine($wpdb);
+        $result = $engine->run([123]);
+        $this->assertTrue($result->has(123));
+    }
+
+    public function test_run_throws_on_db_failure(): void {
+        $wpdb = $this->createMock(\wpdb::class);
+        $wpdb->expects($this->once())->method('prepare')->willReturn('SQL');
+        $wpdb->expects($this->once())->method('query')->willReturn(false);
+        $engine = new AllocationEngine($wpdb);
+        $this->expectException(\SmartAlloc\Allocation\Exceptions\AllocationException::class);
+        $engine->run([123]);
+    }
+}


### PR DESCRIPTION
## Summary
- add DB migration creating `smartalloc_allocations` table and propagating `smartalloc_manage` capability
- introduce `AllocationEngine` and `AllocationResult` scaffolds
- cover allocation engine with a basic unit test
- ensure migration loads `dbDelta` and handle DB insert errors via `AllocationException`

## Testing
- `vendor/bin/phpcs migrations/2025_08_28_add_allocations_table_and_cap.php src/Allocation/AllocationEngine.php src/Allocation/AllocationResult.php src/Allocation/Exceptions/AllocationException.php tests/unit/AllocationEngineTest.php`
- `composer test`
- `npm run status-pack` *(fails: Missing script "status-pack")*
- `php scripts/coverage-import.php`
- `php scripts/artifact-schema-validate.php`
- `php scripts/ga-enforcer.php --profile=rc --junit`


------
https://chatgpt.com/codex/tasks/task_e_68b0c0963b00832182c081aba6210e57