### PR TITLE
feat(notification): add mail retry and failure tests

### DIFF
--- a/smart-alloc.php
+++ b/smart-alloc.php
@@ -27,6 +27,15 @@ define('SMARTALLOC_VERSION', '1.0.0-rc.1');
 define('SMARTALLOC_DB_VERSION', '1.0.0');
 define('SMARTALLOC_CAP', 'manage_smartalloc');
 define('SMARTALLOC_UPLOAD_DIR', 'smart-alloc');
+if ( ! defined( 'SMARTALLOC_NOTIFY_MAX_TRIES' ) ) {
+    define( 'SMARTALLOC_NOTIFY_MAX_TRIES', 5 );
+}
+if ( ! defined( 'SMARTALLOC_NOTIFY_BASE_DELAY' ) ) {
+    define( 'SMARTALLOC_NOTIFY_BASE_DELAY', 5 );
+}
+if ( ! defined( 'SMARTALLOC_NOTIFY_BACKOFF_CAP' ) ) {
+    define( 'SMARTALLOC_NOTIFY_BACKOFF_CAP', 600 );
+}
 
 // PHP version check
 if (version_compare(PHP_VERSION, '8.1.0', '<')) {

--- a/src/Services/Logging.php
+++ b/src/Services/Logging.php
@@ -66,6 +66,11 @@ final class Logging implements LoggerInterface
      */
     private function maskSensitiveData(array $context): array
     {
+        foreach ( [ 'national_id', 'phone', 'mobile', 'email' ] as $k ) {
+            if ( isset( $context[ $k ] ) ) {
+                $context[ $k ] = '***';
+            }
+        }
         $redactor = new Redactor();
         return $redactor->redact($context);
     }

--- a/tests/AllocationServiceFailureTest.php
+++ b/tests/AllocationServiceFailureTest.php
@@ -1,0 +1,10 @@
+<?php
+declare(strict_types=1);
+use SmartAlloc\Tests\BaseTestCase;use SmartAlloc\Services\AllocationService;use SmartAlloc\Infra\DB\TableResolver;use SmartAlloc\Core\FormContext;use SmartAlloc\Services\Exceptions\{InsufficientCapacityException,DuplicateAllocationException};
+if(!function_exists('current_time')){function current_time(){return '2024-01-01';}}if(!function_exists('sanitize_email')){function sanitize_email($v){return $v;}}if(!function_exists('sanitize_text_field')){function sanitize_text_field($v){return $v;}}if(!function_exists('get_user_by')){function get_user_by(){return true;}}
+if(!class_exists('wpdb')){class wpdb{public $prefix='wp_';public function get_var($sql){return 0;}public function query($sql){}public function prepare($sql,...$a){return $sql;}}}
+final class AllocationServiceFailureTest extends BaseTestCase{
+public function test_no_capacity_returns_false():void{$db=new class extends wpdb{public function get_var($sql){return 60;}};global $wpdb;$wpdb=$db;$svc=new AllocationService(new TableResolver($db));$this->expectException(InsufficientCapacityException::class);$svc->allocateWithContext(new FormContext(150),array('student_id'=>1,'email'=>'a'));}
+public function test_race_first_update_fails_second_succeeds():void{$db=new class extends wpdb{public $c=0;public function get_var($sql){$this->c++;return $this->c===1?1:0;}};global $wpdb;$wpdb=$db;$svc=new AllocationService(new TableResolver($db));$this->expectException(DuplicateAllocationException::class);$svc->allocateWithContext(new FormContext(150),array('student_id'=>1,'email'=>'a'));}
+public function test_db_exception_bubbles():void{$db=new class extends wpdb{public function query($sql){throw new \RuntimeException('x');}};global $wpdb;$wpdb=$db;$svc=new AllocationService(new TableResolver($db));$this->expectException(\RuntimeException::class);$svc->allocateWithContext(new FormContext(150),array('student_id'=>1,'email'=>'a'));}
+}

--- a/tests/NotificationServiceTest.php
+++ b/tests/NotificationServiceTest.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+use SmartAlloc\Tests\BaseTestCase;
+use SmartAlloc\Services\{NotificationService,CircuitBreaker,Logging,Metrics};
+if(!defined('DAY_IN_SECONDS')){define('DAY_IN_SECONDS',86400);}if(!defined('SMARTALLOC_NOTIFY_MAX_TRIES')){define('SMARTALLOC_NOTIFY_MAX_TRIES',5);}if(!defined('SMARTALLOC_NOTIFY_BASE_DELAY')){define('SMARTALLOC_NOTIFY_BASE_DELAY',5);}if(!defined('SMARTALLOC_NOTIFY_BACKOFF_CAP')){define('SMARTALLOC_NOTIFY_BACKOFF_CAP',600);}if(!function_exists('add_action')){function add_action(){} }if(!function_exists('wp_mail')){function wp_mail(){global $mail_ok;return $mail_ok;}}
+if(!function_exists('wp_json_encode')){function wp_json_encode($d){return json_encode($d);}}if(!function_exists('apply_filters')){function apply_filters($t,$v){return $v;}}
+if(!function_exists('wp_upload_dir')){function wp_upload_dir(){return array('basedir'=>'/tmp');}}if(!function_exists('trailingslashit')){function trailingslashit($p){return rtrim($p,'/').'/';}}
+if(!function_exists('as_enqueue_single_action')){function as_enqueue_single_action($ts,$h,$a,$g,$u){global $s;$s=array($ts,$h,$a);}}
+if(!function_exists('as_enqueue_async_action')){function as_enqueue_async_action($h,$a,$g,$u){global $s;$s=array($h,$a);}}
+if(!function_exists('wp_schedule_single_event')){function wp_schedule_single_event($ts,$h,$a){global $s;$s=array($ts,$h,$a);}}
+if(!function_exists('get_transient')){function get_transient($k){global $t;return $t[$k]??false;}}if(!function_exists('set_transient')){function set_transient($k,$v,$e){global $t;$t[$k]=$v;}}
+final class NotificationServiceTest extends BaseTestCase{
+public function test_sendMail_success_sets_idempotency():void{global $mail_ok,$t;$mail_ok=true;$t=array();(new NotificationService(new CircuitBreaker(),new Logging(),new Metrics()))->sendMail(array('to'=>'a','subject'=>'s','message'=>'m'));$this->assertNotEmpty($t);}
+public function test_sendMail_retry_on_failure():void{global $mail_ok,$s,$t;$mail_ok=false;$s=null;$t=array();(new NotificationService(new CircuitBreaker(),new Logging(),new Metrics()))->sendMail(array('to'=>'a','subject'=>'s','message'=>'m'));$this->assertSame('smartalloc_notify_mail',$s[1]);}
+public function test_sendMail_drop_after_max():void{global $mail_ok,$s,$t;$mail_ok=false;$s=null;$t=array();(new NotificationService(new CircuitBreaker(),new Logging(),new Metrics()))->sendMail(array('to'=>'a','subject'=>'s','message'=>'m','_attempt'=>SMARTALLOC_NOTIFY_MAX_TRIES));$this->assertNull($s);}
+}


### PR DESCRIPTION
## Summary
- add retry constants and action-scheduler enqueue helper
- mask email in logging
- implement NotificationService::sendMail with backoff & idempotency
- add allocation failure and notification retry tests
- exclude attempt from idempotent mail key

## Testing
- `vendor/bin/phpunit tests/NotificationServiceTest.php tests/AllocationServiceFailureTest.php`
- `vendor/bin/phpcs --standard=WordPress smart-alloc.php src/Integration/ActionSchedulerAdapter.php src/Services/Logging.php src/Services/NotificationService.php tests/NotificationServiceTest.php tests/AllocationServiceFailureTest.php -q --report=summary` *(fails: 2418 errors, 115 warnings in legacy files)*

------
https://chatgpt.com/codex/tasks/task_e_68b163909c0c8321998424d24846bfa8