### PR TITLE
feat(export): stream allocations with DbSafe chunking

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -23,7 +23,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-01T19:57:08Z
+Last Updated (UTC): 2025-09-01T20:09:28Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -23,7 +23,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-01T20:09:28Z
+Last Updated (UTC): 2025-09-01T20:09:32Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-01T20:09:28Z",
+  "last_update_utc": "2025-09-01T20:09:32Z",
   "repo": {
     "default_branch": "codex/implement-streaming-export-feature",
-    "last_commit": "456d97732e0a1d00d02dc5ddbd0195e554323185",
-    "commits_total": 759,
+    "last_commit": "36246eb9717515ada8f08c82807c9343b2b8c95a",
+    "commits_total": 760,
     "files_tracked": 683
   },
   "quality_gate": {

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-01T19:57:08Z",
+  "last_update_utc": "2025-09-01T20:09:28Z",
   "repo": {
-    "default_branch": "main",
-    "last_commit": "b84b408e9e52f455bbe3465425de9be6c49f82ec",
-    "commits_total": 757,
+    "default_branch": "codex/implement-streaming-export-feature",
+    "last_commit": "456d97732e0a1d00d02dc5ddbd0195e554323185",
+    "commits_total": 759,
     "files_tracked": 683
   },
   "quality_gate": {


### PR DESCRIPTION
## Summary
- stream allocation data in chunks using DbSafe prepared queries
- add wpdb test stub to verify streaming export path

## Testing
- `vendor/bin/phpcs src/Services/ExportService.php tests/Integration/Export/StreamingExportTest.php`
- `vendor/bin/phpunit tests/Integration/Export/StreamingExportTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68b5fc5067f08321bd2f65148972ab2c