### PR TITLE
feat(security): sanitize inputs and throttle notifications

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -19,7 +19,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-01T20:34:36Z
+Last Updated (UTC): 2025-09-01T20:34:39Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -19,7 +19,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-01T20:34:39Z
+Last Updated (UTC): 2025-09-01T20:34:43Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1,6 +1,6 @@
 # Feature Status Dashboard
 
-## 📊 Current Project Score: 85/125 (68%)
+## 📊 Current Project Score: 100/125 (80%)
 
 ### **📊 Detailed Validation Score**
 🔒 **Security Score**: 25.00/25
@@ -9,7 +9,7 @@
 📖 **Readability Score**: 20.00/25
 🎯 **Goal Achievement**: 25.00/25
 
-**🏆 Total Score**: 85/125
+**🏆 Total Score**: 100/125
 **📈 Weighted Average**: 92.00%
 
 ### ⛔ Red Flags:
@@ -17,13 +17,9 @@
   "message": "Unsanitized superglobal access /home/runner/work/SmartAlloc/SmartAlloc/src/Debug/ErrorCollector.php:80",
   "severity": 15
 }
-- {
-  "message": "Unsanitized superglobal access /home/runner/work/SmartAlloc/SmartAlloc/src/Debug/ErrorCollector.php:81",
-  "severity": 15
-}
 
 ---
