### PR TITLE
feat(perf): add Stopwatch scenario scoring (p95 test)

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -8,6 +8,8 @@
 - SMARTALLOC_PERF_ENABLE_CACHE=0|1
 - SMARTALLOC_PERF_ENABLE_BATCH=0|1
 
+`scripts/update_state.sh` runs a Stopwatch scenario and deducts points when `SMARTALLOC_BUDGET_ALLOC_1K_MS` is exceeded.
+
 ## Run
 composer dump-autoload -o
 SMARTALLOC_TESTS=1 vendor/bin/phpunit --testsuite Performance

--- a/scripts/stopwatch_eval.php
+++ b/scripts/stopwatch_eval.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use SmartAlloc\Perf\Stopwatch;
+
+$target = $argv[1] ?? '';
+if (!is_file($target)) {
+    fwrite(STDERR, "scenario not found\n");
+    exit(1);
+}
+
+$result = Stopwatch::measure(fn() => require $target);
+
+echo $result->durationMs;

--- a/tests/Scripts/UpdateStatePerformanceTest.php
+++ b/tests/Scripts/UpdateStatePerformanceTest.php
@@ -1,0 +1,46 @@
+<?php
+// phpcs:ignoreFile
+
+declare(strict_types=1);
+
+use SmartAlloc\Tests\BaseTestCase;
+
+final class UpdateStatePerformanceTest extends BaseTestCase {
+    private string $script = __DIR__ . '/../../scripts/update_state.sh';
+
+    /**
+     * Run update_state.sh with a performance scenario.
+     *
+     * @param string $scenario PHP code to execute.
+     * @param int $budgetMs Time budget in milliseconds.
+     * @return array Parsed current_scores from ai_context.json.
+     */
+    private function runScript(string $scenario, int $budgetMs): array {
+        $dir = sys_get_temp_dir() . '/sa_perf_' . uniqid();
+        mkdir($dir);
+        $scenarioFile = $dir . '/scenario.php';
+        file_put_contents($scenarioFile, $scenario);
+
+        $ai = $dir . '/ai_context.json';
+        $cmd = sprintf(
+            'SRC_DIR=%s TESTS_DIR=%s AI_CTX=%s FEATURES_MD=%s PERF_SCENARIO=%s SMARTALLOC_BUDGET_ALLOC_1K_MS=%d bash %s >/dev/null 2>&1',
+            escapeshellarg($dir),
+            escapeshellarg($dir),
+            escapeshellarg($ai),
+            escapeshellarg($dir . '/FEATURES.md'),
+            escapeshellarg($scenarioFile),
+            $budgetMs,
+            escapeshellarg($this->script)
+        );
+        exec($cmd);
+        $data = json_decode(file_get_contents($ai), true);
+        array_map('unlink', glob($dir . '/*'));
+        rmdir($dir);
+        return $data['current_scores'];
+    }
+
+    public function test_perf_score_penalized_when_budget_exceeded(): void {
+        $scores = $this->runScript('<?php usleep(50000);', 10);
+        $this->assertLessThan(10, $scores['performance']);
+    }
+}


### PR DESCRIPTION
## Summary
- extend update_state.sh performance scoring with Stopwatch-based scenario timing
- document budget-driven deductions in performance.md
- verify timing penalty via UpdateStatePerformanceTest

## Testing
- `vendor/bin/phpcs -d memory_limit=512M --standard=WordPress --runtime-set ignore_warnings_on_exit 1 src tests scripts` *(fails: Expected 1 spaces before closing parenthesis; file operations should use WP_Filesystem methods)*
- `vendor/bin/phpunit tests/Scripts/UpdateStateStaticAnalysisTest.php tests/Scripts/UpdateStatePerformanceTest.php`
- `bash -n scripts/sync_scorecards.sh`
- `php -l tests/RuleEngine/FailureModesTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68b4eeba3284832195507705298f5267