### PR TITLE
feat(ci): enforce score thresholds via evaluate_scores

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -15,7 +15,7 @@
 ### ✅ No Red Flags Detected
 
 ---
-Last Updated (UTC): 2025-09-01T04:23:56Z
+Last Updated (UTC): 2025-09-01T04:24:00Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -15,7 +15,7 @@
 ### ✅ No Red Flags Detected
 
 ---
-Last Updated (UTC): 2025-09-01T04:17:44Z
+Last Updated (UTC): 2025-09-01T04:23:53Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -15,7 +15,7 @@
 ### ✅ No Red Flags Detected
 
 ---
-Last Updated (UTC): 2025-09-01T04:23:53Z
+Last Updated (UTC): 2025-09-01T04:23:56Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-01T04:23:53Z",
+  "last_update_utc": "2025-09-01T04:23:56Z",
   "repo": {
     "default_branch": "codex/extract-and-compare-thresholds-in-evaluate_scores.sh",
-    "last_commit": "a6a619076617c3000c0b3f93c9b46349b16a47bf",
-    "commits_total": 655,
+    "last_commit": "7c432c7763b70b70f2524ad05f4dd7c37c9877c1",
+    "commits_total": 656,
     "files_tracked": 657
   },
   "quality_gate": {

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-01T04:23:56Z",
+  "last_update_utc": "2025-09-01T04:24:00Z",
   "repo": {
     "default_branch": "codex/extract-and-compare-thresholds-in-evaluate_scores.sh",
-    "last_commit": "7c432c7763b70b70f2524ad05f4dd7c37c9877c1",
-    "commits_total": 656,
+    "last_commit": "531e486e7d2f9c43e1c088f691f8ff941061cf46",
+    "commits_total": 657,
     "files_tracked": 657
   },
   "quality_gate": {

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-01T04:17:44Z",
+  "last_update_utc": "2025-09-01T04:23:53Z",
   "repo": {
-    "default_branch": "main",
-    "last_commit": "a07231c922d5a67603b8af5d253813a84f5e688a",
-    "commits_total": 653,
+    "default_branch": "codex/extract-and-compare-thresholds-in-evaluate_scores.sh",
+    "last_commit": "a6a619076617c3000c0b3f93c9b46349b16a47bf",
+    "commits_total": 655,
     "files_tracked": 657
   },
   "quality_gate": {

--- a/scripts/evaluate_scores.sh
+++ b/scripts/evaluate_scores.sh
@@ -27,14 +27,15 @@ if (( $(printf '%.0f' "$SEC") < 20 )) || \
   jq -n --argjson sec "${SEC:-0}" \
         --argjson phpcs "${PHPCS_FAILS:-0}" \
         --argjson tests "${TEST_FAILS:-0}" \
-        --argjson logic "${LOGIC:-0}" \
-        --argjson perf "${PERF:-0}" \
-        --argjson read "${READ:-0}" \
-        --argjson goal "${GOAL:-0}" \
-        '{ci_failure:{security_score:$sec, phpcs_errors:$phpcs, test_failures:$tests, logic_score:$logic, performance_score:$perf, readability_score:$read, goal_score:$goal}}' \
+        --argjson logic "${LOGIC:-0}" --argjson logic_min "$LOGIC_MIN" \
+        --argjson perf "${PERF:-0}" --argjson perf_min "$PERFORMANCE_MIN" \
+        --argjson read "${READ:-0}" --argjson read_min "$READABILITY_MIN" \
+        --argjson goal "${GOAL:-0}" --argjson goal_min "$GOAL_MIN" \
+        '{ci_failure:{security_score:$sec, phpcs_errors:$phpcs, test_failures:$tests, logic:{score:$logic,min:$logic_min}, performance:{score:$perf,min:$perf_min}, readability:{score:$read,min:$read_min}, goal:{score:$goal,min:$goal_min}}}' \
   > .ci_failure.tmp
   # merge into ai_context.json (non-destructive)
   jq -s '.[0] * .[1]' "$AI_CTX" .ci_failure.tmp > ai_context.tmp && mv ai_context.tmp "$AI_CTX"
   rm -f .ci_failure.tmp
+  exit 1
 fi
 

--- a/tests/Scripts/EvaluateScoresTest.php
+++ b/tests/Scripts/EvaluateScoresTest.php
@@ -8,47 +8,48 @@ use SmartAlloc\Tests\BaseTestCase;
 
 final class EvaluateScoresTest extends BaseTestCase
 {
-    /**
-     * @dataProvider dimensionProvider
-     */
-    public function test_ci_failure_when_dimension_below_threshold(string $dimension, string $envVar): void
-    {
-        $tmp = sys_get_temp_dir() . '/sa_eval_' . uniqid();
-        mkdir($tmp, 0777, true);
-        $root = dirname(__DIR__, 2);
-        symlink($root . '/vendor', $tmp . '/vendor');
-        symlink($root . '/src', $tmp . '/src');
-        symlink($root . '/tests', $tmp . '/tests');
-        $context = [
-            'current_scores' => [
-                'security' => 25,
-                'logic' => 25,
-                'performance' => 25,
-                'readability' => 25,
-                'goal' => 25,
-                'weighted_percent' => 95.0,
-            ],
-        ];
-        $context['current_scores'][$dimension] = 10;
-        file_put_contents($tmp . '/ai_context.json', json_encode($context));
-        $cwd = getcwd();
-        chdir($tmp);
-        putenv($envVar . '=20');
-        exec('bash ' . escapeshellarg($root . '/scripts/evaluate_scores.sh'), $o, $s);
-        exec('bash ' . escapeshellarg($root . '/scripts/fail_on_ci_failure.sh'), $o2, $s2);
-        chdir($cwd);
+	/**
+	 * @dataProvider dimensionProvider
+	 */
+	public function test_ci_failure_when_dimension_below_threshold(string $dimension, string $envVar): void
+	{
+	    $tmp = sys_get_temp_dir() . '/sa_eval_' . uniqid();
+	    mkdir($tmp, 0777, true);
+	    $root = dirname(__DIR__, 2);
+	    symlink($root . '/vendor', $tmp . '/vendor');
+	    symlink($root . '/src', $tmp . '/src');
+	    symlink($root . '/tests', $tmp . '/tests');
+	    $context = [
+	        'current_scores' => [
+	            'security' => 25,
+	            'logic' => 25,
+	            'performance' => 25,
+	            'readability' => 25,
+	            'goal' => 25,
+	            'weighted_percent' => 95.0,
+	        ],
+	    ];
+	    $context['current_scores'][$dimension] = 10;
+	    file_put_contents($tmp . '/ai_context.json', json_encode($context));
+	    $cwd = getcwd();
+	    chdir($tmp);
+	    putenv($envVar . '=20');
+	    exec('bash ' . escapeshellarg($root . '/scripts/evaluate_scores.sh'), $o, $s);
+	    chdir($cwd);
 
-        $this->assertSame(0, $s);
-        $this->assertSame(1, $s2);
-    }
+	    $this->assertSame(1, $s);
+	    $ctx = json_decode(file_get_contents($tmp . '/ai_context.json'), true);
+	    $this->assertSame(10, (int) $ctx['ci_failure'][$dimension]['score']);
+	    $this->assertSame(20, (int) $ctx['ci_failure'][$dimension]['min']);
+	}
 
-    public function dimensionProvider(): array
-    {
-        return [
-            ['logic', 'LOGIC_MIN'],
-            ['performance', 'PERFORMANCE_MIN'],
-            ['readability', 'READABILITY_MIN'],
-            ['goal', 'GOAL_MIN'],
-        ];
-    }
+	public function dimensionProvider(): array
+	{
+	    return [
+	        ['logic', 'LOGIC_MIN'],
+	        ['performance', 'PERFORMANCE_MIN'],
+	        ['readability', 'READABILITY_MIN'],
+	        ['goal', 'GOAL_MIN'],
+	    ];
+	}
 }


### PR DESCRIPTION
## Summary
- enforce score threshold environment variables in evaluate_scores and exit non-zero with details
- simulate threshold failures via unit test

## Testing
- `vendor/bin/phpcs --standard=WordPress --runtime-set ignore_warnings_on_exit 1 tests/Scripts/EvaluateScoresTest.php` (fails: 100 errors, 12 warnings)
- `vendor/bin/phpunit --coverage-xml=coverage.xml --coverage-php=coverage.dat`
- `bash -n scripts/sync_scorecards.sh`
- `php -l tests/RuleEngine/FailureModesTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68b51e71d1f88321892ea9338b246794