### PR TITLE
feat(ci): enforce score thresholds

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -15,7 +15,7 @@
 ### ✅ No Red Flags Detected
 
 ---
-Last Updated (UTC): 2025-09-01T01:17:33Z
+Last Updated (UTC): 2025-09-01T01:17:36Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -15,7 +15,7 @@
 ### ✅ No Red Flags Detected
 
 ---
-Last Updated (UTC): 2025-09-01T01:17:36Z
+Last Updated (UTC): 2025-09-01T01:17:41Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -15,7 +15,7 @@
 ### ✅ No Red Flags Detected
 
 ---
-Last Updated (UTC): 2025-09-01T01:05:02Z
+Last Updated (UTC): 2025-09-01T01:17:33Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,10 +1,10 @@
 {
-  "last_update_utc": "2025-09-01T01:05:02Z",
+  "last_update_utc": "2025-09-01T01:17:34Z",
   "repo": {
-    "default_branch": "main",
-    "last_commit": "a1196d4ae87b82802116efebaadd09b60ab92711",
-    "commits_total": 631,
-    "files_tracked": 656
+    "default_branch": "codex/read-dimensions-from-ai_context.json",
+    "last_commit": "00144ccf5db23a23131f816632c26d1892ec74fa",
+    "commits_total": 633,
+    "files_tracked": 657
   },
   "quality_gate": {
     "weighted_threshold": 0.85,

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-01T01:17:34Z",
+  "last_update_utc": "2025-09-01T01:17:36Z",
   "repo": {
     "default_branch": "codex/read-dimensions-from-ai_context.json",
-    "last_commit": "00144ccf5db23a23131f816632c26d1892ec74fa",
-    "commits_total": 633,
+    "last_commit": "ff9b332c59e69b0ee66e6e712baf71bf5fd306f1",
+    "commits_total": 634,
     "files_tracked": 657
   },
   "quality_gate": {

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-01T01:17:36Z",
+  "last_update_utc": "2025-09-01T01:17:41Z",
   "repo": {
     "default_branch": "codex/read-dimensions-from-ai_context.json",
-    "last_commit": "ff9b332c59e69b0ee66e6e712baf71bf5fd306f1",
-    "commits_total": 634,
+    "last_commit": "b4d65a6369a17bdd376780f11a33c2c5706160b1",
+    "commits_total": 635,
     "files_tracked": 657
   },
   "quality_gate": {

--- a/scripts/evaluate_scores.sh
+++ b/scripts/evaluate_scores.sh
@@ -5,16 +5,33 @@ test -s "$AI_CTX" || echo '{"decisions":[]}' > "$AI_CTX"
 jq empty "$AI_CTX"
 SEC="$(jq -r '.current_scores.security // 0' "$AI_CTX")"
 WGT="$(jq -r '.current_scores.weighted_percent // 0' "$AI_CTX")"
+LOGIC="$(jq -r '.current_scores.logic // 0' "$AI_CTX")"
+PERF="$(jq -r '.current_scores.performance // 0' "$AI_CTX")"
+READ="$(jq -r '.current_scores.readability // 0' "$AI_CTX")"
+GOAL="$(jq -r '.current_scores.goal // 0' "$AI_CTX")"
 PHPCS_JSON="$(vendor/bin/phpcs --standard=WordPress --extensions=php src tests --report=json 2>/dev/null || true)"
 PHPCS_FAILS="$(jq -r '.totals.errors + .totals.warnings' <<<"$PHPCS_JSON" 2>/dev/null || echo 0)"
 tmp="$AI_CTX.tmp"
 jq --argjson phpcs "$PHPCS_FAILS" '.phpcs_errors=$phpcs' "$AI_CTX" > "$tmp" && mv "$tmp" "$AI_CTX"
 TEST_FAILS="${TEST_FAILS:-0}"
-if (( $(printf '%.0f' "$SEC") < 20 )) || (( $(printf '%.0f' "$WGT") < 85 )); then
+LOGIC_MIN="${LOGIC_MIN:-0}"
+PERFORMANCE_MIN="${PERFORMANCE_MIN:-0}"
+READABILITY_MIN="${READABILITY_MIN:-0}"
+GOAL_MIN="${GOAL_MIN:-0}"
+if (( $(printf '%.0f' "$SEC") < 20 )) || \
+   (( $(printf '%.0f' "$WGT") < 85 )) || \
+   (( $(printf '%.0f' "$LOGIC") < LOGIC_MIN )) || \
+   (( $(printf '%.0f' "$PERF") < PERFORMANCE_MIN )) || \
+   (( $(printf '%.0f' "$READ") < READABILITY_MIN )) || \
+   (( $(printf '%.0f' "$GOAL") < GOAL_MIN )); then
   jq -n --argjson sec "${SEC:-0}" \
         --argjson phpcs "${PHPCS_FAILS:-0}" \
         --argjson tests "${TEST_FAILS:-0}" \
-        '{ci_failure:{security_score:$sec, phpcs_errors:$phpcs, test_failures:$tests}}' \
+        --argjson logic "${LOGIC:-0}" \
+        --argjson perf "${PERF:-0}" \
+        --argjson read "${READ:-0}" \
+        --argjson goal "${GOAL:-0}" \
+        '{ci_failure:{security_score:$sec, phpcs_errors:$phpcs, test_failures:$tests, logic_score:$logic, performance_score:$perf, readability_score:$read, goal_score:$goal}}' \
   > .ci_failure.tmp
   # merge into ai_context.json (non-destructive)
   jq -s '.[0] * .[1]' "$AI_CTX" .ci_failure.tmp > ai_context.tmp && mv ai_context.tmp "$AI_CTX"

--- a/tests/Scripts/EvaluateScoresTest.php
+++ b/tests/Scripts/EvaluateScoresTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SmartAlloc\Tests\Scripts;
+
+use SmartAlloc\Tests\BaseTestCase;
+
+final class EvaluateScoresTest extends BaseTestCase
+{
+    /**
+     * @dataProvider dimensionProvider
+     */
+    public function test_ci_failure_when_dimension_below_threshold(string $dimension, string $envVar): void
+    {
+        $tmp = sys_get_temp_dir() . '/sa_eval_' . uniqid();
+        mkdir($tmp, 0777, true);
+        $root = dirname(__DIR__, 2);
+        symlink($root . '/vendor', $tmp . '/vendor');
+        symlink($root . '/src', $tmp . '/src');
+        symlink($root . '/tests', $tmp . '/tests');
+        $context = [
+            'current_scores' => [
+                'security' => 25,
+                'logic' => 25,
+                'performance' => 25,
+                'readability' => 25,
+                'goal' => 25,
+                'weighted_percent' => 95.0,
+            ],
+        ];
+        $context['current_scores'][$dimension] = 10;
+        file_put_contents($tmp . '/ai_context.json', json_encode($context));
+        $cwd = getcwd();
+        chdir($tmp);
+        putenv($envVar . '=20');
+        exec('bash ' . escapeshellarg($root . '/scripts/evaluate_scores.sh'), $o, $s);
+        exec('bash ' . escapeshellarg($root . '/scripts/fail_on_ci_failure.sh'), $o2, $s2);
+        chdir($cwd);
+
+        $this->assertSame(0, $s);
+        $this->assertSame(1, $s2);
+    }
+
+    public function dimensionProvider(): array
+    {
+        return [
+            ['logic', 'LOGIC_MIN'],
+            ['performance', 'PERFORMANCE_MIN'],
+            ['readability', 'READABILITY_MIN'],
+            ['goal', 'GOAL_MIN'],
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- read 5D scores from ai_context.json and gate via environment thresholds
- add test ensuring evaluate_scores marks ci_failure when any threshold is unmet

## Testing
- `vendor/bin/phpcs --standard=WordPress --extensions=php tests/Scripts/EvaluateScoresTest.php`
- `vendor/bin/phpunit tests/Scripts/EvaluateScoresTest.php`
- `bash -n scripts/sync_scorecards.sh`
- `php -l tests/RuleEngine/FailureModesTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68b4f1418f748321ac02549d2c4ae0b5