-Last Updated (UTC): 2025-09-01T20:09:46Z
+Last Updated (UTC): 2025-09-01T20:34:36Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-01T20:34:39Z",
+  "last_update_utc": "2025-09-01T20:34:43Z",
   "repo": {
     "default_branch": "codex/harden-security-and-complete-ruleengine-logic",
-    "last_commit": "10246e2d0df341ccd383a3884f53673f7712d89f",
-    "commits_total": 765,
+    "last_commit": "2a2463f2424aefc0c8009d3ebf38a74587adabba",
+    "commits_total": 766,
     "files_tracked": 687
   },
   "quality_gate": {

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-01T20:34:36Z",
+  "last_update_utc": "2025-09-01T20:34:39Z",
   "repo": {
     "default_branch": "codex/harden-security-and-complete-ruleengine-logic",
-    "last_commit": "8fe05543c88aa1de38d2df2e0f9aeaa4dfeb7dbc",
-    "commits_total": 764,
+    "last_commit": "10246e2d0df341ccd383a3884f53673f7712d89f",
+    "commits_total": 765,
     "files_tracked": 687
   },
   "quality_gate": {

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,10 +1,10 @@
 {
-  "last_update_utc": "2025-09-01T20:09:46Z",
+  "last_update_utc": "2025-09-01T20:34:36Z",
   "repo": {
-    "default_branch": "main",
-    "last_commit": "76ddec485ccb21d65ca673da5b8c799a95beead6",
-    "commits_total": 762,
-    "files_tracked": 683
+    "default_branch": "codex/harden-security-and-complete-ruleengine-logic",
+    "last_commit": "8fe05543c88aa1de38d2df2e0f9aeaa4dfeb7dbc",
+    "commits_total": 764,
+    "files_tracked": 687
   },
   "quality_gate": {
     "weighted_threshold": 0.85,

--- a/src/RuleEngine/Contracts.php
+++ b/src/RuleEngine/Contracts.php
@@ -25,6 +25,10 @@ interface RuleEngineContract
     public function evaluate(array $studentCtx): EvaluationResult;
 }
 
-final class RuleEngineException extends \RuntimeException
+class RuleEngineException extends \RuntimeException
+{
+}
+
+final class InvalidRuleException extends RuleEngineException
 {
 }

--- a/src/RuleEngine/RuleEngineService.php
+++ b/src/RuleEngine/RuleEngineService.php
@@ -1,19 +1,118 @@
-<?php declare(strict_types=1);
+<?php
+declare(strict_types=1);
+
 namespace SmartAlloc\RuleEngine;
-use SmartAlloc\Allocation\CapacityProvider;
+
 use SmartAlloc\Allocation\ArrayCapacityProvider;
+use SmartAlloc\Allocation\CapacityProvider;
+
+require_once __DIR__ . '/../Allocation/CapacityProvider.php';
 use SmartAlloc\Rules\ExternalDependencyError;
+
 require_once __DIR__ . '/Contracts.php';
-final class RuleEngineService implements RuleEngineContract {
-    public function __construct(?CapacityProvider $capacity = null) { $this->capacity = $capacity ?? new ArrayCapacityProvider([]); }
-    public function evaluate(array $studentCtx): EvaluationResult {
+
+final class RuleEngineService implements RuleEngineContract
+{
+    private CapacityProvider $capacity;
+
+    public function __construct(?CapacityProvider $capacity = null)
+    {
+        $this->capacity = $capacity ?? new ArrayCapacityProvider([]);
+    }
+
+    /** @param array<string,mixed> $studentCtx */
+    public function evaluate(array $studentCtx): EvaluationResult
+    {
         $score = (float) ($studentCtx['school_fuzzy'] ?? 0.0);
-        $decision = 'reject'; $reasons = ['school_match_low'];
-        if ($score >= 0.90) { $decision = 'auto'; $reasons = []; }
-        elseif ($score >= 0.80) { $decision = 'manual'; $reasons = ['school_match_borderline']; }
-        $r = new EvaluationResult($decision); $r->scores['school_fuzzy'] = $score; $r->reasons = $reasons;
+        $decision = 'reject';
+        $reasons = ['school_match_low'];
+        if ($score >= 0.90) {
+            $decision = 'auto';
+            $reasons = [];
+        } elseif ($score >= 0.80) {
+            $decision = 'manual';
+            $reasons = ['school_match_borderline'];
+        }
+        $r = new EvaluationResult($decision);
+        $r->scores['school_fuzzy'] = $score;
+        $r->reasons = $reasons;
         $flag = apply_filters('smartalloc_rule_cap_check', SMARTALLOC_RULE_CAP_CHECK);
-        if ($flag) { $mentorId = $studentCtx['mentor_id'] ?? 0; if (!$this->capacity->hasCapacity($mentorId)) { throw new ExternalDependencyError('NO_CAPACITY'); } }
+        if ($flag) {
+            $mentorId = $studentCtx['mentor_id'] ?? 0;
+            if (!$this->capacity->hasCapacity($mentorId)) {
+                throw new ExternalDependencyError('NO_CAPACITY');
+            }
+        }
         return $r;
+    }
+
+    /**
+     * @param array<string,mixed> $rule
+     * @param array<string,mixed> $context
+     */
+    public function evaluateCompositeRule(array $rule, array $context): bool
+    {
+        if (isset($rule['operator']) && isset($rule['conditions'])) {
+            return $this->evaluateLogicalOperator($rule, $context);
+        }
+        return $this->evaluateSimpleCondition($rule, $context);
+    }
+
+    /**
+     * @param array<string,mixed> $rule
+     * @param array<string,mixed> $context
+     */
+    private function evaluateLogicalOperator(array $rule, array $context): bool
+    {
+        $operator = strtoupper((string) ($rule['operator'] ?? ''));
+        $conditions = is_array($rule['conditions'] ?? null) ? $rule['conditions'] : [];
+        return match ($operator) {
+            'AND' => $this->allConditionsTrue($conditions, $context),
+            'OR' => $this->anyConditionTrue($conditions, $context),
+            default => throw new InvalidRuleException("Unsupported operator: {$operator}"), // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
+        };
+    }
+
+    /** @param array<int,array<string,mixed>> $conditions */
+    private function allConditionsTrue(array $conditions, array $context): bool
+    {
+        foreach ($conditions as $condition) {
+            if (!$this->evaluateCompositeRule($condition, $context)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /** @param array<int,array<string,mixed>> $conditions */
+    private function anyConditionTrue(array $conditions, array $context): bool
+    {
+        foreach ($conditions as $condition) {
+            if ($this->evaluateCompositeRule($condition, $context)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * @param array<string,mixed> $rule
+     * @param array<string,mixed> $context
+     */
+    private function evaluateSimpleCondition(array $rule, array $context): bool
+    {
+        $field = (string) ($rule['field'] ?? '');
+        $op = (string) ($rule['operator'] ?? '');
+        $value = $rule['value'] ?? null;
+        $current = $context[$field] ?? null;
+        return match ($op) {
+            '>' => $current > $value,
+            '>=' => $current >= $value,
+            '<' => $current < $value,
+            '<=' => $current <= $value,
+            '=' => $current === $value,
+            '!=' => $current !== $value,
+            default => throw new InvalidRuleException("Unsupported comparator: {$op}"), // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
+        };
     }
 }

--- a/src/Security/InputRedactor.php
+++ b/src/Security/InputRedactor.php
@@ -1,0 +1,49 @@
+<?php
+declare(strict_types=1);
+
+namespace SmartAlloc\Security;
+
+/**
+ * Sanitize and redact server input values.
+ */
+final class InputRedactor
+{
+    /** @var array<int,string> */
+    private const SENSITIVE_KEYS = [
+        'HTTP_AUTHORIZATION',
+        'PHP_AUTH_PW',
+        'HTTP_COOKIE',
+    ];
+
+    /**
+     * @param mixed $value
+     */
+    public static function sanitizeServerVar(string $key, $value): string
+    {
+        if (in_array($key, self::SENSITIVE_KEYS, true)) {
+            return '[REDACTED]';
+        }
+        $raw = \function_exists('sanitize_text_field')
+            ? \sanitize_text_field((string) $value)
+            : (string) $value;
+        if (\function_exists('wp_strip_all_tags')) {
+            $raw = \wp_strip_all_tags($raw);
+        } else {
+            $raw = strip_tags($raw); // phpcs:ignore WordPressVIPMinimum.Functions.StripTags.StripTagsOneParameter
+        }
+        return trim($raw);
+    }
+
+    /**
+     * @param array<string,mixed> $server
+     * @return array<string,string>
+     */
+    public static function sanitizeServerArray(array $server): array
+    {
+        $sanitized = [];
+        foreach ($server as $k => $v) {
+            $sanitized[$k] = self::sanitizeServerVar((string) $k, $v);
+        }
+        return $sanitized;
+    }
+}

--- a/tests/Unit/RuleEngine/CompositeRuleTest.php
+++ b/tests/Unit/RuleEngine/CompositeRuleTest.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use SmartAlloc\RuleEngine\RuleEngineService;
+
+final class CompositeRuleTest extends TestCase
+{
+    public function test_and_operator_requires_all_conditions_true(): void
+    {
+        $svc = new RuleEngineService();
+        $rule = [
+            'operator' => 'AND',
+            'conditions' => [
+                ['field' => 'age', 'operator' => '>', 'value' => 18],
+                ['field' => 'status', 'operator' => '=', 'value' => 'active'],
+            ],
+        ];
+        $this->assertTrue($svc->evaluateCompositeRule($rule, ['age' => 20, 'status' => 'active']));
+        $this->assertFalse($svc->evaluateCompositeRule($rule, ['age' => 20, 'status' => 'inactive']));
+    }
+
+    public function test_or_operator_requires_any_condition_true(): void
+    {
+        $svc = new RuleEngineService();
+        $rule = [
+            'operator' => 'OR',
+            'conditions' => [
+                ['field' => 'age', 'operator' => '>', 'value' => 18],
+                ['field' => 'status', 'operator' => '=', 'value' => 'active'],
+            ],
+        ];
+        $this->assertTrue($svc->evaluateCompositeRule($rule, ['age' => 20, 'status' => 'inactive']));
+        $this->assertFalse($svc->evaluateCompositeRule($rule, ['age' => 17, 'status' => 'inactive']));
+    }
+}

--- a/tests/Unit/Security/InputRedactorTest.php
+++ b/tests/Unit/Security/InputRedactorTest.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use SmartAlloc\Security\InputRedactor;
+
+if (!function_exists('sanitize_text_field')) {
+    function sanitize_text_field($s) { return trim(strip_tags((string) $s)); }
+}
+
+final class InputRedactorTest extends TestCase
+{
+    public function test_sensitive_keys_are_redacted(): void
+    {
+        $out = InputRedactor::sanitizeServerVar('HTTP_AUTHORIZATION', 'Bearer abc');
+        $this->assertSame('[REDACTED]', $out);
+    }
+
+    public function test_normal_values_are_sanitized(): void
+    {
+        $out = InputRedactor::sanitizeServerVar('REQUEST_METHOD', '<script>GET</script>');
+        $this->assertSame('GET', $out);
+    }
+}

--- a/tests/Unit/Services/NotificationRateLimitTest.php
+++ b/tests/Unit/Services/NotificationRateLimitTest.php
@@ -1,0 +1,61 @@
+<?php
+declare(strict_types=1);
+
+use SmartAlloc\Services\{NotificationService,CircuitBreaker,Logging,Metrics};
+use PHPUnit\Framework\TestCase;
+
+if (!function_exists('add_action')) { function add_action() {} }
+if (!function_exists('apply_filters')) { function apply_filters($t, $v) { return $v; } }
+if (!function_exists('get_transient')) {
+    function get_transient($k) { global $t; return $t[$k] ?? false; }
+}
+if (!function_exists('set_transient')) {
+    function set_transient($k, $v, $e) { global $t; $t[$k] = $v; }
+}
+if (!function_exists('wp_schedule_single_event')) {
+    function wp_schedule_single_event($ts, $hook, $args) {}
+}
+if (!function_exists('wp_json_encode')) {
+    function wp_json_encode($d) { return json_encode($d); }
+}
+if (!function_exists('trailingslashit')) {
+    function trailingslashit($p) { return rtrim($p, '/') . '/'; }
+}
+if (!class_exists('wpdb')) {
+    class wpdb {
+        public $prefix = '';
+        public $queries = [];
+        public function insert($t, $d) {}
+        public function get_results($q, $type = ARRAY_A) { return []; }
+        public function get_row($q, $type = ARRAY_A) { return []; }
+        public function prepare($q, ...$a) { return $q; }
+    }
+}
+
+final class NotificationRateLimitTest extends TestCase
+{
+    public function test_rate_limiting_blocks_excessive_notifications(): void
+    {
+        global $t; $t = [];
+        $GLOBALS['wpdb'] = new wpdb();
+        $svc = new NotificationService(new CircuitBreaker(), new Logging(), new Metrics());
+        for ($i = 0; $i < 10; $i++) {
+            $svc->send(['body' => []]);
+        }
+        $this->assertSame(10, get_transient('smartalloc_notify_rate'));
+        $svc->send(['body' => []]);
+        $this->assertSame(10, get_transient('smartalloc_notify_rate'));
+    }
+
+    public function test_rate_limit_resets_after_transient_cleared(): void
+    {
+        global $t; $t = ['smartalloc_notify_rate' => 10];
+        $GLOBALS['wpdb'] = new wpdb();
+        $svc = new NotificationService(new CircuitBreaker(), new Logging(), new Metrics());
+        $svc->send(['body' => []]);
+        $this->assertSame(10, get_transient('smartalloc_notify_rate'));
+        unset($t['smartalloc_notify_rate']);
+        $svc->send(['body' => []]);
+        $this->assertSame(1, get_transient('smartalloc_notify_rate'));
+    }
+}


### PR DESCRIPTION
## Summary
- sanitize and redact server inputs via new `InputRedactor`
- throttle notification dispatches to 10/min using transients
- add composite AND/OR evaluation for rule engine

## Testing
- `php baseline-check --current-phase=expansion` *(fails: Could not open input file)*
- `php baseline-compare --feature=RuleEngine` *(fails: Could not open input file)*
- `php gap-analysis --target=security` *(fails: Could not open input file)*
- `vendor/bin/phpunit tests/Unit/Security/InputRedactorTest.php` *(passes)*
- `vendor/bin/phpunit tests/Unit/Services/NotificationRateLimitTest.php` *(passes)*
- `vendor/bin/phpunit tests/Unit/RuleEngine/CompositeRuleTest.php` *(passes)*
- `vendor/bin/phpcs src/Security/InputRedactor.php src/Debug/ErrorCollector.php src/Services/NotificationService.php src/RuleEngine/RuleEngineService.php src/RuleEngine/Contracts.php tests/Unit/Security/InputRedactorTest.php tests/Unit/Services/NotificationRateLimitTest.php tests/Unit/RuleEngine/CompositeRuleTest.php` *(passes)*

------
https://chatgpt.com/codex/tasks/task_e_68b6000cc2588321afaa313f1cbcafca