### PR TITLE
feat(perf): add scenario runner with budget scoring

### DIFF
--- a/scripts/run_scenario.php
+++ b/scripts/run_scenario.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Run performance scenarios with budgets.
+ */
+
+declare(strict_types=1);
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use SmartAlloc\Perf\ScenarioRunner;
+
+$runner = new ScenarioRunner();
+
+$scenarios = [
+    'fast' => array( 'budget' => 50, 'fn' => fn() => usleep(20000) ),
+    'slow' => array( 'budget' => 30, 'fn' => fn() => usleep(50000) ),
+];
+
+foreach ($scenarios as $name => $data) {
+    $result         = $runner->run($name, $data['fn'], $data['budget']);
+    $scenario_status = $result['passed'] ? 'PASS' : 'FAIL';
+    // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+    printf("%s: %.2fms (budget %d) %s\n", $name, $result['time'], $data['budget'], $scenario_status);
+}
+
+// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+printf("Score: %d\n", $runner->score());

--- a/src/Perf/ScenarioRunner.php
+++ b/src/Perf/ScenarioRunner.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Simple performance scenario runner.
+ *
+ * @package SmartAlloc\Perf
+ */
+
+declare(strict_types=1);
+
+namespace SmartAlloc\Perf;
+
+/**
+ * Executes scenarios with time budgets and calculates a score.
+ */
+class ScenarioRunner
+{
+    /**
+     * Results keyed by scenario name.
+     *
+     * @var array<string, array{time:float,budget:int,passed:bool}>
+     */
+    private array $results = [];
+
+    /**
+     * Run a scenario and record its timing.
+     *
+     * @param string   $name   Scenario identifier.
+     * @param callable $fn     Scenario function.
+     * @param int      $budget Time budget in milliseconds.
+     *
+     * @return array{time:float,budget:int,passed:bool}
+     */
+    public function run(string $name, callable $fn, int $budget): array
+    {
+        $start = hrtime(true);
+        $fn();
+        $duration = (hrtime(true) - $start) / 1_000_000;
+        $passed = $duration <= $budget;
+        return $this->results[$name] = [
+            'time'   => $duration,
+            'budget' => $budget,
+            'passed' => $passed,
+        ];
+    }
+
+    /**
+     * Get performance score out of 20.
+     */
+    public function score(): int
+    {
+        if (!$this->results) {
+            return 0;
+        }
+        $total  = count($this->results);
+        $passed = count(array_filter($this->results, static fn($r) => $r['passed']));
+        return (int) round(20 * $passed / $total);
+    }
+
+    /**
+     * Retrieve results for all scenarios.
+     *
+     * @return array<string, array{time:float,budget:int,passed:bool}>
+     */
+    public function results(): array
+    {
+        return $this->results;
+    }
+}

--- a/tests/Performance/ScenarioRunnerTest.php
+++ b/tests/Performance/ScenarioRunnerTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SmartAlloc\Tests\Performance;
+
+use SmartAlloc\Perf\ScenarioRunner;
+use SmartAlloc\Tests\BaseTestCase;
+
+final class ScenarioRunnerTest extends BaseTestCase
+{
+    public function testSlowScenarioReducesScore(): void
+    {
+        $runner = new ScenarioRunner();
+        $runner->run('fast', fn() => usleep(10000), 50);
+        $runner->run('slow', fn() => usleep(100000), 30);
+        $results = $runner->results();
+        $this->assertTrue($results['fast']['passed']);
+        $this->assertFalse($results['slow']['passed']);
+        $this->assertLessThan(20, $runner->score());
+    }
+}


### PR DESCRIPTION
## Summary
- add simple ScenarioRunner to execute scenarios with time budgets and scoring
- provide run_scenario script demonstrating fast and slow cases
- ensure slow scenario reduces performance score through unit test

## Testing
- `vendor/bin/phpcs --standard=phpcs.xml src/Perf/ScenarioRunner.php tests/Performance/ScenarioRunnerTest.php scripts/run_scenario.php`
- `vendor/bin/phpunit tests/Performance/ScenarioRunnerTest.php`
- `php scripts/run_scenario.php`


------
https://chatgpt.com/codex/tasks/task_e_68b55c48598c83219456633c308a8353