### PR TITLE
chore(ci): grant write access to workflow contents

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 permissions:
-  contents: read
+  contents: write
   actions: write
 
 env:

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -16,7 +16,7 @@
 | CI/CD | 🟢 Green | 5D gate with AUTO-FIX loop |
 | rule-engine-reliability-gates | 🟡 Amber |  |
 | rag-template-automation | 🟡 Amber |  |
-| memory-sync-branch | ⚪ Unknown | Workflow covers all branches and ensures pushes use active branch |
+| ci-contents-write | ⚪ Unknown | Updated CI workflow to grant write access to contents |
 
 _Last Updated (UTC): 2025-08-29_
 <!-- AUTO-GEN:RAG END -->

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -2,7 +2,7 @@
 <!-- AUTO-GEN:STATE START -->
 # PROJECT_STATE — 2025-08-29
 ## Implemented Features
-- memory-sync-branch
+- ci-contents-write
 
 ## Milestones
 - ✅ Core Allocation shipped

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-08-29T21:40:08Z",
+  "last_update_utc": "2025-08-29T21:40:11Z",
   "repo": {
     "default_branch": "codex/change-permissions.contents-to-write",
-    "last_commit": "7723b8ffde093341efea37a30a18b8e02441aa07",
-    "commits_total": 482,
+    "last_commit": "eeddb27006b4f1b16540eb690a5c7eb370f5b4bc",
+    "commits_total": 483,
     "files_tracked": 623
   },
   "quality_gate": {

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-08-29T21:34:33Z",
+  "last_update_utc": "2025-08-29T21:40:08Z",
   "repo": {
-    "default_branch": "main",
-    "last_commit": "16eefc1896afdb34a20f135df5e9b8c84fc75406",
-    "commits_total": 480,
+    "default_branch": "codex/change-permissions.contents-to-write",
+    "last_commit": "7723b8ffde093341efea37a30a18b8e02441aa07",
+    "commits_total": 482,
     "files_tracked": 623
   },
   "quality_gate": {
@@ -37,9 +37,9 @@
   },
   "features": [
   {
-    "name": "memory-sync-branch",
+    "name": "ci-contents-write",
     "status": "implemented",
-    "notes": "Workflow covers all branches and ensures pushes use active branch"
+    "notes": "Updated CI workflow to grant write access to contents"
   }
 ]
 }

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-08-29T21:40:11Z",
+  "last_update_utc": "2025-08-29T21:40:17Z",
   "repo": {
     "default_branch": "codex/change-permissions.contents-to-write",
-    "last_commit": "eeddb27006b4f1b16540eb690a5c7eb370f5b4bc",
-    "commits_total": 483,
+    "last_commit": "e90046351110aa82839a5d652ae3890c4a61437b",
+    "commits_total": 484,
     "files_tracked": 623
   },
   "quality_gate": {

--- a/ai_outputs/last_state.yml
+++ b/ai_outputs/last_state.yml
@@ -1,12 +1,12 @@
-feature: memory-sync-branch
-selected_option: D
-timestamp: "2025-08-29T21:32:32Z"
+timestamp: "2025-08-29T21:38:12Z"
+feature: ci-contents-write
+selected_option: A
 scores:
-  security: 24
-  logic: 19
+  security: 22
+  logic: 20
   performance: 20
   readability: 19
   goal: 15
-weighted_percent: 97.0
+weighted_percent: 96.0
 status: implemented
-notes: "Workflow covers all branches and ensures pushes use active branch"
+notes: "Updated CI workflow to grant write access to contents"


### PR DESCRIPTION
## Summary
- allow CI workflow to write repository contents
- record audit state for updated permission

## Status-Pack
- not available

## 5D Score
| Dimension | Before | After |
| --- | --- | --- |
| Security | 24 | 22 |
| Logic | 19 | 20 |
| Performance | 20 | 20 |
| Readability | 19 | 19 |
| Goal/Scope | 15 | 15 |
| Weighted % | 97 | 96 |

## Testing
- `vendor/bin/phpcs --extensions=yml,yaml .github/workflows/ci.yml`
- `vendor/bin/phpcs --extensions=yml,yaml ai_outputs/last_state.yml`
- `vendor/bin/phpunit --testsuite Unit,WordPress,VIP,Integration` *(errors: Debug bundle not exercised)*

------
https://chatgpt.com/codex/tasks/task_e_68b21cf6c40c8321b40d0ffdbd67415b