### PR TITLE
feat(sync): filter implemented features in state files

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -2,6 +2,9 @@
 <!-- AUTO-GEN:STATE START -->
 # PROJECT_STATE — 2025-08-29
 
+## Implemented Features
+- None
+
 ## Milestones
 - ✅ Core Allocation shipped
 - 🟡 Rule Engine & Notifications in progress

--- a/README.md
+++ b/README.md
@@ -428,11 +428,11 @@ bash scripts/new_adr.sh "Choose database library"
 
 Artifacts:
 
-FEATURES.md: feature readiness scores
+FEATURES.md: feature readiness scores for all features
 
-ai_context.json: ADR-derived AI context
+ai_context.json: ADR-derived AI context (implemented features only)
 
-PROJECT_STATE.md: snapshot summary (CI also uploads as artifact)
+PROJECT_STATE.md: snapshot summary highlighting implemented features (CI also uploads as artifact)
 
 ## Codex Prompt Handoff
 

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,11 +1,12 @@
 {
-  "last_update_utc": "2025-08-29T18:51:20Z",
+  "last_update_utc": "2025-08-29T19:12:56Z",
   "repo": {
-    "default_branch": "main",
-    "last_commit": "4b2f47920694d6c171be99ccfcaeb0de6a3eb08c",
-    "commits_total": 459,
+    "default_branch": "work",
+    "last_commit": "3ad9e6abe1c99fd0396559fae13e18d5094462b0",
+    "commits_total": 460,
     "files_tracked": 616
   },
+  "implemented_features": [],
   "quality_gate": {
     "weighted_threshold": 0.85,
     "security_min": 20,


### PR DESCRIPTION
## Summary
- restrict PROJECT_STATE.md and ai_context.json to implemented features while FEATURES.md retains full list
- document filtering rules in sync_memory_files.sh and README

## Testing
- `bash scripts/validate_memory_files.sh`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68b1fb0ad63c83218b91ff8df3380d36