### PR TITLE
ci(thresholds): sync features before score evaluation

### DIFF
--- a/docs/SCORING.md
+++ b/docs/SCORING.md
@@ -10,3 +10,4 @@
 `features.json` tracks the status of all features. At the start of CI, `scripts/sync-features-to-ai-context.php` copies these statuses into `ai_context.json` so scoring uses the latest data. The script tolerates an empty `features` array, and tests simulate this scenario to ensure synchronization remains accurate.
 
 `scripts/check_phase_transition.sh` now invokes the sync script before evaluating requirements. If `features.json` lacks entries, the phase transition check fails until synchronization populates the needed statuses.
+CI gates such as `scripts/ci/ensure_ci_thresholds.sh` also run the sync step to guarantee `ai_context.json` reflects current features before score evaluation.

--- a/scripts/ci/ensure_ci_thresholds.sh
+++ b/scripts/ci/ensure_ci_thresholds.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 AI_CTX="ai_context.json"
 if [ ! -s "$AI_CTX" ]; then echo '{"current_scores":{}}' > "$AI_CTX"; fi
+php scripts/sync-features-to-ai-context.php "features.json" "$AI_CTX" >/dev/null
 
 read_k() { jq -r "$1 // 0" "$AI_CTX" 2>/dev/null || echo 0; }
 SEC="$(read_k '.current_scores.security')"

--- a/tests/Scripts/CheckPhaseTransitionTest.php
+++ b/tests/Scripts/CheckPhaseTransitionTest.php
@@ -40,5 +40,7 @@ final class CheckPhaseTransitionTest extends BaseTestCase
 
         exec('cd ' . escapeshellarg($tmp) . ' && bash scripts/check_phase_transition.sh >/dev/null 2>&1', $out2, $code2);
         $this->assertSame(0, $code2);
+        $synced = json_decode(file_get_contents($contextPath), true);
+        $this->assertSame('implemented', $synced['features']['rule_engine']);
     }
 }


### PR DESCRIPTION
## Summary
- ensure `scripts/ci/ensure_ci_thresholds.sh` syncs feature statuses before reading scores
- assert phase transition test writes synced feature status
- document that CI gates execute feature-sync step early

## Testing
- `vendor/bin/phpcs --standard=WordPress --runtime-set ignore_warnings_on_exit 1 scripts/ci/ensure_ci_thresholds.sh tests/Scripts/CheckPhaseTransitionTest.php`
- `vendor/bin/phpunit --coverage-xml=coverage.xml --coverage-php=coverage.dat`
- `bash -n scripts/sync_scorecards.sh`
- `php -l tests/RuleEngine/FailureModesTest.php`

------
https://chatgpt.com/codex/tasks/task_e_68b51bf86318832191b6431a059bc3e0