### PR TITLE
feat(export): add streaming export with bulk error logging

### DIFF
--- a/migrations/2025_09_01_create_export_errors_table.php
+++ b/migrations/2025_09_01_create_export_errors_table.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+use SmartAlloc\Infra\DB\TableResolver;
+use SmartAlloc\Services\DbSafe;
+
+function smartalloc_run_migration_2025_09_01_create_export_errors_table(): void {
+    global $wpdb;
+    $resolver = new TableResolver($wpdb);
+    $table    = $resolver->exportErrors();
+    $sql      = "CREATE TABLE {$table} (
+        id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+        allocation_id BIGINT UNSIGNED NOT NULL,
+        error_type VARCHAR(50) NOT NULL,
+        message TEXT NOT NULL,
+        created_at DATETIME NOT NULL,
+        INDEX idx_allocation (allocation_id),
+        INDEX idx_created (created_at)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci";
+    $wpdb->query(DbSafe::mustPrepare($sql, [])); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+}

--- a/src/Http/Ajax/ExportStreamAction.php
+++ b/src/Http/Ajax/ExportStreamAction.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SmartAlloc\Http\Ajax;
+
+use SmartAlloc\Services\ExportService;
+use WP_REST_Request;
+
+final class ExportStreamAction
+{
+    public function __construct(private ExportService $svc) {}
+
+    public function register(): void
+    {
+        add_action('wp_ajax_smartalloc_export_stream', [$this, 'handle']);
+    }
+
+    public function handle(): void
+    {
+        $nonce = filter_input(INPUT_GET, '_wpnonce', FILTER_SANITIZE_STRING);
+        $nonce = is_null($nonce) ? '' : wp_unslash($nonce);
+        if (!wp_verify_nonce($nonce, 'smartalloc_export_stream') || !current_user_can('smartalloc_manage')) {
+            wp_send_json_error('forbidden', 403);
+        }
+
+        $filters = [];
+        $limit = filter_input(INPUT_GET, 'limit', FILTER_SANITIZE_NUMBER_INT);
+        if ($limit !== null) {
+            $filters['limit'] = (string) wp_unslash($limit);
+        }
+        nocache_headers();
+        $this->svc->streamExport($filters);
+    }
+}

--- a/src/Infra/DB/TableResolver.php
+++ b/src/Infra/DB/TableResolver.php
@@ -15,4 +15,5 @@ final class TableResolver {
     public function runs(FormContext $ctx): string        { return "{$this->prefix}smartalloc_runs{$ctx->suffix()}"; }
     public function logs(FormContext $ctx): string        { return "{$this->prefix}smartalloc_logs{$ctx->suffix()}"; }
     public function dlq(FormContext $ctx): string         { return "{$this->prefix}smartalloc_dlq{$ctx->suffix()}"; }
+    public function exportErrors(): string                { return "{$this->prefix}smartalloc_export_errors"; }
 }

--- a/src/Services/DbSafe.php
+++ b/src/Services/DbSafe.php
@@ -33,9 +33,24 @@ final class DbSafe
         }
 
         global $wpdb;
-        $prepared = $wpdb->prepare($sql, $params);
+        $prepared = $wpdb->prepare($sql, $params); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
         if (preg_match('/(?<!%)%[dsf]/i', $prepared)) {
             throw new \RuntimeException('SQL not fully prepared');
+        }
+        return $prepared;
+    }
+
+    /**
+     * Prepare multiple value fragments for bulk inserts.
+     *
+     * @param array<int,array<int|string|float|null>> $rows
+     * @return array<int,string>
+     */
+    public static function mustPrepareMany(string $fragment, array $rows): array
+    {
+        $prepared = [];
+        foreach ($rows as $params) {
+            $prepared[] = self::mustPrepare($fragment, $params);
         }
         return $prepared;
     }

--- a/tests/Integration/Export/StreamingExportTest.php
+++ b/tests/Integration/Export/StreamingExportTest.php
@@ -1,0 +1,64 @@
+<?php
+declare(strict_types=1);
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use SmartAlloc\Http\Ajax\ExportStreamAction;
+use SmartAlloc\Infra\DB\TableResolver;
+use SmartAlloc\Services\ExportService;
+use SmartAlloc\Tests\BaseTestCase;
+
+if (!class_exists('wpdb')) {
+    class wpdb {
+        public string $prefix = 'wp_';
+        public string $last_query = '';
+        public function query($sql): void { $this->last_query = $sql; }
+    }
+}
+
+final class StreamingExportTest extends BaseTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Monkey\setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    public function test_ajax_endpoint_streams_correctly(): void
+    {
+        $GLOBALS['wpdb'] = new wpdb();
+        Functions\when('add_action');
+        Functions\expect('wp_verify_nonce')->with('n', 'smartalloc_export_stream')->andReturn(true);
+        Functions\expect('current_user_can')->with('smartalloc_manage')->andReturn(true);
+        Functions\expect('wp_send_json_error')->never();
+        Functions\expect('nocache_headers');
+        $_GET['_wpnonce'] = 'n';
+        $_GET['limit']    = '1';
+        $svc    = new ExportService(new TableResolver($GLOBALS['wpdb']));
+        $action = new ExportStreamAction($svc);
+        ob_start();
+        $action->handle();
+        $out = ob_get_clean();
+        $this->assertStringContainsString('PK', (string) $out);
+    }
+
+    public function test_error_handling_persists_to_database(): void
+    {
+        $GLOBALS['wpdb'] = new wpdb();
+        $svc = new ExportService(new TableResolver($GLOBALS['wpdb']));
+        $ref = new \ReflectionClass($svc);
+        $m   = $ref->getMethod('bulkInsertErrors');
+        $m->setAccessible(true);
+        $m->invoke($svc, [
+            ['allocation_id' => 5, 'error_type' => 'E', 'error_message' => 'oops'],
+            ['allocation_id' => 6, 'error_type' => 'E', 'error_message' => 'bad'],
+        ]);
+        $this->assertStringContainsString('INSERT INTO', $GLOBALS['wpdb']->last_query);
+    }
+}


### PR DESCRIPTION
## Summary
- implement streaming export via PhpSpreadsheet with disk caching
- log export errors in bulk using DbSafe::mustPrepareMany
- add AJAX action for on-demand export streaming

## Testing
- `vendor/bin/phpcs src/Services/ExportService.php src/Services/DbSafe.php src/Http/Ajax/ExportStreamAction.php src/Infra/DB/TableResolver.php tests/Unit/Services/ExportServiceTest.php tests/Integration/Export/StreamingExportTest.php migrations/2025_09_01_create_export_errors_table.php`
- `vendor/bin/phpunit tests/Unit/Services/ExportServiceTest.php tests/Integration/Export/StreamingExportTest.php`
- `php baseline-check --current-phase=foundation` *(fails: Could not open input file: baseline-check)*
- `php baseline-compare --feature=export` *(fails: Could not open input file: baseline-compare)*
- `php gap-analysis --target=export` *(fails: Could not open input file: gap-analysis)*

------
https://chatgpt.com/codex/tasks/task_e_68b5f908505883218327a13e150722c3