### PR TITLE
ci: enforce default 5d thresholds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,10 @@ permissions:
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   TZ: UTC
+  LOGIC_MIN: ${{ vars.LOGIC_MIN || '18' }}
+  PERFORMANCE_MIN: ${{ vars.PERFORMANCE_MIN || '19' }}
+  READABILITY_MIN: ${{ vars.READABILITY_MIN || '19' }}
+  GOAL_MIN: ${{ vars.GOAL_MIN || '18' }}
 
 jobs:
   qa:

--- a/scripts/evaluate_scores.sh
+++ b/scripts/evaluate_scores.sh
@@ -14,10 +14,10 @@ PHPCS_FAILS="$(jq -r '.totals.errors + .totals.warnings' <<<"$PHPCS_JSON" 2>/dev
 tmp="$AI_CTX.tmp"
 jq --argjson phpcs "$PHPCS_FAILS" '.phpcs_errors=$phpcs' "$AI_CTX" > "$tmp" && mv "$tmp" "$AI_CTX"
 TEST_FAILS="${TEST_FAILS:-0}"
-LOGIC_MIN="${LOGIC_MIN:-0}"
-PERFORMANCE_MIN="${PERFORMANCE_MIN:-0}"
-READABILITY_MIN="${READABILITY_MIN:-0}"
-GOAL_MIN="${GOAL_MIN:-0}"
+LOGIC_MIN="${LOGIC_MIN:-18}"
+PERFORMANCE_MIN="${PERFORMANCE_MIN:-19}"
+READABILITY_MIN="${READABILITY_MIN:-19}"
+GOAL_MIN="${GOAL_MIN:-18}"
 if (( $(printf '%.0f' "$SEC") < 20 )) || \
    (( $(printf '%.0f' "$WGT") < 85 )) || \
    (( $(printf '%.0f' "$LOGIC") < LOGIC_MIN )) || \

--- a/tests/Scripts/EvaluateScoresDefaultTest.php
+++ b/tests/Scripts/EvaluateScoresDefaultTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SmartAlloc\Tests\Scripts;
+
+use SmartAlloc\Tests\BaseTestCase;
+
+final class EvaluateScoresDefaultTest extends BaseTestCase {
+
+		/**
+		 * @dataProvider dimensionDefaultProvider
+		 */
+	public function test_default_thresholds_trigger_ci_failure( string $dimension, int $expectedMin ): void {
+		$tmp = sys_get_temp_dir() . '/sa_eval_' . uniqid();
+		mkdir( $tmp, 0777, true );
+		$root = dirname( __DIR__, 2 );
+		symlink( $root . '/vendor', $tmp . '/vendor' );
+		symlink( $root . '/src', $tmp . '/src' );
+		symlink( $root . '/tests', $tmp . '/tests' );
+		$context                                 = array(
+			'current_scores' => array(
+				'security'         => 25,
+				'logic'            => 25,
+				'performance'      => 25,
+				'readability'      => 25,
+				'goal'             => 25,
+				'weighted_percent' => 95.0,
+			),
+		);
+		$context['current_scores'][ $dimension ] = $expectedMin - 1;
+		file_put_contents( $tmp . '/ai_context.json', json_encode( $context ) );
+		$cwd = getcwd();
+		chdir( $tmp );
+		exec( 'bash ' . escapeshellarg( $root . '/scripts/evaluate_scores.sh' ), $o, $s );
+		chdir( $cwd );
+
+		$this->assertSame( 1, $s );
+		$ctx = json_decode( file_get_contents( $tmp . '/ai_context.json' ), true );
+		$this->assertSame( $expectedMin - 1, (int) $ctx['ci_failure'][ $dimension ]['score'] );
+		$this->assertSame( $expectedMin, (int) $ctx['ci_failure'][ $dimension ]['min'] );
+	}
+
+	public function dimensionDefaultProvider(): array {
+		return array(
+			array( 'logic', 18 ),
+			array( 'performance', 19 ),
+			array( 'readability', 19 ),
+			array( 'goal', 18 ),
+		);
+	}
+}


### PR DESCRIPTION
## Summary
- ensure evaluate_scores uses default logic/performance/readability/goal thresholds
- expose configurable 5D gates via CI env vars
- add test validating default threshold failures

## Testing
- `vendor/bin/phpcs --standard=WordPress --extensions=php src tests`
- `vendor/bin/phpunit --coverage-xml=coverage.xml --coverage-php=coverage.dat`
- `bash -n scripts/sync_scorecards.sh`
- `php -l tests/RuleEngine/FailureModesTest.php`
- `vendor/bin/phpunit tests/Scripts/EvaluateScoresDefaultTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68b5755f35e4832190e56c541289f58e