### PR TITLE
feat(notify): respect retry config and type circuit status

### DIFF
--- a/tests/Domain/CircuitBreakerTest.php
+++ b/tests/Domain/CircuitBreakerTest.php
@@ -69,4 +69,19 @@ final class CircuitBreakerTest extends BaseTestCase
         $dt = DateTimeImmutable::createFromFormat('Y-m-d H:i:s',$snap['opened_at'],new DateTimeZone('UTC'));
         $this->assertInstanceOf(DateTimeImmutable::class,$dt);
     }
+
+    public function test_get_status_shape_is_stable(): void
+    {
+        $s = new ArrayCircuitStorage();
+        $b = new CircuitBreaker(threshold:1,cooldown:5,halfOpenCallback:null,storage:$s);
+        try { $b->failure('svc.export', new \Exception()); } catch (\Throwable $e) {}
+        $st = $b->getStatus();
+        $this->assertArrayHasKey('svc.export', $st);
+        $one = $st['svc.export'];
+        $this->assertIsArray($one);
+        $this->assertArrayHasKey('state', $one);
+        $this->assertContains($one['state'], ['open','half','closed']);
+        $this->assertArrayHasKey('failures', $one);
+        $this->assertIsInt($one['failures']);
+    }
 }

--- a/tests/NotificationServiceTest.php
+++ b/tests/NotificationServiceTest.php
@@ -1,7 +1,130 @@
 <?php
 declare(strict_types=1);
+
 use SmartAlloc\Tests\BaseTestCase;
