### PR TITLE
feat(score): derive security and logic scores from PHPStan

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -15,7 +15,7 @@
 ### ✅ No Red Flags Detected
 
 ---
-Last Updated (UTC): 2025-09-01T00:29:19Z
+Last Updated (UTC): 2025-09-01T00:47:14Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -15,7 +15,7 @@
 ### ✅ No Red Flags Detected
 
 ---
-Last Updated (UTC): 2025-09-01T00:47:16Z
+Last Updated (UTC): 2025-09-01T00:47:22Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -15,7 +15,7 @@
 ### ✅ No Red Flags Detected
 
 ---
-Last Updated (UTC): 2025-09-01T00:47:14Z
+Last Updated (UTC): 2025-09-01T00:47:16Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-01T00:47:15Z",
+  "last_update_utc": "2025-09-01T00:47:16Z",
   "repo": {
     "default_branch": "codex/replace-grep-with-static-analysis-tool",
-    "last_commit": "ddd53ce3d6a057f7465f9f7fce0bebc4ceaaf5cf",
-    "commits_total": 609,
+    "last_commit": "c5dcbe2dceacd98a6cedb4981473879a8ab687f7",
+    "commits_total": 610,
     "files_tracked": 653
   },
   "quality_gate": {

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-01T00:47:16Z",
+  "last_update_utc": "2025-09-01T00:47:22Z",
   "repo": {
     "default_branch": "codex/replace-grep-with-static-analysis-tool",
-    "last_commit": "c5dcbe2dceacd98a6cedb4981473879a8ab687f7",
-    "commits_total": 610,
+    "last_commit": "849a328754be8e99b90a116b22bfb1fd898fda73",
+    "commits_total": 611,
     "files_tracked": 653
   },
   "quality_gate": {

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-01T00:29:19Z",
+  "last_update_utc": "2025-09-01T00:47:15Z",
   "repo": {
-    "default_branch": "main",
-    "last_commit": "ee8722c5858de7cc39da49ca4046a44a73b407ba",
-    "commits_total": 607,
+    "default_branch": "codex/replace-grep-with-static-analysis-tool",
+    "last_commit": "ddd53ce3d6a057f7465f9f7fce0bebc4ceaaf5cf",
+    "commits_total": 609,
     "files_tracked": 653
   },
   "quality_gate": {

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
     "phpcsstandards/phpcsextra": "^1.2",
     "phpcsstandards/phpcsutils": "^1.0",
     "sirbrillig/phpcs-variable-analysis": "^2.11",
+    "phpstan/phpstan": "^1.11",
     "vimeo/psalm": "^5.18",
     "php-stubs/wordpress-stubs": "^6.6",
     "giorgiosironi/eris": "^1.0"

--- a/tests/Scripts/UpdateStateStaticAnalysisTest.php
+++ b/tests/Scripts/UpdateStateStaticAnalysisTest.php
@@ -36,14 +36,19 @@ return $data['current_scores'];
 }
 
 public function test_scores_with_clean_code(): void {
-$scores = $this->runScript('<?php function ok(): int { return 1; }');
-$this->assertSame(25, $scores['security']);
-$this->assertSame(25, $scores['logic']);
+    $scores = $this->runScript('<?php function ok(): int { return 1; }');
+    $this->assertSame(25, $scores['security']);
+    $this->assertSame(25, $scores['logic']);
 }
 
-public function test_scores_with_errors(): void {
-$scores = $this->runScript('<?php function bad(: int { }');
-$this->assertLessThan(25, $scores['security']);
-$this->assertLessThan(25, $scores['logic']);
+public function test_scores_reflect_error_counts(): void {
+    $oneError = $this->runScript('<?php foo();');
+    $twoErrors = $this->runScript('<?php foo(); bar();');
+    $this->assertSame(20, $oneError['security']);
+    $this->assertSame(20, $oneError['logic']);
+    $this->assertSame(15, $twoErrors['security']);
+    $this->assertSame(15, $twoErrors['logic']);
+    $this->assertGreaterThan($twoErrors['security'], $oneError['security']);
+    $this->assertGreaterThan($twoErrors['logic'], $oneError['logic']);
 }
 }


### PR DESCRIPTION
## Summary
- replace custom parser with PHPStan for security/logic scoring
- adjust scoring to count PHPStan errors
- add unit test covering score changes for varying error counts

## Testing
- `php -l tests/RuleEngine/FailureModesTest.php`
- `bash -n scripts/sync_scorecards.sh`
- `vendor/bin/phpunit --coverage-xml=coverage.xml --coverage-php=coverage.dat`
- `vendor/bin/phpcs --standard=WordPress --runtime-set ignore_warnings_on_exit 1 .` *(fails: memory limit exhausted)*

------
https://chatgpt.com/codex/tasks/task_e_68b4e9fb03148321b4b514eff4e74762