### PR TITLE
feat(memory): load last_state.yml in sync script

### DIFF
--- a/ai_outputs/last_state.yml
+++ b/ai_outputs/last_state.yml
@@ -1,12 +1,12 @@
-feature: rule-engine-reliability-gates
+feature: memory-sync-parse-fix
 selected_option: A
-timestamp: "2025-08-29T18:44:06Z"
+timestamp: "2025-08-29T19:19:16Z"
 scores:
-  security: 22
-  logic: 18
-  performance: 18
+  security: 23
+  logic: 19
+  performance: 19
   readability: 19
   goal: 14
-weighted_percent: 90.0
+weighted_percent: 91.0
 status: implemented
-notes: "Adds boundary and metrics tests; Rule Engine API placeholders remain"
+notes: "Fix python invocation for last_state.yml parsing; adds dependency check"

--- a/scripts/sync_memory_files.sh
+++ b/scripts/sync_memory_files.sh
@@ -57,6 +57,35 @@ LAST_COMMIT=$(git rev-parse HEAD)
 
 mkdir -p reports docs/architecture/decisions
 
+LAST_STATE_FILE="ai_outputs/last_state.yml"
+if [ ! -f "$LAST_STATE_FILE" ]; then
+  echo "Error: missing $LAST_STATE_FILE" >&2
+  exit 1
+fi
+
+LAST_STATE_DATA=$(python3 - "$LAST_STATE_FILE" <<'PY'
+import sys, json
+try:
+    import yaml
+except ImportError as e:
+    print(f"Error: yaml module missing: {e}", file=sys.stderr)
+    sys.exit(1)
+
+file = sys.argv[1]
+try:
+    with open(file, 'r', encoding='utf-8') as f:
+        data = yaml.safe_load(f) or {}
+    missing = [k for k in ('feature', 'status', 'notes') if k not in data]
+    if missing:
+        raise KeyError(', '.join(missing))
+    json.dump({k: data[k] for k in ('feature', 'status', 'notes')}, sys.stdout)
+except Exception as e:
+    print(f"Error parsing {file}: {e}", file=sys.stderr)
+    sys.exit(1)
+PY
+)
+write_file ai_outputs/last_state.json "$LAST_STATE_DATA"
+
 AI_CONTEXT=$(cat <<EOF2
 {
   "last_update_utc": "$NOW",


### PR DESCRIPTION
## Summary
- parse `ai_outputs/last_state.yml` during memory sync
- export feature status and notes to JSON for downstream use
- fix argument order so parser gets file path, with graceful YAML module checks

## Testing
- `bash scripts/sync_memory_files.sh`
- `vendor/bin/phpcs`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b1fafb27bc83218c415db6118a279f