-use SmartAlloc\Services\{NotificationService,CircuitBreaker,Logging,Metrics,DlqService};
-if(!defined('DAY_IN_SECONDS')){define('DAY_IN_SECONDS',86400);}if(!defined('SMARTALLOC_NOTIFY_MAX_TRIES')){define('SMARTALLOC_NOTIFY_MAX_TRIES',5);}if(!defined('SMARTALLOC_NOTIFY_BASE_DELAY')){define('SMARTALLOC_NOTIFY_BASE_DELAY',5);}if(!defined('SMARTALLOC_NOTIFY_BACKOFF_CAP')){define('SMARTALLOC_NOTIFY_BACKOFF_CAP',600);}if(!function_exists('add_action')){function add_action(){}}if(!function_exists('wp_mail')){function wp_mail(){global $mail_ok;return $mail_ok;}}if(!function_exists('wp_json_encode')){function wp_json_encode($d){return json_encode($d);}}if(!function_exists('apply_filters')){function apply_filters($t,$v){return $v;}}if(!function_exists('wp_upload_dir')){function wp_upload_dir(){return array('basedir'=>'/tmp');}}if(!function_exists('trailingslashit')){function trailingslashit($p){return rtrim($p,'/').'/';}}if(!function_exists('as_enqueue_single_action')){function as_enqueue_single_action($ts,$h,$a,$g,$u){global $s;$s=array($ts,$h,$a);}}if(!function_exists('as_enqueue_async_action')){function as_enqueue_async_action($h,$a,$g,$u){global $s;$s=array($h,$a);}}if(!function_exists('wp_schedule_single_event')){function wp_schedule_single_event($ts,$h,$a){global $s;$s=array($ts,$h,$a);}}if(!function_exists('get_transient')){function get_transient($k){global $t;return $t[$k]??false;}}if(!function_exists('set_transient')){function set_transient($k,$v,$e){global $t;$t[$k]=$v;}}if(!function_exists('current_time')){function current_time($t='mysql'){return gmdate('Y-m-d H:i:s');}}
-class SpyDlq implements \SmartAlloc\Infrastructure\Contracts\DlqRepository{public array $entries=[];public function insert(string $topic,array $payload,\DateTimeImmutable $ts):void{$this->entries[]=['topic'=>$topic,'payload'=>$payload,'ts'=>$ts];}public function has(string $topic):bool{return !empty(array_filter($this->entries,fn($e)=>$e['topic']===$topic));}public function last(string $topic):?array{$f=array_filter($this->entries,fn($e)=>$e['topic']===$topic);return end($f)['payload']??null;}}
-final class NotificationServiceTest extends BaseTestCase{public function test_final_email_failure_goes_to_dlq():void{global $mail_ok,$s,$t;$mail_ok=false;$s=null;$t=array();$spy=new SpyDlq();$dlq=new DlqService($spy);$svc=new NotificationService(new CircuitBreaker(),new Logging(),new Metrics(),null,$dlq);$svc->sendMail(array('to'=>'a','subject'=>'s','message'=>'m','_attempt'=>SMARTALLOC_NOTIFY_MAX_TRIES));$this->assertTrue($spy->has('mail'));}public function test_dlq_payload_includes_all_metadata():void{global $mail_ok,$s,$t;$mail_ok=false;$s=null;$t=array();$spy=new SpyDlq();$dlq=new DlqService($spy);$svc=new NotificationService(new CircuitBreaker(),new Logging(),new Metrics(),null,$dlq);$svc->sendMail(array('to'=>'a','subject'=>'s','message'=>'m','_attempt'=>SMARTALLOC_NOTIFY_MAX_TRIES,'meta'=>'x'));$p=$spy->last('mail');$this->assertSame('x',$p['meta']);$this->assertSame(SMARTALLOC_NOTIFY_MAX_TRIES,$p['attempts']);}}
+use SmartAlloc\Services\{NotificationService,CircuitBreaker,Logging,DlqService};
+use SmartAlloc\Tests\TestDoubles\{SpyDlq,NullMetrics};
+
+if (!defined('DAY_IN_SECONDS')) {
+    define('DAY_IN_SECONDS', 86400);
+}
+if (!defined('SMARTALLOC_NOTIFY_MAX_TRIES')) {
+    define('SMARTALLOC_NOTIFY_MAX_TRIES', 3);
+}
+if (!defined('SMARTALLOC_NOTIFY_BASE_DELAY')) {
+    define('SMARTALLOC_NOTIFY_BASE_DELAY', 5);
+}
+if (!defined('SMARTALLOC_NOTIFY_BACKOFF_CAP')) {
+    define('SMARTALLOC_NOTIFY_BACKOFF_CAP', 600);
+}
+if (!function_exists('add_action')) {
+    function add_action() {}
+}
+if (!function_exists('wp_mail')) {
+    function wp_mail() {
+        global $mail_ok;
+        return $mail_ok;
+    }
+}
+if (!function_exists('wp_json_encode')) {
+    function wp_json_encode($d) {
+        return json_encode($d);
+    }
+}
+if (!function_exists('apply_filters')) {
+    function apply_filters($t, $v) {
+        return $v;
+    }
+}
+if (!function_exists('wp_upload_dir')) {
+    function wp_upload_dir() {
+        return ['basedir' => '/tmp'];
+    }
+}
+if (!function_exists('trailingslashit')) {
+    function trailingslashit($p) {
+        return rtrim($p, '/') . '/';
+    }
+}
+if (!function_exists('as_enqueue_single_action')) {
+    function as_enqueue_single_action($ts, $h, $a, $g, $u) {
+        global $s;
+        $s = [$ts, $h, $a];
+    }
+}
+if (!function_exists('as_enqueue_async_action')) {
+    function as_enqueue_async_action($h, $a, $g, $u) {
+        global $s;
+        $s = [$h, $a];
+    }
+}
+if (!function_exists('wp_schedule_single_event')) {
+    function wp_schedule_single_event($ts, $h, $a) {
+        global $s;
+        $s = [$ts, $h, $a];
+    }
+}
+if (!function_exists('get_transient')) {
+    function get_transient($k) {
+        global $t;
+        return $t[$k] ?? false;
+    }
+}
+if (!function_exists('set_transient')) {
+    function set_transient($k, $v, $e) {
+        global $t;
+        $t[$k] = $v;
+    }
+}
+if (!function_exists('current_time')) {
+    function current_time($t = 'mysql') {
+        return gmdate('Y-m-d H:i:s');
+    }
+}
+
+final class NotificationServiceTest extends BaseTestCase
+{
+    public function test_final_email_failure_goes_to_dlq(): void
+    {
+        global $mail_ok, $s, $t;
+        $mail_ok = false;
+        $s = null;
+        $t = [];
+        $spy = new SpyDlq();
+        $dlq = new DlqService($spy);
+        $svc = new NotificationService(new CircuitBreaker(), new Logging(), new NullMetrics(), null, $dlq);
+        $svc->sendMail(['to' => 'a', 'subject' => 's', 'message' => 'm', '_attempt' => SMARTALLOC_NOTIFY_MAX_TRIES]);
+        $this->assertTrue($spy->has('mail'));
+    }
+
+    public function test_dlq_payload_includes_all_metadata(): void
+    {
+        global $mail_ok, $s, $t;
+        $mail_ok = false;
+        $s = null;
+        $t = [];
+        $spy = new SpyDlq();
+        $dlq = new DlqService($spy);
+        $svc = new NotificationService(new CircuitBreaker(), new Logging(), new NullMetrics(), null, $dlq);
+        $svc->sendMail(['to' => 'a', 'subject' => 's', 'message' => 'm', '_attempt' => SMARTALLOC_NOTIFY_MAX_TRIES, 'meta' => 'x']);
+        $p = $spy->last('mail');
+        $this->assertSame('x', $p['meta']);
+        $this->assertSame(SMARTALLOC_NOTIFY_MAX_TRIES, $p['attempts']);
+    }
+
+    public function test_retry_limit_uses_config_constant(): void
+    {
+        global $mail_ok, $s, $t;
+        $mail_ok = false;
+        $s = null;
+        $t = [];
+        $spy = new SpyDlq();
+        $dlq = new DlqService($spy);
+        $svc = new NotificationService(new CircuitBreaker(), new Logging(), new NullMetrics(), null, $dlq);
+        $GLOBALS['filters']['smartalloc_notify_transport'] = fn() => 'fail';
+        $svc->handle(['event_name' => 'mail', 'body' => [], '_attempt' => SMARTALLOC_NOTIFY_MAX_TRIES]);
+        $this->assertTrue($spy->has('mail'));
+        unset($GLOBALS['filters']['smartalloc_notify_transport']);
+    }
+}
+

