### PR TITLE
feat(core): add CircuitBreaker contract and test scaffolds

### DIFF
--- a/ai_outputs/last_state.yml
+++ b/ai_outputs/last_state.yml
@@ -1,12 +1,12 @@
-timestamp: 2025-08-29T16:06:09Z
-feature: Mail retry system
+timestamp: 2025-08-29T16:37:09Z
+feature: Phase-1 test coverage & circuit breaker contract
 selected_option: A
 scores:
-  security: 22
-  logic: 18
-  performance: 19
+  security: 20
+  logic: 17
+  performance: 20
   readability: 19
-  goal: 14
-weighted_percent: 89.25
+  goal: 13
+weighted_percent: 88.15
 status: completed
-notes: added time injection and comprehensive tests
+notes: added test scaffolding and CircuitBreaker interface

--- a/src/Core/Contracts/CircuitBreaker.php
+++ b/src/Core/Contracts/CircuitBreaker.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+namespace SmartAlloc\Core\Contracts;
+
+/**
+ * Circuit breaker pattern for protecting against cascading failures.
+ *
+ * Lightweight contract to be injected later; no runtime usage yet.
+ */
+interface CircuitBreaker {
+    /**
+     * Check if circuit is open (failing) for given key.
+     *
+     * @param string $key Service or operation identifier
+     * @return bool True if circuit is open (should not proceed)
+     */
+    public function isOpen(string $key): bool;
+
+    /**
+     * Record successful operation.
+     *
+     * @param string $key Service or operation identifier
+     */
+    public function recordSuccess(string $key): void;
+
+    /**
+     * Record failed operation.
+     *
+     * @param string $key Service or operation identifier
+     */
+    public function recordFailure(string $key): void;
+}

--- a/tests/Allocation/RollbackOnNotifyFailTest.php
+++ b/tests/Allocation/RollbackOnNotifyFailTest.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for allocation rollback on notification failures.
+ *
+ * @group allocation
+ */
+final class RollbackOnNotifyFailTest extends TestCase {
+    /**
+     * Test that allocations are rolled back when notifications fail.
+     */
+    public function test_allocation_rolled_back_when_notification_final_fails(): void {
+        $this->markTestIncomplete(
+            'Bind to Allocation facade + RetryingMailer final-fail path; expect rollback and error log entry.'
+        );
+    }
+}

--- a/tests/RuleEngine/FailureModesTest.php
+++ b/tests/RuleEngine/FailureModesTest.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for Rule Engine failure modes and edge cases.
+ *
+ * @group rule-engine
+ */
+final class FailureModesTest extends TestCase {
+    /**
+     * Test that invalid inputs are properly validated.
+     */
+    public function test_invalid_inputs(): void {
+        $this->markTestIncomplete(
+            'Bind to RuleEngine API: invalid inputs should yield ValidationException or error result.'
+        );
+    }
+
+    /**
+     * Test handling of dependency failures.
+     */
+    public function test_dependency_error(): void {
+        $this->markTestIncomplete(
+            'Bind to RuleEngine API: repository adapter throws → engine surfaces typed error and no side-effects.'
+        );
+    }
+
+    /**
+     * Test timeout protection and circuit breaker integration.
+     */
+    public function test_timeout_guard(): void {
+        $this->markTestIncomplete(
+            'Bind to RuleEngine API: execution exceeds budget → timeout/circuit path triggers and emits metric.'
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add CircuitBreaker interface for future resilience patterns
- scaffold Rule Engine and Allocation rollback failure-mode tests
- record 5D scores in ai_outputs/last_state.yml

## Testing
- `npx --yes status-pack` *(fails: 404 Not Found)*
- `vendor/bin/phpcs tests/RuleEngine/ tests/Allocation/ src/Core/Contracts/`
- `vendor/bin/phpunit tests/RuleEngine/FailureModesTest.php`
- `vendor/bin/phpunit tests/Allocation/RollbackOnNotifyFailTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68b1d6be75888321a1ab16727c023f6c