### PR TITLE
ci: sync features into ai_context at workflow start

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,8 @@ jobs:
           set -euo pipefail
           test -s ai_context.json || echo '{"decisions":[]}' > ai_context.json
           jq empty ai_context.json
+      - name: 🔄 Sync AI context features
+        run: php scripts/sync-features-to-ai-context.php
       - name: 📥 Install dependencies
         run: composer install --no-interaction --prefer-dist --no-progress
       - name: Install Playwright deps
@@ -132,6 +134,8 @@ jobs:
           set -euo pipefail
           test -s ai_context.json || echo '{"decisions":[]}' > ai_context.json
           jq empty ai_context.json
+      - name: 🔄 Sync AI context features
+        run: php scripts/sync-features-to-ai-context.php
       - name: 📥 Install dependencies
         run: composer install --no-interaction --prefer-dist --no-progress
       - name: Install Playwright deps

--- a/docs/SCORING.md
+++ b/docs/SCORING.md
@@ -4,3 +4,7 @@
 - Red Flags: direct superglobals, raw SQL without prepare
 - Total: /125, plus Weighted %
 - Outputs: `FEATURES.md` + `ai_context.json.current_scores`
+
+## Feature Status Sync
+
+`features.json` tracks the status of all features. At the start of CI, `scripts/sync-features-to-ai-context.php` copies these statuses into `ai_context.json` so scoring uses the latest data. The script tolerates an empty `features` array, and tests simulate this scenario to ensure synchronization remains accurate.

--- a/tests/Scripts/AiContextFeaturesSyncTest.php
+++ b/tests/Scripts/AiContextFeaturesSyncTest.php
@@ -29,4 +29,31 @@ final class AiContextFeaturesSyncTest extends BaseTestCase
         $synced = json_decode(file_get_contents($contextPath), true);
         $this->assertSame('red', $synced['features']['DB Safety']);
     }
+
+    public function test_handles_empty_features_array(): void
+    {
+        $tmp = sys_get_temp_dir() . '/sa_feat_sync_' . uniqid();
+        mkdir($tmp);
+        exec('cp -R . ' . escapeshellarg($tmp) . ' >/dev/null 2>&1');
+
+        $featuresPath = $tmp . '/features.json';
+        $contextPath  = $tmp . '/ai_context.json';
+
+        file_put_contents(
+            $featuresPath,
+            json_encode(['features' => []], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)
+        );
+
+        $context = json_decode(file_get_contents($contextPath), true);
+        $context['features'] = ['Legacy' => 'green'];
+        file_put_contents(
+            $contextPath,
+            json_encode($context, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)
+        );
+
+        exec('cd ' . escapeshellarg($tmp) . ' && php scripts/sync-features-to-ai-context.php >/dev/null 2>&1');
+
+        $synced = json_decode(file_get_contents($contextPath), true);
+        $this->assertSame([], $synced['features']);
+    }
 }


### PR DESCRIPTION
## Summary
- sync features into ai_context.json early in CI workflows
- cover empty feature list in sync script test
- document feature sync in scoring guide

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68b4ed2ce33083219972f852c173019b