### PR TITLE
feat(scripts): add phase report generator

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -15,7 +15,7 @@
 ### ✅ No Red Flags Detected
 
 ---
-Last Updated (UTC): 2025-08-31T13:02:06Z
+Last Updated (UTC): 2025-08-31T13:19:37Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -15,7 +15,7 @@
 ### ✅ No Red Flags Detected
 
 ---
-Last Updated (UTC): 2025-08-31T13:19:40Z
+Last Updated (UTC): 2025-08-31T13:19:42Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -15,7 +15,7 @@
 ### ✅ No Red Flags Detected
 
 ---
-Last Updated (UTC): 2025-08-31T13:19:37Z
+Last Updated (UTC): 2025-08-31T13:19:40Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,10 +1,10 @@
 {
-  "last_update_utc": "2025-08-31T13:02:06Z",
+  "last_update_utc": "2025-08-31T13:19:37Z",
   "repo": {
-    "default_branch": "main",
-    "last_commit": "57319f6e20bd4c846bb20f06a5cdf70da2d600f7",
-    "commits_total": 572,
-    "files_tracked": 650
+    "default_branch": "codex/create-script-to-generate-phase-report",
+    "last_commit": "efdb28520295ba26cd964d844b2ac7d9b01709f7",
+    "commits_total": 574,
+    "files_tracked": 651
   },
   "quality_gate": {
     "weighted_threshold": 0.85,

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-08-31T13:19:37Z",
+  "last_update_utc": "2025-08-31T13:19:40Z",
   "repo": {
     "default_branch": "codex/create-script-to-generate-phase-report",
-    "last_commit": "efdb28520295ba26cd964d844b2ac7d9b01709f7",
-    "commits_total": 574,
+    "last_commit": "1f4fe2c9d503426be75670cb5a7c5458bceb20cc",
+    "commits_total": 575,
     "files_tracked": 651
   },
   "quality_gate": {

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-08-31T13:19:40Z",
+  "last_update_utc": "2025-08-31T13:19:42Z",
   "repo": {
     "default_branch": "codex/create-script-to-generate-phase-report",
-    "last_commit": "1f4fe2c9d503426be75670cb5a7c5458bceb20cc",
-    "commits_total": 575,
+    "last_commit": "9745838cd4d36db0671b678c3e0bf37e62281912",
+    "commits_total": 576,
     "files_tracked": 651
   },
   "quality_gate": {

--- a/scripts/generate_phase_report.sh
+++ b/scripts/generate_phase_report.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+JSON_FILE="ai_context.json"
+PHASES_FILE="ai_config/project_phases.yml"
+TEMPLATE_FILE="ai_outputs/phase_transition_template.md"
+OUTPUT_FILE="phase_report.md"
+
+# Validate JSON structure
+jq empty "$JSON_FILE"
+
+ruby - "$JSON_FILE" "$PHASES_FILE" "$TEMPLATE_FILE" "$OUTPUT_FILE" <<'RUBY'
+require 'json'
+require 'yaml'
+
+json_file, phases_file, template_file, output_file = ARGV
+context = JSON.parse(File.read(json_file))
+phases = YAML.load_file(phases_file)['phases']
+template = File.read(template_file)
+
+scores = context['current_scores'] || {}
+features = (context['features'] || []).reduce({}) { |h,f| h.merge(f) }
+
+current_phase = nil
+next_phase = nil
+
+phases.each do |name, data|
+  req = data['requirements'] || {}
+  min_scores = req['min_scores'] || {}
+  feat_req = req['features_required'] || []
+  ok_scores = min_scores.all? { |k,v| (scores[k] || 0) >= v }
+  ok_features = feat_req.all? { |f| k,v = f.first; features[k] == v }
+  unless ok_scores && ok_features
+    current_phase = name
+    next_phase = data['next_phase']
+    break
+  end
+end
+current_phase ||= phases.keys.last
+next_phase ||= nil
+
+req = phases[current_phase]['requirements']
+min_scores = req['min_scores'] || {}
+feat_req = req['features_required'] || []
+
+score_lines = %w[security logic performance readability goal].map do |dim|
+  cur = scores[dim] || 0
+  reqd = min_scores[dim] || 0
+  check = cur >= reqd ? '✅' : '❌'
+  "| #{dim.capitalize} | #{cur} | #{reqd} | #{check} |"
+end
+
+feature_lines = if feat_req.empty?
+  ["| No feature requirements | | |"]
+else
+  feat_req.map do |f|
+    k,v = f.first
+    cur = features[k] || 'missing'
+    check = cur == v ? '✅' : '❌'
+    "| #{k} | #{cur} | #{v} | #{check} |"
+  end
+end
+feature_table = ["| Feature | Current | Required | Status |", "|---------|---------|----------|--------|", *feature_lines].join("\n")
+
+blockers = []
+min_scores.each { |k,v| blockers << "#{k} below requirement" if (scores[k] || 0) < v }
+feat_req.each { |f| k,v = f.first; blockers << "#{k} not #{v}" unless features[k] == v }
+blocker_list = blockers.empty? ? "None" : blockers.map { |b| "- #{b}" }.join("\n")
+status = blockers.empty? ? 'READY' : 'BLOCKED'
+
+actions = context['next_actions'] || []
+action1 = actions[0] || 'TBD'
+action2 = actions[1] || 'TBD'
+
+report = template
+report = report.gsub('{{DATE}}', context['last_update_utc'])
+report = report.gsub('{{CURRENT_PHASE}}', current_phase)
+report = report.gsub('{{NEXT_PHASE}}', next_phase.to_s)
+report = report.gsub('{{READY|BLOCKED}}', status)
+report = report.sub('| Security | {{X}} | {{Y}} | {{✅/❌}} |', score_lines[0])
+report = report.sub('| Logic | {{X}} | {{Y}} | {{✅/❌}} |', score_lines[1])
+report = report.sub('| Performance | {{X}} | {{Y}} | {{✅/❌}} |', score_lines[2])
+report = report.sub('| Readability | {{X}} | {{Y}} | {{✅/❌}} |', score_lines[3])
+report = report.sub('| Goal | {{X}} | {{Y}} | {{✅/❌}} |', score_lines[4])
+report = report.gsub('{{FEATURE_CHECK_TABLE}}', feature_table)
+report = report.gsub('{{LIST_OF_BLOCKERS}}', blocker_list)
+report = report.gsub('{{ACTION_1}}', action1)
+report = report.gsub('{{ACTION_2}}', action2)
+
+File.write(output_file, report)
+RUBY
+
+echo "Report written to $OUTPUT_FILE"


### PR DESCRIPTION
## Summary
- add script to generate phase transition report from JSON/YAML data

## Testing
- `~/.local/share/mise/installs/php/8.4.11/.composer/vendor/bin/phpcs -d memory_limit=1G --standard=WordPress --runtime-set ignore_warnings_on_exit 1 scripts/generate_phase_report.sh`
- `./vendor/bin/phpunit --coverage-xml=coverage.xml --coverage-php=coverage.dat` (errors: 2, skipped: 9, incomplete: 2)
- `bash -n scripts/sync_scorecards.sh`
- `php -l tests/RuleEngine/FailureModesTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68b44a83b5908321ad63930d82b1a5ae