### PR TITLE
chore(session): auto-update snapshot with commit step

### DIFF
--- a/.github/workflows/session.yml
+++ b/.github/workflows/session.yml
@@ -17,12 +17,33 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.issue.pull_request.head.ref || github.ref_name }}
 
-      - name: 🧮 Generate/refresh project state (if missing)
+      - name: 🧮 Generate/refresh project state
+        run: make state
+
+      - name: 📦 Commit & Push (if changed)
+        env:
+          BRANCH_NAME: ${{ github.event.issue.pull_request.head.ref || github.ref_name }}
         run: |
-          if [ ! -f PROJECT_STATE.md ]; then
-            chmod +x scripts/update_state.sh || true
-            ./scripts/update_state.sh || true
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          for f in FEATURES.md PROJECT_STATE.md ai_context.json; do
+            [ -f "$f" ] && git add "$f"
+          done
+          branch="$BRANCH_NAME"
+          current_branch="$(git rev-parse --abbrev-ref HEAD)"
+          if [ "$current_branch" != "$branch" ]; then
+            echo "Aborting: checked out $current_branch but expected $branch"
+            exit 1
+          fi
+          if git diff --cached --quiet; then
+            echo "No changes to commit."
+          else
+            git commit -m "chore: auto-update project snapshot"
+            git push origin "HEAD:$branch"
           fi
 
       - name: 🧾 Post snapshot as comment

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -15,4 +15,4 @@
 ### ✅ No Red Flags Detected
 
 ---
-Last Updated (UTC): 2025-08-30T08:28:37Z
+Last Updated (UTC): 2025-08-30T08:51:27Z

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -15,4 +15,4 @@
 ### ✅ No Red Flags Detected
 
 ---
-Last Updated (UTC): 2025-08-30T08:51:29Z
+Last Updated (UTC): 2025-08-30T08:51:32Z

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -15,4 +15,4 @@
 ### ✅ No Red Flags Detected
 
 ---
-Last Updated (UTC): 2025-08-30T08:51:27Z
+Last Updated (UTC): 2025-08-30T08:51:29Z

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-08-30T08:28:37Z",
+  "last_update_utc": "2025-08-30T08:51:27Z",
   "repo": {
-    "default_branch": "main",
-    "last_commit": "b987d61096c475a0787ec8cbb83a1e3c2f19a8b8",
-    "commits_total": 510,
+    "default_branch": "codex/diagnose-github-actions-workflow-issues",
+    "last_commit": "15dd21b1099933490aa777deaefb9a66ddc79171",
+    "commits_total": 512,
     "files_tracked": 623
   },
   "quality_gate": {
@@ -46,5 +46,5 @@
       "notes": "Run make state after tests in CI workflow"
     }
   ],
-  "last_updated_utc": "2025-08-30T08:28:37Z"
+  "last_updated_utc": "2025-08-30T08:51:27Z"
 }

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-08-30T08:51:27Z",
+  "last_update_utc": "2025-08-30T08:51:28Z",
   "repo": {
     "default_branch": "codex/diagnose-github-actions-workflow-issues",
-    "last_commit": "15dd21b1099933490aa777deaefb9a66ddc79171",
-    "commits_total": 512,
+    "last_commit": "bdf88ee4e31ac02af22596f1d333f671ff7a8a6b",
+    "commits_total": 513,
     "files_tracked": 623
   },
   "quality_gate": {
@@ -46,5 +46,5 @@
       "notes": "Run make state after tests in CI workflow"
     }
   ],
-  "last_updated_utc": "2025-08-30T08:51:27Z"
+  "last_updated_utc": "2025-08-30T08:51:29Z"
 }

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-08-30T08:51:28Z",
+  "last_update_utc": "2025-08-30T08:51:32Z",
   "repo": {
     "default_branch": "codex/diagnose-github-actions-workflow-issues",
-    "last_commit": "bdf88ee4e31ac02af22596f1d333f671ff7a8a6b",
-    "commits_total": 513,
+    "last_commit": "9708744275eda36064645a11b8e2b7a5d3076e5e",
+    "commits_total": 514,
     "files_tracked": 623
   },
   "quality_gate": {
@@ -46,5 +46,5 @@
       "notes": "Run make state after tests in CI workflow"
     }
   ],
-  "last_updated_utc": "2025-08-30T08:51:29Z"
+  "last_updated_utc": "2025-08-30T08:51:32Z"
 }


### PR DESCRIPTION
## Summary
- add branch-aware checkout and commit/push step to session snapshot workflow
- guard commit step when state files are missing

## Testing
- `composer test`
- `composer phpcs` *(fails: Tabs must be used to indent lines; spaces are not allowed)*

------
https://chatgpt.com/codex/tasks/task_e_68b2b1d2ad908321acc73607ed32c190