### PR TITLE
feat(analysis): support psalm in update_state scoring

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -15,7 +15,7 @@
 ### ✅ No Red Flags Detected
 
 ---
-Last Updated (UTC): 2025-09-01T04:34:35Z
+Last Updated (UTC): 2025-09-01T06:44:38Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -15,7 +15,7 @@
 ### ✅ No Red Flags Detected
 
 ---
-Last Updated (UTC): 2025-09-01T06:44:38Z
+Last Updated (UTC): 2025-09-01T06:44:43Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-01T06:44:38Z",
+  "last_update_utc": "2025-09-01T06:44:43Z",
   "repo": {
     "default_branch": "codex/replace-grep-with-phpstan-or-psalm",
-    "last_commit": "5e24d0542abb79b1563b0f8f002fecf23f31ebb2",
-    "commits_total": 666,
+    "last_commit": "e1cfda747040ed6419ff0fb2b197b80f08089b7f",
+    "commits_total": 667,
     "files_tracked": 657
   },
   "quality_gate": {

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-01T04:34:35Z",
+  "last_update_utc": "2025-09-01T06:44:38Z",
   "repo": {
-    "default_branch": "main",
-    "last_commit": "aef38c7f924e8aae02d335a383ba0597b460084f",
-    "commits_total": 664,
+    "default_branch": "codex/replace-grep-with-phpstan-or-psalm",
+    "last_commit": "5e24d0542abb79b1563b0f8f002fecf23f31ebb2",
+    "commits_total": 666,
     "files_tracked": 657
   },
   "quality_gate": {


### PR DESCRIPTION
## Summary
- add psalm fallback to static analysis in `update_state.sh`
- record analysis errors for psalm or phpstan and reflect in SECURITY/LOGIC scores
- extend tests to cover psalm-based scoring

## Testing
- `vendor/bin/phpcs --standard=WordPress --runtime-set ignore_warnings_on_exit 1 src tests` *(fails: Tabs must be used to indent lines; spaces are not allowed)*
- `vendor/bin/phpunit --coverage-xml=coverage.xml --coverage-php=coverage.dat`
- `bash -n scripts/sync_scorecards.sh`
- `php -l tests/RuleEngine/FailureModesTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68b5238065f483219c00ee3a8545ac97