### PR TITLE
feat(notifications): add retrying mailer (PHPCS=0)

### DIFF
--- a/ai_outputs/last_state.yml
+++ b/ai_outputs/last_state.yml
@@ -1,12 +1,12 @@
-timestamp: 2025-08-29T10:54:33Z
-feature: CI stabilization and policy contract
+timestamp: 2025-08-29T15:30:51Z
+feature: Notification retry mailer
 selected_option: A
 scores:
-  security: 25
-  logic: 20
-  performance: 20
-  readability: 19
-  goal: 15
-weighted_percent: 93.5
+  security: 21
+  logic: 17
+  performance: 18
+  readability: 18
+  goal: 14
+weighted_percent: 88
 status: completed
-notes: added CI gate script and policy tests
+notes: added mail retry service and deterministic test

--- a/src/Bootstrap/NotificationsBootstrap.php
+++ b/src/Bootstrap/NotificationsBootstrap.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SmartAlloc\Bootstrap;
+
+use SmartAlloc\Notifications\RetryingMailer;
+
+final class NotificationsBootstrap
+{
+    public static function init(): void
+    {
+        $mailFn = static function (array $p): bool {
+            return function_exists('wp_mail')
+                ? (bool) wp_mail($p['to'], $p['subject'], $p['message'], $p['headers'], $p['attachments'])
+                : false;
+        };
+
+        $scheduleFn = static function (int $ts, string $hook, array $args): bool {
+            return function_exists('wp_schedule_single_event')
+                ? (bool) wp_schedule_single_event($ts, $hook, $args)
+                : false;
+        };
+
+        (new RetryingMailer($mailFn, $scheduleFn))->register();
+    }
+}

--- a/src/Notifications/MailerInterface.php
+++ b/src/Notifications/MailerInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SmartAlloc\Notifications;
+
+interface MailerInterface
+{
+    /**
+     * Sends an email payload or schedules a retry.
+     *
+     * @param array<string,mixed> $payload Email arguments.
+     * @param int                 $attempt Current attempt number.
+     *
+     * @return bool True if delivered or scheduled, false on final failure.
+     */
+    public function send(array $payload, int $attempt = 1): bool;
+
+    /** Registers WP-Cron hook for retries. */
+    public function register(): void;
+}

--- a/src/Notifications/RetryingMailer.php
+++ b/src/Notifications/RetryingMailer.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SmartAlloc\Notifications;
+
+use SmartAlloc\Logging\Logger;
+
+final class RetryingMailer implements MailerInterface
+{
+    /** @var callable(array):bool */
+    private $mailFn;
+
+    /** @var callable(int,string,array):bool */
+    private $scheduleFn;
+
+    private Logger $logger;
+
+    private int $maxAttempts;
+
+    private int $baseDelay;
+
+    private static ?self $singleton = null;
+
+    public function __construct(callable $mailFn, callable $scheduleFn, ?Logger $logger = null, int $maxAttempts = 3, int $baseDelay = 60)
+    {
+        $this->mailFn     = $mailFn;
+        $this->scheduleFn = $scheduleFn;
+        $this->logger     = $logger ?? new Logger();
+        $this->maxAttempts = max(1, $maxAttempts);
+        $this->baseDelay   = max(15, $baseDelay);
+        self::$singleton   = $this;
+    }
+
+    public function register(): void
+    {
+        if (function_exists('add_action')) {
+            add_action('smartalloc_mail_retry', [__CLASS__, 'retryAction'], 10, 1);
+        }
+    }
+
+    /** @param array{payload:array,attempt:int} $args */
+    public static function retryAction(array $args): void
+    {
+        if (!self::$singleton) {
+            return;
+        }
+        $payload = $args['payload'] ?? [];
+        $attempt = (int) ($args['attempt'] ?? 1);
+        self::$singleton->send($payload, $attempt);
+    }
+
+    public function send(array $payload, int $attempt = 1): bool
+    {
+        $ok = (bool) call_user_func($this->mailFn, [
+            'to'          => $payload['to'] ?? '',
+            'subject'     => $payload['subject'] ?? '',
+            'message'     => $payload['message'] ?? '',
+            'headers'     => $payload['headers'] ?? [],
+            'attachments' => $payload['attachments'] ?? [],
+        ]);
+
+        $context = ['attempt' => $attempt, 'corr' => $payload['corr'] ?? null];
+
+        if ($ok) {
+            $this->logger->info('mail ok', $context);
+            return true;
+        }
+
+        if ($attempt >= $this->maxAttempts) {
+            $this->logger->error('mail fail final', $context);
+            return false;
+        }
+
+        $delay = (int) min(900, $this->baseDelay * (1 << ($attempt - 1)));
+        $ts    = time() + $delay; // UTC
+        $args  = [['payload' => $payload, 'attempt' => $attempt + 1]];
+        $scheduled = (bool) call_user_func($this->scheduleFn, $ts, 'smartalloc_mail_retry', $args);
+        $context['delay'] = $delay;
+        $this->logger->info($scheduled ? 'mail scheduled' : 'schedule failed', $context);
+
+        return $scheduled;
+    }
+}

--- a/tests/Notifications/RetryingMailerTest.php
+++ b/tests/Notifications/RetryingMailerTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use SmartAlloc\Notifications\RetryingMailer;
+
+final class RetryingMailerTest extends TestCase
+{
+    public function test_retries_then_succeeds(): void
+    {
+        $calls = 0;
+        $scheduled = [];
+        $mailFn = static function (array $p) use (&$calls): bool {
+            $calls++;
+            return $calls >= 3;
+        };
+        $scheduleFn = static function (int $ts, string $hook, array $args) use (&$scheduled): bool {
+            $scheduled[] = ['ts' => $ts, 'args' => $args];
+            return true;
+        };
+        $mailer = new RetryingMailer($mailFn, $scheduleFn, null, 3, 1);
+        $sent = $mailer->send(['to' => 't', 'subject' => 's', 'message' => 'm'], 1);
+        $this->assertTrue($sent);
+        $this->assertCount(1, $scheduled);
+        $mailer::retryAction($scheduled[0]['args'][0]);
+        $this->assertCount(2, $scheduled);
+        $mailer::retryAction($scheduled[1]['args'][0]);
+        $this->assertSame(3, $calls);
+    }
+}


### PR DESCRIPTION
## Summary
- add mailer contract and retrying mailer with WP-Cron scheduling
- wire notification bootstrap to register retry service
- add deterministic unit test

## Testing
- `composer exec phpcs`
- `composer exec phpunit tests/Notifications/RetryingMailerTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68b1c4cf3b3c8321ab322baa965c9d25