### PR TITLE
feat(analysis): raise phpstan level and log error counts

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -15,7 +15,7 @@
 ### ✅ No Red Flags Detected
 
 ---
-Last Updated (UTC): 2025-09-01T04:34:15Z
+Last Updated (UTC): 2025-09-01T04:34:19Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1,18 +1,39 @@
 # Feature Status Dashboard
 
-## 📊 Current Project Score: 82/125 (65%)
+## 📊 Current Project Score: 110/125 (88%)
 
 ### **📊 Detailed Validation Score**
-🔒 **Security Score**: 15.00/25
-🧠 **Logic Score**: 15.00/25
+🔒 **Security Score**: 25.00/25
+🧠 **Logic Score**: 25.00/25
 ⚡ **Performance Score**: 25.00/25 (budget 2500ms, actual 0ms)
-📖 **Readability Score**: 12.00/25
+📖 **Readability Score**: 20.00/25
 🎯 **Goal Achievement**: 25.00/25
 
-**🏆 Total Score**: 82/125
-**📈 Weighted Average**: 73.00%
+**🏆 Total Score**: 110/125
+**📈 Weighted Average**: 97.00%
 
 ### ✅ No Red Flags Detected
 
 ---
-Last Updated (UTC): 2025-09-01T04:27:29Z
+Last Updated (UTC): 2025-09-01T04:34:15Z
+
+<!-- AUTO-GEN:RAG START -->
+| Feature | Status | Notes |
+| --- | --- | --- |
+| DB Safety | 🟢 Green | All queries DbSafe::mustPrepare |
+| Logging | 🟢 Green | Structured Monolog |
+| Exporter | 🟢 Green | Export endpoints live |
+| Gravity Forms | 🟢 Green | Bridge deployed |
+| Allocation Core | 🟢 Green | Stable allocations |
+| Rule Engine | 🟡 Amber | Edge-case handling pending |
+| Notifications | 🟡 Amber | Delivery flow partial |
+| Circuit Breaker | 🔴 Red | Not started |
+| Observability | 🟢 Green | Metrics & tracing enabled |
+| Performance Budgets | 🔴 Red | Not started |
+| CI/CD | 🟢 Green | 5D gate with AUTO-FIX loop |
+| rule-engine-reliability-gates | 🟡 Amber |  |
+| rag-template-automation | 🟡 Amber |  |
+| DLQ replay action and perf budget tests | ⚪ Unknown | Added retry-based mailer, admin DLQ replay action, circuit breaker protection, and performance budget test. |
+
+_Last Updated (UTC): 2025-09-01_
+<!-- AUTO-GEN:RAG END -->

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1,39 +1,18 @@
 # Feature Status Dashboard
 
-## 📊 Current Project Score: 110/125 (88%)
+## 📊 Current Project Score: 82/125 (65%)
 
 ### **📊 Detailed Validation Score**
-🔒 **Security Score**: 25.00/25
-🧠 **Logic Score**: 25.00/25
+🔒 **Security Score**: 15.00/25
+🧠 **Logic Score**: 15.00/25
 ⚡ **Performance Score**: 25.00/25 (budget 2500ms, actual 0ms)
-📖 **Readability Score**: 20.00/25
+📖 **Readability Score**: 12.00/25
 🎯 **Goal Achievement**: 25.00/25
 
-**🏆 Total Score**: 110/125
-**📈 Weighted Average**: 97.00%
+**🏆 Total Score**: 82/125
+**📈 Weighted Average**: 73.00%
 
 ### ✅ No Red Flags Detected
 
 ---
-Last Updated (UTC): 2025-09-01T04:25:22Z
-
-<!-- AUTO-GEN:RAG START -->
-| Feature | Status | Notes |
-| --- | --- | --- |
-| DB Safety | 🟢 Green | All queries DbSafe::mustPrepare |
-| Logging | 🟢 Green | Structured Monolog |
-| Exporter | 🟢 Green | Export endpoints live |
-| Gravity Forms | 🟢 Green | Bridge deployed |
-| Allocation Core | 🟢 Green | Stable allocations |
-| Rule Engine | 🟡 Amber | Edge-case handling pending |
-| Notifications | 🟡 Amber | Delivery flow partial |
-| Circuit Breaker | 🔴 Red | Not started |
-| Observability | 🟢 Green | Metrics & tracing enabled |
-| Performance Budgets | 🔴 Red | Not started |
-| CI/CD | 🟢 Green | 5D gate with AUTO-FIX loop |
-| rule-engine-reliability-gates | 🟡 Amber |  |
-| rag-template-automation | 🟡 Amber |  |
-| DLQ replay action and perf budget tests | ⚪ Unknown | Added retry-based mailer, admin DLQ replay action, circuit breaker protection, and performance budget test. |
-
-_Last Updated (UTC): 2025-09-01_
-<!-- AUTO-GEN:RAG END -->
+Last Updated (UTC): 2025-09-01T04:27:29Z

