### PR TITLE
feat(baseline): add baseline comparison support

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -23,7 +23,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-01T17:47:20Z
+Last Updated (UTC): 2025-09-01T18:01:10Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -23,7 +23,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-01T18:01:10Z
+Last Updated (UTC): 2025-09-01T18:01:14Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,10 +1,10 @@
 {
-  "last_update_utc": "2025-09-01T17:47:20Z",
+  "last_update_utc": "2025-09-01T18:01:10Z",
   "repo": {
-    "default_branch": "main",
-    "last_commit": "0c17442f36e0ebb399bcab86c8faa92fc529cfd7",
-    "commits_total": 747,
-    "files_tracked": 672
+    "default_branch": "codex/add-baseline-document-generation",
+    "last_commit": "b271c69c1b12522a6b14592d416b5de246c3e239",
+    "commits_total": 749,
+    "files_tracked": 680
   },
   "quality_gate": {
     "weighted_threshold": 0.85,

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-01T18:01:10Z",
+  "last_update_utc": "2025-09-01T18:01:14Z",
   "repo": {
     "default_branch": "codex/add-baseline-document-generation",
-    "last_commit": "b271c69c1b12522a6b14592d416b5de246c3e239",
-    "commits_total": 749,
+    "last_commit": "072559f7168e913916c6361f86c1a107738375e2",
+    "commits_total": 750,
     "files_tracked": 680
   },
   "quality_gate": {

--- a/docs/BASELINE-2025-08-31.md
+++ b/docs/BASELINE-2025-08-31.md
@@ -1,0 +1,53 @@
+# سند مبنا برای ادامه توسعه افزونه بر اساس وضعیت پروژه در تاریخ 10 شهریور 1404
+
+## Project Status Schema
+
+```yaml
+project_baseline:
+  date: "2025-08-31"
+  date_persian: "10 شهریور 1404"
+  version: "1.0.0"
+  
+phases:
+  foundation:
+    status: completed
+    tasks:
+      security_framework:
+        status: completed
+        description: "پیاده‌سازی چارچوب امنیتی"
+      rule_engine_core:
+        status: completed
+        description: "موتور قوانین پایه"
+      database_schema:
+        status: completed
+        description: "طراحی و پیاده‌سازی دیتابیس"
+        
+  expansion:
+    status: in-progress
+    tasks:
+      notification_throttle:
+        status: in-progress
+        description: "سیستم محدودسازی نرخ اعلانات"
+      circuit_breaker_types:
+        status: in-progress
+        description: "تایپ‌دهی دقیق مدارشکن"
+      rule_engine_composite:
+        status: pending
+        description: "پشتیبانی از شرایط ترکیبی AND/OR"
+      export_streaming:
+        status: pending
+        description: "خروجی استریم‌محور برای فایل‌های بزرگ"
+        
+  polish:
+    status: pending
+    tasks:
+      performance_optimization:
+        status: pending
+        description: "بهینه‌سازی عملکرد کلی"
+      ui_refinements:
+        status: pending
+        description: "بهبود رابط کاربری"
+      documentation_complete:
+        status: pending
+        description: "تکمیل مستندات"
+```

--- a/prompts/codex_auditor.md
+++ b/prompts/codex_auditor.md
@@ -1,0 +1,37 @@
+## Codex Auditor Enhanced Instructions
+
+When generating status reports, follow this EXACT structure:
+
+1. **Standard Sections** (keep as-is):
+   - Project Overview
+   - Phase Status
+   - Recent Changes
+   - Quality Metrics
+   - Post-Commit Snapshot
+
+2. **NEW: Baseline Comparison Section** (add after Post-Commit Snapshot):
+   ```markdown
+   ## طبق «سند مبنا برای ادامه توسعه افزونه بر اساس وضعیت پروژه در تاریخ <date>» موارد زیر تکمیل و باقی مانده
+
+   | فاز | وظیفه | وضعیت | توضیحات |
+   |-----|-------|--------|----------|
+   | foundation | security_framework | 🟢 completed | پیاده‌سازی چارچوب امنیتی |
+   | expansion | notification_throttle | 🟡 in-progress | سیستم محدودسازی نرخ اعلانات |
+   | expansion | rule_engine_composite | 🔴 pending | پشتیبانی از شرایط ترکیبی AND/OR |
+   ```
+
+3. **Implementation Details**:
+   - Look for `docs/BASELINE-*.md` files (use most recent by filename)
+   - Parse YAML block between ```yaml markers
+   - Use status icons: 🟢 (completed), 🟡 (in-progress), 🔴 (pending)
+   - If no baseline found, print: "Baseline document not available (N/A)"
+
+4. **Phase Transition Logic** (preserve existing):
+   - Foundation → Expansion: when Security ≥20 AND RuleEngine implemented
+   - Expansion → Polish: when Security ≥22 AND Logic ≥18 AND Performance ≥18
+   - Never regress phases
+
+5. **File Updates Required**:
+   - `prompts/codex_auditor.md`: Add baseline comparison instructions
+   - `scripts/status-pack.sh`: Add baseline YAML extraction
+   - Create initial `docs/BASELINE-2025-08-31.md` with current status

--- a/scripts/status-pack.sh
+++ b/scripts/status-pack.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Parse baseline YAML if exists
+BASELINE_FILE=$(find docs -name "BASELINE-*.md" -type f | sort -r | head -1)
+if [ -f "$BASELINE_FILE" ]; then
+    BASELINE_YAML=$(sed -n '/^```yaml$/,/^```$/p' "$BASELINE_FILE" | sed '1d;$d')
+    echo "$BASELINE_YAML" > /tmp/baseline.yaml
+fi
+
+# Placeholder for existing status pack logic

--- a/src/Baseline/BaselineComparisonRenderer.php
+++ b/src/Baseline/BaselineComparisonRenderer.php
@@ -1,0 +1,34 @@
+<?php
+// src/Baseline/BaselineComparisonRenderer.php
+
+declare(strict_types=1);
+
+namespace SmartAlloc\Baseline;
+
+class BaselineComparisonRenderer
+{
+    public function render(array $baseline): string
+    {
+        $date = $baseline['date_persian'] ?? '';
+        $out = "\n## طبق «سند مبنا برای ادامه توسعه افزونه بر اساس وضعیت پروژه در تاریخ {$date}» موارد زیر تکمیل و باقی مانده\n\n";
+        $out .= "| فاز | وظیفه | وضعیت | توضیحات |\n";
+        $out .= "|-----|-------|--------|----------|\n";
+        foreach ($baseline['phases'] as $phaseName => $phase) {
+            foreach ($phase['tasks'] as $taskName => $task) {
+                $icon = $this->iconForStatus($task['status'] ?? '');
+                $out .= "| {$phaseName} | {$taskName} | {$icon} {$task['status']} | {$task['description']} |\n";
+            }
+        }
+        return $out;
+    }
+
+    private function iconForStatus(string $status): string
+    {
+        return match ($status) {
+            'completed' => '🟢',
+            'in-progress' => '🟡',
+            'pending' => '🔴',
+            default => '⚪',
+        };
+    }
+}

--- a/src/Baseline/BaselineParser.php
+++ b/src/Baseline/BaselineParser.php
@@ -1,0 +1,48 @@
+<?php
+// src/Baseline/BaselineParser.php
+
+declare(strict_types=1);
+
+namespace SmartAlloc\Baseline;
+
+class BaselineParser
+{
+    public function parse(?string $yaml): ?array
+    {
+        if (null === $yaml || '' === trim($yaml)) {
+            return null;
+        }
+        if (function_exists('yaml_parse')) {
+            $parsed = yaml_parse($yaml);
+            return is_array($parsed) ? $parsed : null;
+        }
+        $lines   = preg_split('/\r?\n/', trim($yaml));
+        $result  = [];
+        $stack   = [&$result];
+        $indents = [0];
+        foreach ($lines as $line) {
+            if ('' === trim($line)) {
+                continue;
+            }
+            if (!preg_match('/^(\s*)([^:]+):\s*(.*)$/', $line, $m)) {
+                continue;
+            }
+            $indentStr = $m[1];
+            $key       = $m[2];
+            $value     = $m[3];
+            $indent    = strlen($indentStr);
+            while ($indent < end($indents)) {
+                array_pop($indents);
+                array_pop($stack);
+            }
+            if ($value === '') {
+                $stack[count($stack)-1][$key] = [];
+                $stack[]                       =& $stack[count($stack)-1][$key];
+                $indents[]                     = $indent + 2;
+            } else {
+                $stack[count($stack)-1][$key] = trim($value, "'\"");
+            }
+        }
+        return $result;
+    }
+}

--- a/tests/Unit/BaselineComparisonRendererTest.php
+++ b/tests/Unit/BaselineComparisonRendererTest.php
@@ -1,0 +1,30 @@
+<?php
+// tests/Unit/BaselineComparisonRendererTest.php
+
+declare(strict_types=1);
+
+namespace SmartAlloc\Tests\Unit;
+
+use SmartAlloc\Baseline\BaselineComparisonRenderer;
+use SmartAlloc\Tests\BaseTestCase;
+
+class BaselineComparisonRendererTest extends BaseTestCase
+{
+    public function testRendersComparisonTable(): void
+    {
+        $baseline = [
+            'date_persian' => '10 شهریور 1404',
+            'phases' => [
+                'foundation' => [
+                    'tasks' => [
+                        'security' => ['status' => 'completed', 'description' => 'امنیت'],
+                    ],
+                ],
+            ],
+        ];
+        $renderer = new BaselineComparisonRenderer();
+        $output = $renderer->render($baseline);
+        $this->assertStringContainsString('🟢', $output);
+        $this->assertStringContainsString('foundation', $output);
+    }
+}

--- a/tests/Unit/BaselineParserTest.php
+++ b/tests/Unit/BaselineParserTest.php
@@ -1,0 +1,29 @@
+<?php
+// tests/Unit/BaselineParserTest.php
+
+declare(strict_types=1);
+
+namespace SmartAlloc\Tests\Unit;
+
+use SmartAlloc\Baseline\BaselineParser;
+use SmartAlloc\Tests\BaseTestCase;
+
+class BaselineParserTest extends BaseTestCase
+{
+    public function testParsesValidBaselineYaml(): void
+    {
+        $parser = new BaselineParser();
+        $yaml = file_get_contents(__DIR__ . '/../fixtures/baseline-valid.yaml');
+        $result = $parser->parse($yaml);
+        $this->assertArrayHasKey('phases', $result);
+        $this->assertArrayHasKey('foundation', $result['phases']);
+        $this->assertSame('completed', $result['phases']['foundation']['status']);
+    }
+
+    public function testHandlesMissingBaselineGracefully(): void
+    {
+        $parser = new BaselineParser();
+        $result = $parser->parse(null);
+        $this->assertNull($result);
+    }
+}

--- a/tests/fixtures/baseline-valid.yaml
+++ b/tests/fixtures/baseline-valid.yaml
@@ -1,0 +1,7 @@
+project_baseline:
+  date: "2025-08-31"
+  date_persian: "10 شهریور 1404"
+  version: "1.0.0"
+phases:
+  foundation:
+    status: completed


### PR DESCRIPTION
## Summary
- add baseline document for project status
- parse baseline in status-pack script and codex prompt
- add baseline parser and renderer with tests

## Testing
- `vendor/bin/phpcs src/Baseline/BaselineParser.php`
- `vendor/bin/phpcs src/Baseline/BaselineComparisonRenderer.php`
- `vendor/bin/phpunit --coverage-xml=coverage.xml --coverage-php=coverage.dat tests/Unit/BaselineParserTest.php tests/Unit/BaselineComparisonRendererTest.php`
- `bash -n scripts/sync_scorecards.sh`
- `php -l tests/RuleEngine/FailureModesTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68b5dc68413c8321812fc15e81319d01