--- a/tests/TestDoubles/NullMetrics.php
+++ b/tests/TestDoubles/NullMetrics.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+
+namespace SmartAlloc\Tests\TestDoubles;
+
+use SmartAlloc\Services\Metrics;
+
+final class NullMetrics extends Metrics
+{
+    public function __construct() {}
+
+    public function inc(string $key, float $value = 1.0, array $labels = []): void {}
+
+    public function observe(string $key, int $milliseconds, array $labels = []): void {}
+}
+

--- a/tests/TestDoubles/SpyDlq.php
+++ b/tests/TestDoubles/SpyDlq.php
@@ -1,0 +1,39 @@
+<?php
+declare(strict_types=1);
+
+namespace SmartAlloc\Tests\TestDoubles;
+
+use SmartAlloc\Infrastructure\Contracts\DlqRepository;
+use DateTimeImmutable;
+
+final class SpyDlq implements DlqRepository
+{
+    /** @var array<int,array{topic:string,payload:array,ts:DateTimeImmutable}> */
+    public array $entries = [];
+
+    public function insert(string $topic, array $payload, DateTimeImmutable $createdAtUtc): void
+    {
+        $this->entries[] = ['topic' => $topic, 'payload' => $payload, 'ts' => $createdAtUtc];
+    }
+
+    public function has(string $topic): bool
+    {
+        foreach ($this->entries as $e) {
+            if ($e['topic'] === $topic) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public function last(string $topic): ?array
+    {
+        foreach (array_reverse($this->entries) as $e) {
+            if ($e['topic'] === $topic) {
+                return $e['payload'];
+            }
+        }
+        return null;
+    }
+}
+


### PR DESCRIPTION
## Summary
- make notification retries honor SMARTALLOC_NOTIFY_MAX_TRIES
- document CircuitBreaker status structures with typed docblocks
- add tests for retry limit and status shape

## Testing
- `vendor/bin/phpcs -p --standard=phpcs.xml src/Services/NotificationService.php` (no errors)
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68b5a6d56b008321a0070b43e93adc79