### PR TITLE
feat(infra): add DbPort and capacity provider

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     "psr-4": {
       "SmartAlloc\\": "src/"
     },
-    "files": ["src/Support/SafetyKit.php"]
+    "files": ["src/Support/SafetyKit.php", "src/Infra/DbAbstraction.php"]
   },
   "scripts": {
     "score:5d": ["@phpcbf", "bash scripts/update_state.sh"],

--- a/src/Allocation/CapacityProvider.php
+++ b/src/Allocation/CapacityProvider.php
@@ -1,0 +1,6 @@
+<?php namespace SmartAlloc\Allocation;
+interface CapacityProvider { public function hasCapacity(int|string $resourceId): bool; }
+final class ArrayCapacityProvider implements CapacityProvider {
+    public function __construct(private array $caps) {}
+    public function hasCapacity(int|string $id): bool { return (int) ($this->caps[$id] ?? 0) > 0; }
+}

--- a/src/Infra/DbAbstraction.php
+++ b/src/Infra/DbAbstraction.php
@@ -1,0 +1,33 @@
+<?php
+namespace SmartAlloc\Infra;
+interface DbPort {
+    public function exec(string $sql, array $args = []): int;
+}
+final class WpdbAdapter implements DbPort {
+    public function __construct(private \wpdb $wpdb) {}
+
+    public function exec(string $sql, array $args = []): int {
+        $prepared = \DbSafe::mustPrepare($this->wpdb, $sql, $args);
+        // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+        $this->wpdb->query($prepared);
+        return (int) $this->wpdb->rows_affected;
+    }
+}
+interface CircuitStorage {
+    public function get(string $key): array;
+    public function put(string $key, array $state, int $ttl): void;
+    public function clear(string $key): void;
+}
+final class TransientCircuitStorage implements CircuitStorage {
+    private string $prefix = 'smartalloc_cb_';
+    public function get(string $key): array {
+        $v = get_transient($this->prefix . $key);
+        return is_array($v) ? $v : [];
+    }
+    public function put(string $key, array $state, int $ttl): void {
+        set_transient($this->prefix . $key, $state, $ttl);
+    }
+    public function clear(string $key): void {
+        delete_transient($this->prefix . $key);
+    }
+}

--- a/src/Notifications/DlqRepository.php
+++ b/src/Notifications/DlqRepository.php
@@ -1,0 +1,16 @@
+<?php namespace SmartAlloc\Notifications;
+use SmartAlloc\Infra\DbPort;
+final class DlqRepository {
+    public function __construct(private DbPort $db, private string $table) {}
+    /** @param array<string,mixed> $row */
+    public function enqueue(array $row): void {
+        $sql = "INSERT INTO {$this->table} (channel, payload, reason, created_at) VALUES (%s, %s, %s, %s)";
+        $args = [
+            $row['channel'] ?? 'unknown',
+            wp_json_encode($row['payload'] ?? []),
+            substr((string) ($row['reason'] ?? ''), 0, 255),
+            gmdate('Y-m-d H:i:s'),
+        ];
+        $this->db->exec($sql, $args);
+    }
+}

--- a/src/RuleEngine/RuleEngineService.php
+++ b/src/RuleEngine/RuleEngineService.php
@@ -1,38 +1,19 @@
-<?php
-declare(strict_types=1);
-
+<?php declare(strict_types=1);
 namespace SmartAlloc\RuleEngine;
-
+use SmartAlloc\Allocation\CapacityProvider;
+use SmartAlloc\Allocation\ArrayCapacityProvider;
+use SmartAlloc\Rules\ExternalDependencyError;
 require_once __DIR__ . '/Contracts.php';
-
-final class RuleEngineService implements RuleEngineContract
-{
-    public function evaluate(array $studentCtx): EvaluationResult
-    {
-        $score    = (float) ($studentCtx['school_fuzzy'] ?? 0.0);
-        $decision = 'reject';
-        $reasons  = ['school_match_low'];
-        if ($score >= 0.90) {
-            $decision = 'auto';
-            $reasons  = [];
-        } elseif ($score >= 0.80) {
-            $decision = 'manual';
-            $reasons  = ['school_match_borderline'];
-        }
-        $r = new EvaluationResult($decision);
-        $r->scores['school_fuzzy'] = $score;
-        $r->reasons = $reasons;
-        // NEW: capacity check with filter override
+final class RuleEngineService implements RuleEngineContract {
+    public function __construct(?CapacityProvider $capacity = null) { $this->capacity = $capacity ?? new ArrayCapacityProvider([]); }
+    public function evaluate(array $studentCtx): EvaluationResult {
+        $score = (float) ($studentCtx['school_fuzzy'] ?? 0.0);
+        $decision = 'reject'; $reasons = ['school_match_low'];
+        if ($score >= 0.90) { $decision = 'auto'; $reasons = []; }
+        elseif ($score >= 0.80) { $decision = 'manual'; $reasons = ['school_match_borderline']; }
+        $r = new EvaluationResult($decision); $r->scores['school_fuzzy'] = $score; $r->reasons = $reasons;
         $flag = apply_filters('smartalloc_rule_cap_check', SMARTALLOC_RULE_CAP_CHECK);
-        if ($flag) {
-            $capacityOk = true; // placeholder until provider injected
-            if (!$capacityOk && class_exists('\\SmartAlloc\\Services\\Exceptions\\InsufficientCapacityException')) {
-                throw new \SmartAlloc\Services\Exceptions\InsufficientCapacityException(
-                    'Capacity check failed (flag ON).'
-                );
-            }
-        }
-        // TODO: Add mentor validation when available
+        if ($flag) { $mentorId = $studentCtx['mentor_id'] ?? 0; if (!$this->capacity->hasCapacity($mentorId)) { throw new ExternalDependencyError('NO_CAPACITY'); } }
         return $r;
     }
 }

--- a/tests/Notifications/DlqRepositoryTest.php
+++ b/tests/Notifications/DlqRepositoryTest.php
@@ -1,0 +1,15 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use SmartAlloc\Notifications\DlqRepository;
+final class DlqRepositoryTest extends TestCase {
+    public function testEnqueueUsesPreparedSql(): void {
+        $fake = new class implements \SmartAlloc\Infra\DbPort {
+            public string $lastSql = '';public array $lastArgs = [];
+            public function exec(string $sql, array $args = []): int { $this->lastSql = $sql; $this->lastArgs = $args; return 1; }
+        };
+        $repo = new DlqRepository($fake, 'wp_smartalloc_dlq');
+        $repo->enqueue(['channel' => 'mail','payload' => ['k' => 'v'],'reason' => 'oops']);
+        $this->assertStringContainsString('%s', $fake->lastSql);
+        $this->assertCount(4, $fake->lastArgs);
+    }
+}


### PR DESCRIPTION
## Summary
- add DbPort with WpdbAdapter and transient circuit storage
- introduce DlqRepository using DbPort and wire into DlqService
- add CapacityProvider and hook into RuleEngine

## Testing
- `vendor/bin/phpcs src/Infra/DbAbstraction.php src/Notifications/DlqRepository.php src/Allocation/CapacityProvider.php src/Services/CircuitBreaker.php src/Services/DlqService.php src/RuleEngine/RuleEngineService.php tests/Notifications/DlqRepositoryTest.php`
- `vendor/bin/phpunit` *(fails: Debug bundle not exercised, GF not available)*

------
https://chatgpt.com/codex/tasks/task_e_68b430adc4c08321bcde187f64ee2129