### PR TITLE
chore(score): count phpstan errors for security and logic

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -15,7 +15,7 @@
 ### ✅ No Red Flags Detected
 
 ---
-Last Updated (UTC): 2025-09-01T03:58:17Z
+Last Updated (UTC): 2025-09-01T04:06:46Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -15,7 +15,7 @@
 ### ✅ No Red Flags Detected
 
 ---
-Last Updated (UTC): 2025-09-01T04:06:46Z
+Last Updated (UTC): 2025-09-01T04:06:50Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-01T03:58:17Z",
+  "last_update_utc": "2025-09-01T04:06:46Z",
   "repo": {
-    "default_branch": "main",
-    "last_commit": "4c4e71eb0ab59fea1d1c566d376928f6227f7717",
-    "commits_total": 642,
+    "default_branch": "codex/replace-text-searches-with-full-phpstan-output",
+    "last_commit": "65e7ac855452bdb21e9f8f371e95b1a6f2a545b1",
+    "commits_total": 644,
     "files_tracked": 657
   },
   "quality_gate": {

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-01T04:06:46Z",
+  "last_update_utc": "2025-09-01T04:06:50Z",
   "repo": {
     "default_branch": "codex/replace-text-searches-with-full-phpstan-output",
-    "last_commit": "65e7ac855452bdb21e9f8f371e95b1a6f2a545b1",
-    "commits_total": 644,
+    "last_commit": "8406e66376829e2d8390edfb5c179c7d36b7d360",
+    "commits_total": 645,
     "files_tracked": 657
   },
   "quality_gate": {

--- a/scripts/update_state.sh
+++ b/scripts/update_state.sh
@@ -33,7 +33,8 @@ if [ -x "$phpstan_cmd" ]; then
   set -e
   rm -f "$tmp_cfg"
 fi
-analysis_errors=$(echo "$analysis_json" | jq '.totals.file_errors // 0' 2>/dev/null || echo 0)
+# Count total static analysis errors instead of files with errors.
+analysis_errors=$(echo "$analysis_json" | jq '.totals.errors // 0' 2>/dev/null || echo 0)
 base_score=$((25 - analysis_errors*5))
 SECURITY_SCORE=$(score_part "$base_score" 25)
 LOGIC_SCORE=$(score_part "$base_score" 25)

--- a/tests/Scripts/UpdateStateStaticAnalysisTest.php
+++ b/tests/Scripts/UpdateStateStaticAnalysisTest.php
@@ -50,5 +50,6 @@ public function test_scores_reflect_error_counts(): void {
     $this->assertSame(15, $twoErrors['logic']);
     $this->assertGreaterThan($twoErrors['security'], $oneError['security']);
     $this->assertGreaterThan($twoErrors['logic'], $oneError['logic']);
+    $this->assertGreaterThan($twoErrors['total'], $oneError['total']);
 }
 }


### PR DESCRIPTION
## Summary
- use total PHPStan error count to grade security/logic
- assert score total changes when static analysis errors change

## Testing
- `vendor/bin/phpunit --coverage-xml=coverage.xml --coverage-php=coverage.dat`
- `bash -n scripts/sync_scorecards.sh`
- `php -l tests/RuleEngine/FailureModesTest.php`
- `vendor/bin/phpcs -d memory_limit=1G --standard=WordPress --runtime-set ignore_warnings_on_exit 1 .` *(fails: Allowed memory size exhausted)*

------
https://chatgpt.com/codex/tasks/task_e_68b519f29f64832192599069384d8e2b