### PR TITLE
ci: install jq for phase check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,6 +188,11 @@ jobs:
           wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
           chmod +x /usr/local/bin/yq
 
+      - name: Install jq
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq
+
       - name: Check Phase Transition Readiness
         run: |
           ./scripts/check_phase_transition.sh

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -15,7 +15,7 @@
 ### ✅ No Red Flags Detected
 
 ---
-Last Updated (UTC): 2025-08-31T13:22:22Z
+Last Updated (UTC): 2025-08-31T13:22:24Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -15,7 +15,7 @@
 ### ✅ No Red Flags Detected
 
 ---
-Last Updated (UTC): 2025-08-31T13:19:55Z
+Last Updated (UTC): 2025-08-31T13:22:22Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-08-31T13:22:23Z",
+  "last_update_utc": "2025-08-31T13:22:24Z",
   "repo": {
     "default_branch": "codex/add-step-to-install-jq-before-script",
-    "last_commit": "afb3f54892c89ce42a8b54a82474f1c7fd1e72d4",
-    "commits_total": 580,
+    "last_commit": "db4b258d59232831493093bf0e9bedc2aad4b26e",
+    "commits_total": 581,
     "files_tracked": 651
   },
   "quality_gate": {

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-08-31T13:19:55Z",
+  "last_update_utc": "2025-08-31T13:22:23Z",
   "repo": {
-    "default_branch": "main",
-    "last_commit": "a7e6f1282f872ee08c281500d1c492dfed4f0490",
-    "commits_total": 578,
+    "default_branch": "codex/add-step-to-install-jq-before-script",
+    "last_commit": "afb3f54892c89ce42a8b54a82474f1c7fd1e72d4",
+    "commits_total": 580,
     "files_tracked": 651
   },
   "quality_gate": {


### PR DESCRIPTION
## Summary
- install jq via apt in phase-check job before running check_phase_transition.sh

## Testing
- `./scripts/check_phase_transition.sh || true`


------
https://chatgpt.com/codex/tasks/task_e_68b44bfac6a883219b77b75e7758e0cb