### PR TITLE
feat(phase): add phase management system

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,8 @@ jobs:
           scripts/evaluate_scores.sh
       - name: CI 5D Gates
         run: bash scripts/ci/ensure_ci_thresholds.sh
+      - name: 🔍 Check phase transition
+        run: bash scripts/check_phase_transition.sh
       - name: 🔄 Update project state
         run: make state
       - name: 🚀 Commit state files
@@ -147,6 +149,8 @@ jobs:
           scripts/evaluate_scores.sh
       - name: CI 5D Gates
         run: bash scripts/ci/ensure_ci_thresholds.sh
+      - name: 🔍 Check phase transition
+        run: bash scripts/check_phase_transition.sh
       - name: 🔄 Update project state
         run: make state
       - name: 🚀 Commit state files

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1,4 +1,5 @@
 # Feature Status Dashboard
+Current Phase: foundation
 
 ## 📊 Current Project Score: 110/125 (88%)
 

--- a/ai_config/project_phases.yml
+++ b/ai_config/project_phases.yml
@@ -1,0 +1,11 @@
+current: foundation
+phases:
+  foundation:
+    next: expansion
+    min_weighted_percent: 85
+  expansion:
+    next: polish
+    min_weighted_percent: 90
+  polish:
+    next: null
+    min_weighted_percent: 95

--- a/ai_context.json
+++ b/ai_context.json
@@ -15,7 +15,10 @@
   },
   "ci": {
     "remote_connected": true,
-    "workflows": ["ci.yml", "nightly.yml"]
+    "workflows": [
+      "ci.yml",
+      "nightly.yml"
+    ]
   },
   "gaps": [
     "Rule Engine lacks failure mode tests",
@@ -35,5 +38,6 @@
     "weighted_percent": 95.0,
     "red_flags": []
   },
-  "features": []
+  "features": [],
+  "project_phase": "foundation"
 }

--- a/docs/5d_scoring_rules.md
+++ b/docs/5d_scoring_rules.md
@@ -1,0 +1,7 @@
+# 5D Scoring Rules
+
+- **Security**: nonce use, prepared SQL, UTC time, typed exceptions (6.25 each).
+- **Logic**: edge cases, error handling, input validation heuristics.
+- **Performance**: fewer DB queries and presence of caching APIs.
+- **Readability**: PHPCS warnings and average cyclomatic complexity via PHPLOC.
+- **Goal**: source files and automated tests exist.

--- a/scripts/check_phase_transition.sh
+++ b/scripts/check_phase_transition.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+CID="$(uuidgen 2>/dev/null || date +%s)"
+PHASE_FILE="ai_config/project_phases.yml"
+FEATURES_MD="FEATURES.md"
+AI_CTX="ai_context.json"
+
+command -v jq >/dev/null 2>&1 || {
+  echo "{\"cid\":\"$CID\",\"level\":\"error\",\"msg\":\"jq required\"}" >&2
+  exit 1
+}
+
+PHASE=$(grep '^current:' "$PHASE_FILE" | awk '{print $2}')
+NEXT=$(grep -A2 "  $PHASE:" "$PHASE_FILE" | grep 'next:' | awk '{print $2}')
+MIN=$(grep -A2 "  $PHASE:" "$PHASE_FILE" | grep 'min_weighted_percent:' | awk '{print $2}')
+WGT=$(jq -r '.current_scores.weighted_percent' "$AI_CTX")
+WGT_INT=$(printf '%0.f' "$WGT")
+
+jq --arg phase "$PHASE" '.project_phase=$phase' "$AI_CTX" > "$AI_CTX.tmp" && mv "$AI_CTX.tmp" "$AI_CTX"
+if grep -q '^Current Phase:' "$FEATURES_MD"; then
+  sed -i "s/^Current Phase:.*/Current Phase: $PHASE/" "$FEATURES_MD"
+else
+  sed -i "2i Current Phase: $PHASE" "$FEATURES_MD"
+fi
+
+if [ "$WGT_INT" -ge "$MIN" ] && [ "$NEXT" != "null" ]; then
+  echo "{\"cid\":\"$CID\",\"level\":\"info\",\"msg\":\"ready for $NEXT\"}"
+else
+  echo "{\"cid\":\"$CID\",\"level\":\"info\",\"msg\":\"stay in $PHASE\"}"
+fi

--- a/scripts/update_state.sh
+++ b/scripts/update_state.sh
@@ -65,6 +65,13 @@ if [ -x "$phpcs_cmd" ]; then
   else READABILITY_SCORE=12; fi
 fi
 
+# cyclomatic complexity check with phploc
+if [ -x "$ROOT/vendor/bin/phploc" ]; then
+  "$ROOT/vendor/bin/phploc" --no-progress --log-json "$ROOT/.phploc.json" "$SRC_DIR" >/dev/null 2>&1 || true
+  ccn=$(jq -r '.avg.cyclomaticComplexity // 0' "$ROOT/.phploc.json" 2>/dev/null || echo 0)
+  if [ "$(printf '%0.f' "$ccn")" -gt 10 ]; then READABILITY_SCORE=$((READABILITY_SCORE-2)); fi
+fi
+
 # ---------- Goal Achievement (25 = 15 + 10) ----------
 req_score=0 integ_score=0
 [ -d "$SRC_DIR" ]   && [ "$(ls -A "$SRC_DIR" 2>/dev/null | wc -l)" -gt 0 ] && req_score=15

--- a/tests/Scoring/UpdateStateTest.php
+++ b/tests/Scoring/UpdateStateTest.php
@@ -1,0 +1,21 @@
+<?php
+// phpcs:ignoreFile
+
+declare(strict_types=1);
+
+use SmartAlloc\Tests\BaseTestCase;
+
+final class UpdateStateTest extends BaseTestCase
+{
+    public function test_phase_written_after_update(): void
+    {
+        $tmp = sys_get_temp_dir() . '/sa_state_' . uniqid();
+        mkdir($tmp);
+        exec('cp -R . ' . escapeshellarg($tmp) . ' >/dev/null 2>&1');
+        exec('cd ' . escapeshellarg($tmp) . ' && bash scripts/update_state.sh >/dev/null 2>&1');
+        exec('cd ' . escapeshellarg($tmp) . ' && bash scripts/check_phase_transition.sh >/dev/null 2>&1');
+        $ctx = json_decode(file_get_contents($tmp . '/ai_context.json'), true);
+        $this->assertSame('foundation', $ctx['project_phase']);
+        $this->assertStringContainsString('Current Phase: foundation', file_get_contents($tmp . '/FEATURES.md'));
+    }
+}


### PR DESCRIPTION
## Summary
- add phase configuration and transition check
- document scoring rules and current phase output
- include unit test for state update phase metadata

## Testing
- `vendor/bin/phpcs --standard=WordPress --runtime-set ignore_warnings_on_exit 1 tests/Scoring/UpdateStateTest.php`
- `vendor/bin/phpunit --coverage-xml=coverage.xml --coverage-php=coverage.dat tests/Scoring/UpdateStateTest.php`
- `bash -n scripts/sync_scorecards.sh`
- `bash -n scripts/check_phase_transition.sh`
- `php scripts/coverage-import.php`
- `php scripts/artifact-schema-validate.php`
- `php scripts/ga-enforcer.php --profile=rc --junit`
- `php -l tests/RuleEngine/FailureModesTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68b42fa41bdc8321b379f47807f7bf9d