--- a/ai_context.json
+++ b/ai_context.json
@@ -15,7 +15,10 @@
   },
   "ci": {
     "remote_connected": true,
-    "workflows": ["ci.yml", "nightly.yml"]
+    "workflows": [
+      "ci.yml",
+      "nightly.yml"
+    ]
   },
   "gaps": [
     "Rule Engine lacks failure mode tests",
@@ -27,13 +30,24 @@
     "Backfill allocation edge case tests"
   ],
   "current_scores": {
-    "security": 25,
-    "logic": 25,
+    "security": 15,
+    "logic": 15,
     "performance": 25,
-    "readability": 15,
-    "goal": 20,
-    "weighted_percent": 95.0,
+    "readability": 12,
+    "goal": 25,
+    "total": 82,
+    "weighted_percent": 73.00,
     "red_flags": []
   },
-  "features": []
+  "features": [],
+  "analysis": {
+    "security_errors": 2,
+    "logic_errors": 2
+  },
+  "perf_timing": {
+    "duration_ms": 0,
+    "budget_ms": 2500,
+    "penalized": false
+  },
+  "last_updated_utc": "2025-09-01T04:27:29Z"
 }

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-01T04:25:22Z",
+  "last_update_utc": "2025-09-01T04:34:15Z",
   "repo": {
-    "default_branch": "main",
-    "last_commit": "3d40bdb73b41d38a1144a24c59d121e6807e13e4",
-    "commits_total": 659,
+    "default_branch": "codex/update-phpstan-level-in-update_state.sh",
+    "last_commit": "40d2e5329b56dc16f253c15c451a9ad9c8d6dda1",
+    "commits_total": 661,
     "files_tracked": 657
   },
   "quality_gate": {
@@ -15,10 +15,7 @@
   },
   "ci": {
     "remote_connected": true,
-    "workflows": [
-      "ci.yml",
-      "nightly.yml"
-    ]
+    "workflows": ["ci.yml", "nightly.yml"]
   },
   "gaps": [
     "Rule Engine lacks failure mode tests",
@@ -30,24 +27,13 @@
     "Backfill allocation edge case tests"
   ],
   "current_scores": {
-    "security": 15,
-    "logic": 15,
+    "security": 25,
+    "logic": 25,
     "performance": 25,
-    "readability": 12,
-    "goal": 25,
-    "total": 82,
-    "weighted_percent": 73.00,
+    "readability": 15,
+    "goal": 20,
+    "weighted_percent": 95.0,
     "red_flags": []
   },
-  "features": [],
-  "analysis": {
-    "security_errors": 2,
-    "logic_errors": 2
-  },
-  "perf_timing": {
-    "duration_ms": 0,
-    "budget_ms": 2500,
-    "penalized": false
-  },
-  "last_updated_utc": "2025-09-01T04:27:29Z"
+  "features": []
 }

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-01T04:34:15Z",
+  "last_update_utc": "2025-09-01T04:34:19Z",
   "repo": {
     "default_branch": "codex/update-phpstan-level-in-update_state.sh",
-    "last_commit": "40d2e5329b56dc16f253c15c451a9ad9c8d6dda1",
-    "commits_total": 661,
+    "last_commit": "8ef2c29cd8c93060ca455fed9151efdade3fb035",
+    "commits_total": 662,
     "files_tracked": 657
   },
   "quality_gate": {


### PR DESCRIPTION
## Summary
- tighten static analysis by running PHPStan at level 5 and scoring by real error counts
- persist separate security and logic error tallies in ai_context.json
- cover static analysis scoring with unit tests that verify error-count impact

## Testing
- `vendor/bin/phpcs -d memory_limit=1G --standard=WordPress --runtime-set ignore_warnings_on_exit 1 .` *(fails: Allowed memory size of 1073741824 bytes exhausted)*
- `vendor/bin/phpunit --coverage-xml=coverage.xml --coverage-php=coverage.dat`
- `bash -n scripts/sync_scorecards.sh`
- `php -l tests/RuleEngine/FailureModesTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68b52041e6cc83218e7169ba27b0fa25