### PR TITLE
chore(ci): allow session workflow to write contents

### DIFF
--- a/.github/workflows/session.yml
+++ b/.github/workflows/session.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
   issues: write
 

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -16,7 +16,7 @@
 | CI/CD | 🟢 Green | 5D gate with AUTO-FIX loop |
 | rule-engine-reliability-gates | 🟡 Amber |  |
 | rag-template-automation | 🟡 Amber |  |
-| ci-contents-write | ⚪ Unknown | Updated CI workflow to grant write access to contents |
+| ci-contents-write | ⚪ Unknown | Updated session workflow to write repository contents |
 
 _Last Updated (UTC): 2025-08-29_
 <!-- AUTO-GEN:RAG END -->

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-08-29T21:45:34Z",
+  "last_update_utc": "2025-08-29T21:45:40Z",
   "repo": {
     "default_branch": "codex/increase-permissions.contents-to-write",
-    "last_commit": "177279e82dde1d0970f407d7794b8b810379d622",
-    "commits_total": 488,
+    "last_commit": "d813b435ab13806e0746b717f7249f1a5080a579",
+    "commits_total": 489,
     "files_tracked": 623
   },
   "quality_gate": {

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-08-29T21:45:40Z",
+  "last_update_utc": "2025-08-29T21:45:42Z",
   "repo": {
     "default_branch": "codex/increase-permissions.contents-to-write",
-    "last_commit": "d813b435ab13806e0746b717f7249f1a5080a579",
-    "commits_total": 489,
+    "last_commit": "ac71c12c607e1ae86e98162dfaceae352c2726a4",
+    "commits_total": 490,
     "files_tracked": 623
   },
   "quality_gate": {

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-08-29T21:40:40Z",
+  "last_update_utc": "2025-08-29T21:45:34Z",
   "repo": {
-    "default_branch": "main",
-    "last_commit": "c05fe8e9eea67f560cdb8022cb7e5441c396acb7",
-    "commits_total": 486,
+    "default_branch": "codex/increase-permissions.contents-to-write",
+    "last_commit": "177279e82dde1d0970f407d7794b8b810379d622",
+    "commits_total": 488,
     "files_tracked": 623
   },
   "quality_gate": {
@@ -39,7 +39,7 @@
   {
     "name": "ci-contents-write",
     "status": "implemented",
-    "notes": "Updated CI workflow to grant write access to contents"
+    "notes": "Updated session workflow to write repository contents"
   }
 ]
 }

--- a/ai_outputs/last_state.yml
+++ b/ai_outputs/last_state.yml
@@ -1,12 +1,12 @@
-timestamp: "2025-08-29T21:38:12Z"
+timestamp: "2025-08-29T21:43:54Z"
 feature: ci-contents-write
 selected_option: A
 scores:
-  security: 22
+  security: 21
   logic: 20
   performance: 20
   readability: 19
   goal: 15
-weighted_percent: 96.0
+weighted_percent: 95.0
 status: implemented
-notes: "Updated CI workflow to grant write access to contents"
+notes: "Updated session workflow to write repository contents"


### PR DESCRIPTION
## Summary
- allow session continuation workflow to write repository contents

## Testing
- ⚠️ `composer phpcs` (fails: tabs must be used to indent lines) 
- ⚠️ `composer test` (fails: Debug bundle not exercised)


------
https://chatgpt.com/codex/tasks/task_e_68b21e5fbfd88321be0cc6771c4d61d5