### PR TITLE
feat(score): flag unsanitized superglobals with token analysis

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1,6 +1,6 @@
 # Feature Status Dashboard
 
-## 📊 Current Project Score: 110/125 (88%)
+## 📊 Current Project Score: 90/125 (72%)
 
 ### **📊 Detailed Validation Score**
 🔒 **Security Score**: 25.00/25
@@ -9,13 +9,21 @@
 📖 **Readability Score**: 20.00/25
 🎯 **Goal Achievement**: 25.00/25
 
-**🏆 Total Score**: 110/125
+**🏆 Total Score**: 90/125
 **📈 Weighted Average**: 97.00%
 
-### ✅ No Red Flags Detected
+### ⛔ Red Flags:
+- {
+  "message": "Unsanitized superglobal access /home/runner/work/SmartAlloc/SmartAlloc/src/Debug/ErrorCollector.php:80",
+  "severity": 15
+}
+- {
+  "message": "Unsanitized superglobal access /home/runner/work/SmartAlloc/SmartAlloc/src/Debug/ErrorCollector.php:81",
+  "severity": 15
+}
 
 ---
-Last Updated (UTC): 2025-09-01T07:22:53Z
+Last Updated (UTC): 2025-09-01T07:51:48Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -23,7 +23,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-01T07:51:48Z
+Last Updated (UTC): 2025-09-01T07:51:54Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,10 +1,10 @@
 {
-  "last_update_utc": "2025-09-01T07:22:53Z",
+  "last_update_utc": "2025-09-01T07:51:48Z",
   "repo": {
-    "default_branch": "main",
-    "last_commit": "245e661187ef9c29699370fc2b557acb6eba870a",
-    "commits_total": 681,
-    "files_tracked": 657
+    "default_branch": "codex/replace-red-flag-detection-in-update_state.sh",
+    "last_commit": "c642e6f77a8d54a0ebaa736eba08e50b3c5e92ea",
+    "commits_total": 683,
+    "files_tracked": 659
   },
   "quality_gate": {
     "weighted_threshold": 0.85,

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-01T07:51:48Z",
+  "last_update_utc": "2025-09-01T07:51:54Z",
   "repo": {
     "default_branch": "codex/replace-red-flag-detection-in-update_state.sh",
-    "last_commit": "c642e6f77a8d54a0ebaa736eba08e50b3c5e92ea",
-    "commits_total": 683,
+    "last_commit": "e4436c27f6b3eff371713b1eabd79b9c243b58aa",
+    "commits_total": 684,
     "files_tracked": 659
   },
   "quality_gate": {

--- a/scripts/detect_superglobals.php
+++ b/scripts/detect_superglobals.php
@@ -1,0 +1,53 @@
+#!/usr/bin/env php
+<?php
+// phpcs:ignoreFile
+declare(strict_types=1);
+
+if ($argc < 2) {
+    echo "Usage: detect_superglobals.php <dir>\n";
+    exit(1);
+}
+$dir = $argv[1];
+$super = ['$_GET','$_POST','$_REQUEST','$_COOKIE','$_SERVER','$_FILES','$_ENV'];
+$san   = ['sanitize_text_field','sanitize_textarea_field','sanitize_email','sanitize_key','esc_html','esc_attr','esc_url','intval','absint','floatval','doubleval','filter_input','wp_unslash','prepare'];
+$flags = [];
+$iter = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($dir));
+foreach ($iter as $file) {
+    if ($file->isDir()) {
+        continue;
+    }
+    if (pathinfo($file->getFilename(), PATHINFO_EXTENSION) !== 'php') {
+        continue;
+    }
+    $code = file_get_contents($file->getPathname());
+    $tokens = token_get_all($code);
+    $count  = count($tokens);
+    for ($i = 0; $i < $count; $i++) {
+        $t = $tokens[$i];
+        if (is_array($t) && $t[0] === T_VARIABLE && in_array($t[1], $super, true)) {
+            $prev = '';
+            for ($j = $i - 1; $j >= 0 && $j >= $i - 10; $j--) {
+                $pt = $tokens[$j];
+                if (is_array($pt)) {
+                    if ($pt[0] === T_STRING) {
+                        $prev = $pt[1];
+                        break;
+                    }
+                    if (in_array($pt[0], [T_WHITESPACE, T_OPEN_TAG, T_CONSTANT_ENCAPSED_STRING, T_VARIABLE, T_LNUMBER, T_DNUMBER], true)) {
+                        continue;
+                    }
+                } else {
+                    if ($pt === '(' || $pt === '[') {
+                        continue;
+                    }
+                    break;
+                }
+            }
+            if (!in_array($prev, $san, true)) {
+                $flags[] = ['file' => $file->getPathname(), 'line' => $t[2]];
+            }
+        }
+    }
+}
+
+echo json_encode($flags);

--- a/tests/Scripts/UpdateStateSuperglobalsTest.php
+++ b/tests/Scripts/UpdateStateSuperglobalsTest.php
@@ -1,0 +1,44 @@
+<?php
+// phpcs:ignoreFile
+
+declare(strict_types=1);
+
+use SmartAlloc\Tests\BaseTestCase;
+
+final class UpdateStateSuperglobalsTest extends BaseTestCase {
+    private string $script = __DIR__ . '/../../scripts/update_state.sh';
+
+    private function runScript(string $code): array {
+        $dir = sys_get_temp_dir() . '/sa_super_' . uniqid();
+        mkdir($dir);
+        file_put_contents($dir . '/sample.php', $code);
+
+        $ai = $dir . '/ai_context.json';
+        $env = [
+            'SRC_DIR'     => $dir,
+            'TESTS_DIR'   => $dir,
+            'AI_CTX'      => $ai,
+            'FEATURES_MD' => $dir . '/FEATURES.md',
+        ];
+        $envStr = '';
+        foreach ($env as $k => $v) {
+            $envStr .= sprintf('%s=%s ', $k, escapeshellarg((string) $v));
+        }
+        $cmd = sprintf('%sbash %s >/dev/null 2>&1', $envStr, escapeshellarg($this->script));
+        exec($cmd);
+        $data = json_decode(file_get_contents($ai), true);
+        array_map('unlink', glob($dir . '/*'));
+        rmdir($dir);
+        return $data;
+    }
+
+    public function test_unsanitized_superglobal_reduces_score(): void {
+        $clean = $this->runScript('<?php $a = sanitize_text_field($_GET["a"]);');
+        $dirty = $this->runScript('<?php $a = $_GET["a"];');
+
+        $this->assertSame(0, count($clean['current_scores']['red_flags']));
+        $this->assertGreaterThan(0, count($dirty['current_scores']['red_flags']));
+        $this->assertTrue($dirty['current_scores']['total'] < $clean['current_scores']['total']);
+        $this->assertSame(15, $dirty['current_scores']['red_flags'][0]['severity']);
+    }
+}


### PR DESCRIPTION
## Summary
- detect unsanitized PHP superglobals via token analysis
- score red flags by severity and persist in ai_context.json
- add tests covering safe vs unsafe superglobal access

## Testing
- `bash -n scripts/update_state.sh`
- `vendor/bin/phpcs scripts/update_state.sh scripts/detect_superglobals.php tests/Scripts/UpdateStateSuperglobalsTest.php`
- `vendor/bin/phpunit tests/Scripts/UpdateStateSuperglobalsTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68b54c92a5a08321b04c7d53a58f9012