### PR TITLE
feat(perf): support multiple scenarios and budget penalties

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -15,7 +15,7 @@
 ### ✅ No Red Flags Detected
 
 ---
-Last Updated (UTC): 2025-09-01T07:22:19Z
+Last Updated (UTC): 2025-09-01T07:22:22Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -15,7 +15,7 @@
 ### ✅ No Red Flags Detected
 
 ---
-Last Updated (UTC): 2025-09-01T06:51:37Z
+Last Updated (UTC): 2025-09-01T07:22:19Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -15,7 +15,7 @@
 ### ✅ No Red Flags Detected
 
 ---
-Last Updated (UTC): 2025-09-01T07:22:22Z
+Last Updated (UTC): 2025-09-01T07:22:25Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-01T07:22:19Z",
+  "last_update_utc": "2025-09-01T07:22:22Z",
   "repo": {
     "default_branch": "codex/add-performance-scenarios-to-update_state.sh",
-    "last_commit": "06f2a640a32be2aa9889d2df48f0a0afa4de0c1c",
-    "commits_total": 677,
+    "last_commit": "52565f427f1ce2002c00930af6d88de1a3882534",
+    "commits_total": 678,
     "files_tracked": 657
   },
   "quality_gate": {

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-01T06:51:37Z",
+  "last_update_utc": "2025-09-01T07:22:19Z",
   "repo": {
-    "default_branch": "main",
-    "last_commit": "8ff1f9b98a426ecf4405ba1768e2a385922abf9e",
-    "commits_total": 675,
+    "default_branch": "codex/add-performance-scenarios-to-update_state.sh",
+    "last_commit": "06f2a640a32be2aa9889d2df48f0a0afa4de0c1c",
+    "commits_total": 677,
     "files_tracked": 657
   },
   "quality_gate": {

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-01T07:22:22Z",
+  "last_update_utc": "2025-09-01T07:22:25Z",
   "repo": {
     "default_branch": "codex/add-performance-scenarios-to-update_state.sh",
-    "last_commit": "52565f427f1ce2002c00930af6d88de1a3882534",
-    "commits_total": 678,
+    "last_commit": "81eb365e53124ecd629c175cec2b528877073ce6",
+    "commits_total": 679,
     "files_tracked": 657
   },
   "quality_gate": {

--- a/tests/Scripts/UpdateStatePerformanceTest.php
+++ b/tests/Scripts/UpdateStatePerformanceTest.php
@@ -9,27 +9,31 @@ final class UpdateStatePerformanceTest extends BaseTestCase {
     private string $script = __DIR__ . '/../../scripts/update_state.sh';
 
     /**
-     * Run update_state.sh with a performance scenario.
+     * Run update_state.sh with performance scenarios.
      *
-     * @param string $scenario PHP code to execute.
-     * @param int $budgetMs Time budget in milliseconds.
+     * @param array $scenarios List of PHP code strings to execute.
+     * @param int   $budgetMs  Time budget in milliseconds.
      * @return array{scores:array,timing:array,features:string}
      */
-    private function runScript(string $scenario, int $budgetMs): array {
+    private function runScript(array $scenarios, int $budgetMs): array {
         $dir = sys_get_temp_dir() . '/sa_perf_' . uniqid();
         mkdir($dir);
-        $scenarioFile = $dir . '/scenario.php';
-        file_put_contents($scenarioFile, $scenario);
+        $files = [];
+        foreach ($scenarios as $i => $code) {
+            $file = $dir . "/scenario{$i}.php";
+            file_put_contents($file, $code);
+            $files[] = escapeshellarg($file);
+        }
 
         $ai = $dir . '/ai_context.json';
         $featuresFile = $dir . '/FEATURES.md';
         $cmd = sprintf(
-            'SRC_DIR=%s TESTS_DIR=%s AI_CTX=%s FEATURES_MD=%s PERF_SCENARIO=%s SMARTALLOC_BUDGET_ALLOC_1K_MS=%d bash %s >/dev/null 2>&1',
+            'SRC_DIR=%s TESTS_DIR=%s AI_CTX=%s FEATURES_MD=%s PERF_SCENARIOS=%s SMARTALLOC_BUDGET_ALLOC_1K_MS=%d bash %s >/dev/null 2>&1',
             escapeshellarg($dir),
             escapeshellarg($dir),
             escapeshellarg($ai),
             escapeshellarg($featuresFile),
-            escapeshellarg($scenarioFile),
+            implode(':', $files),
             $budgetMs,
             escapeshellarg($this->script)
         );
@@ -46,9 +50,15 @@ final class UpdateStatePerformanceTest extends BaseTestCase {
     }
 
     public function test_perf_score_penalized_when_budget_exceeded(): void {
-        $res = $this->runScript('<?php usleep(50000);', 10);
+        $res = $this->runScript(['<?php usleep(50000);'], 10);
         $this->assertLessThan(10, $res['scores']['performance']);
         $this->assertTrue($res['timing']['penalized']);
         $this->assertStringContainsString('penalty', $res['features']);
+    }
+
+    public function test_slow_scenario_reduces_score_in_multiple_runs(): void {
+        $res = $this->runScript(['<?php usleep(1000);', '<?php usleep(50000);'], 10);
+        $this->assertLessThan(10, $res['scores']['performance']);
+        $this->assertTrue($res['timing']['penalized']);
     }
 }


### PR DESCRIPTION
## Summary
- allow `scripts/update_state.sh` to execute multiple performance scenarios via Stopwatch or `wp profile eval-file`
- reduce performance score when any scenario exceeds the time budget
- add test verifying slow scenario lowers score in multi-scenario run

## Testing
- `vendor/bin/phpcs --standard=WordPress --runtime-set ignore_warnings_on_exit 1 tests/Scripts/UpdateStatePerformanceTest.php`
- `vendor/bin/phpunit --coverage-xml=coverage.xml --coverage-php=coverage.dat`
- `bash -n scripts/sync_scorecards.sh`
- `php -l tests/RuleEngine/FailureModesTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68b54287000083219491d41f7474ab40