### PR TITLE
ci: check phase transition after feature sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,8 @@ jobs:
           jq empty ai_context.json
       - name: 🔄 Sync AI context features
         run: php scripts/sync-features-to-ai-context.php
+      - name: 🔍 Check phase transition
+        run: bash scripts/check_phase_transition.sh
       - name: 📥 Install dependencies
         run: composer install --no-interaction --prefer-dist --no-progress
       - name: Install Playwright deps
@@ -136,6 +138,8 @@ jobs:
           jq empty ai_context.json
       - name: 🔄 Sync AI context features
         run: php scripts/sync-features-to-ai-context.php
+      - name: 🔍 Check phase transition
+        run: bash scripts/check_phase_transition.sh
       - name: 📥 Install dependencies
         run: composer install --no-interaction --prefer-dist --no-progress
       - name: Install Playwright deps

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -23,7 +23,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-01T09:26:02Z
+Last Updated (UTC): 2025-09-01T09:26:11Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -23,7 +23,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-01T08:36:55Z
+Last Updated (UTC): 2025-09-01T09:26:02Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-01T08:36:55Z",
+  "last_update_utc": "2025-09-01T09:26:02Z",
   "repo": {
-    "default_branch": "main",
-    "last_commit": "78b2e9411ec41bd582d1c8a4004ca3fc11a22be1",
-    "commits_total": 696,
+    "default_branch": "codex/add-sync-features-script-to-ci-workflow",
+    "last_commit": "463e88424dbb642de302c7a812f02e9745691044",
+    "commits_total": 698,
     "files_tracked": 660
   },
   "quality_gate": {

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-01T09:26:02Z",
+  "last_update_utc": "2025-09-01T09:26:11Z",
   "repo": {
     "default_branch": "codex/add-sync-features-script-to-ci-workflow",
-    "last_commit": "463e88424dbb642de302c7a812f02e9745691044",
-    "commits_total": 698,
+    "last_commit": "11f8ee4d3f5976c0a3b270c9de0d8ded2367a09c",
+    "commits_total": 699,
     "files_tracked": 660
   },
   "quality_gate": {

--- a/docs/SCORING.md
+++ b/docs/SCORING.md
@@ -10,3 +10,5 @@
 `features.json` tracks the status of all features. At the start of CI, `scripts/sync-features-to-ai-context.php` copies these statuses into `ai_context.json` so scoring uses the latest data. The script tolerates an empty `features` array, and tests simulate this scenario to ensure synchronization remains accurate.
 
 CI workflows explicitly run the sync script before executing `scripts/check_phase_transition.sh` to guarantee `ai_context.json` mirrors `features.json`. If `features.json` lacks entries, the phase transition check fails until synchronization populates the needed statuses. Additional gates such as `scripts/ci/ensure_ci_thresholds.sh` also run the sync step to guarantee `ai_context.json` reflects current features before score evaluation.
+
+A dedicated regression test covers the case where `features.json` is missing entirely. The phase transition check fails first, then passes after `scripts/sync-features-to-ai-context.php` rebuilds `ai_context.json` with the required feature data.

--- a/tests/Scripts/CheckPhaseTransitionTest.php
+++ b/tests/Scripts/CheckPhaseTransitionTest.php
@@ -23,6 +23,13 @@ final class CheckPhaseTransitionTest extends BaseTestCase
         );
         $context = json_decode(file_get_contents($contextPath), true);
         $context['features'] = [];
+        $context['scores']   = [
+            'security'    => 25,
+            'logic'       => 25,
+            'performance' => 25,
+            'readability' => 25,
+            'goal'        => 25,
+        ];
         file_put_contents($contextPath, json_encode($context, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
 
         exec('cd ' . escapeshellarg($tmp) . ' && bash scripts/check_phase_transition.sh >/dev/null 2>&1', $out, $code1);
@@ -32,8 +39,8 @@ final class CheckPhaseTransitionTest extends BaseTestCase
         $features = [
             'schema'   => 1,
             'features' => [
-                ['name' => 'rule_engine', 'status' => 'implemented'],
-                ['name' => 'db_abstraction', 'status' => 'complete'],
+                ['name' => 'notification_system', 'status' => 'complete'],
+                ['name' => 'circuit_breaker', 'status' => 'stable'],
             ],
         ];
         file_put_contents($featuresPath, json_encode($features, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
@@ -43,6 +50,46 @@ final class CheckPhaseTransitionTest extends BaseTestCase
         exec('cd ' . escapeshellarg($tmp) . ' && bash scripts/check_phase_transition.sh >/dev/null 2>&1', $out2, $code2);
         $this->assertSame(0, $code2);
         $synced = json_decode(file_get_contents($contextPath), true);
-        $this->assertSame('implemented', $synced['features']['rule_engine']);
+        $this->assertSame('complete', $synced['features']['notification_system']);
+    }
+
+    public function test_phase_transition_fails_when_features_file_missing_then_succeeds(): void
+    {
+        $tmp = sys_get_temp_dir() . '/sa_phase_' . uniqid();
+        mkdir($tmp);
+        exec('cp -R . ' . escapeshellarg($tmp) . ' >/dev/null 2>&1');
+
+        $featuresPath = $tmp . '/features.json';
+        $contextPath  = $tmp . '/ai_context.json';
+
+        // Remove features.json to simulate missing file
+        unlink($featuresPath);
+        $context = json_decode(file_get_contents($contextPath), true);
+        $context['features'] = [];
+        $context['scores']   = [
+            'security'    => 25,
+            'logic'       => 25,
+            'performance' => 25,
+            'readability' => 25,
+            'goal'        => 25,
+        ];
+        file_put_contents($contextPath, json_encode($context, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+        exec('cd ' . escapeshellarg($tmp) . ' && bash scripts/check_phase_transition.sh >/dev/null 2>&1', $out, $code1);
+        $this->assertSame(1, $code1);
+
+        // Create required features and re-run
+        $features = [
+            'schema'   => 1,
+            'features' => [
+                ['name' => 'notification_system', 'status' => 'complete'],
+                ['name' => 'circuit_breaker', 'status' => 'stable'],
+            ],
+        ];
+        file_put_contents($featuresPath, json_encode($features, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+        exec('cd ' . escapeshellarg($tmp) . ' && php scripts/sync-features-to-ai-context.php >/dev/null 2>&1');
+        exec('cd ' . escapeshellarg($tmp) . ' && bash scripts/check_phase_transition.sh >/dev/null 2>&1', $out2, $code2);
+        $this->assertSame(0, $code2);
     }
 }


### PR DESCRIPTION
## Summary
- run phase transition check right after syncing features in CI
- clarify feature sync process in scoring docs
- cover missing features case in phase transition test

## Testing
- `vendor/bin/phpunit tests/Scripts/CheckPhaseTransitionTest.php`
- `vendor/bin/phpcs --standard=WordPress tests/Scripts/CheckPhaseTransitionTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68b55b2e7c7c8321bde8531d13cdbba8