### PR TITLE
feat(perf): log Stopwatch timings to scorecards

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1,39 +1,18 @@
 # Feature Status Dashboard
 
-## 📊 Current Project Score: 110/125 (88%)
+## 📊 Current Project Score: 105/125 (84%)
 
 ### **📊 Detailed Validation Score**
 🔒 **Security Score**: 25.00/25
 🧠 **Logic Score**: 25.00/25
-⚡ **Performance Score**: 25.00/25
+⚡ **Performance Score**: 20.00/25 (budget 2500ms, actual 3000ms, penalty -5)
 📖 **Readability Score**: 20.00/25
 🎯 **Goal Achievement**: 25.00/25
 
-**🏆 Total Score**: 110/125
-**📈 Weighted Average**: 97.00%
+**🏆 Total Score**: 105/125
+**📈 Weighted Average**: 95.00%
 
 ### ✅ No Red Flags Detected
 
 ---
-Last Updated (UTC): 2025-09-01T03:45:49Z
-
-<!-- AUTO-GEN:RAG START -->
-| Feature | Status | Notes |
-| --- | --- | --- |
-| DB Safety | 🟢 Green | All queries DbSafe::mustPrepare |
-| Logging | 🟢 Green | Structured Monolog |
-| Exporter | 🟢 Green | Export endpoints live |
-| Gravity Forms | 🟢 Green | Bridge deployed |
-| Allocation Core | 🟢 Green | Stable allocations |
-| Rule Engine | 🟡 Amber | Edge-case handling pending |
-| Notifications | 🟡 Amber | Delivery flow partial |
-| Circuit Breaker | 🔴 Red | Not started |
-| Observability | 🟢 Green | Metrics & tracing enabled |
-| Performance Budgets | 🔴 Red | Not started |
-| CI/CD | 🟢 Green | 5D gate with AUTO-FIX loop |
-| rule-engine-reliability-gates | 🟡 Amber |  |
-| rag-template-automation | 🟡 Amber |  |
-| DLQ replay action and perf budget tests | ⚪ Unknown | Added retry-based mailer, admin DLQ replay action, circuit breaker protection, and performance budget test. |
-
-_Last Updated (UTC): 2025-09-01_
-<!-- AUTO-GEN:RAG END -->
+Last Updated (UTC): 2025-09-01T03:54:21Z

--- a/ai_context.json
+++ b/ai_context.json
@@ -15,7 +15,10 @@
   },
   "ci": {
     "remote_connected": true,
-    "workflows": ["ci.yml", "nightly.yml"]
+    "workflows": [
+      "ci.yml",
+      "nightly.yml"
+    ]
   },
   "gaps": [
     "Rule Engine lacks failure mode tests",
@@ -29,11 +32,18 @@
   "current_scores": {
     "security": 25,
     "logic": 25,
-    "performance": 25,
-    "readability": 15,
-    "goal": 20,
-    "weighted_percent": 95.0,
+    "performance": 20,
+    "readability": 20,
+    "goal": 25,
+    "total": 105,
+    "weighted_percent": 95.00,
     "red_flags": []
   },
-  "features": []
+  "features": [],
+  "perf_timing": {
+    "duration_ms": 3000.215571,
+    "budget_ms": 2500,
+    "penalized": true
+  },
+  "last_updated_utc": "2025-09-01T03:54:21Z"
 }

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -9,6 +9,7 @@
 - SMARTALLOC_PERF_ENABLE_BATCH=0|1
 
 `scripts/update_state.sh` runs a Stopwatch scenario and deducts points when `SMARTALLOC_BUDGET_ALLOC_1K_MS` is exceeded.
+The measured duration and any penalty are written to `ai_context.json` and the performance line in `FEATURES.md`.
 
 ## Run
 composer dump-autoload -o

--- a/scripts/stopwatch_eval.php
+++ b/scripts/stopwatch_eval.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-require __DIR__ . '/../vendor/autoload.php';
+require __DIR__ . '/../src/Perf/Stopwatch.php';
 
 use SmartAlloc\Perf\Stopwatch;
 

--- a/tests/Scripts/UpdateStatePerformanceTest.php
+++ b/tests/Scripts/UpdateStatePerformanceTest.php
@@ -13,7 +13,7 @@ final class UpdateStatePerformanceTest extends BaseTestCase {
      *
      * @param string $scenario PHP code to execute.
      * @param int $budgetMs Time budget in milliseconds.
-     * @return array Parsed current_scores from ai_context.json.
+     * @return array{scores:array,timing:array,features:string}
      */
     private function runScript(string $scenario, int $budgetMs): array {
         $dir = sys_get_temp_dir() . '/sa_perf_' . uniqid();
@@ -22,25 +22,33 @@ final class UpdateStatePerformanceTest extends BaseTestCase {
         file_put_contents($scenarioFile, $scenario);
 
         $ai = $dir . '/ai_context.json';
+        $featuresFile = $dir . '/FEATURES.md';
         $cmd = sprintf(
             'SRC_DIR=%s TESTS_DIR=%s AI_CTX=%s FEATURES_MD=%s PERF_SCENARIO=%s SMARTALLOC_BUDGET_ALLOC_1K_MS=%d bash %s >/dev/null 2>&1',
             escapeshellarg($dir),
             escapeshellarg($dir),
             escapeshellarg($ai),
-            escapeshellarg($dir . '/FEATURES.md'),
+            escapeshellarg($featuresFile),
             escapeshellarg($scenarioFile),
             $budgetMs,
             escapeshellarg($this->script)
         );
         exec($cmd);
         $data = json_decode(file_get_contents($ai), true);
+        $features = file_get_contents($featuresFile);
         array_map('unlink', glob($dir . '/*'));
         rmdir($dir);
-        return $data['current_scores'];
+        return [
+            'scores' => $data['current_scores'],
+            'timing' => $data['perf_timing'],
+            'features' => $features,
+        ];
     }
 
     public function test_perf_score_penalized_when_budget_exceeded(): void {
-        $scores = $this->runScript('<?php usleep(50000);', 10);
-        $this->assertLessThan(10, $scores['performance']);
+        $res = $this->runScript('<?php usleep(50000);', 10);
+        $this->assertLessThan(10, $res['scores']['performance']);
+        $this->assertTrue($res['timing']['penalized']);
+        $this->assertStringContainsString('penalty', $res['features']);
     }
 }


### PR DESCRIPTION
## Summary
- log Stopwatch scenario duration and budget in update_state scoring script
- document performance logging and update ai_context/FEATURES outputs
- cover performance penalty via new test

## Testing
- `phpunit tests/Scripts/UpdateStatePerformanceTest.php`

------
https://chatgpt.com/codex/tasks/task_e_68b5185fe79c832191cf48d4cd2ec87b