### PR TITLE
feat(tooling): add baseline verification scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,3 +26,18 @@ gen-context:
 
 state:
 	bash scripts/update_state.sh
+
+baseline-check:
+	@php scripts/baseline-check.php --current-phase=$(PHASE)
+
+baseline-compare:
+	@php scripts/baseline-compare.php --from=$(FROM) --to=$(TO)
+
+gap-analysis:
+	@php scripts/gap-analysis.php --target-phase=$(TARGET)
+
+pre-commit: baseline-check
+	@if [ $$? -ne 0 ]; then \
+		echo "❌ Baseline check failed. Run 'make gap-analysis TARGET=EXPANSION' for details."; \
+		exit 1; \
+	fi

--- a/config/baseline.json
+++ b/config/baseline.json
@@ -1,0 +1,38 @@
+{
+  "version": "1.0.0",
+  "last_updated": "2024-09-10",
+  "phases": {
+    "FOUNDATION": {
+      "metrics": {
+        "Security": 20,
+        "Logic": 16,
+        "Performance": 16,
+        "Observability": 14,
+        "Maintainability": 14
+      },
+      "required_features": ["RuleEngine", "ErrorCollector", "Logger"],
+      "completion_target": 80
+    },
+    "EXPANSION": {
+      "metrics": {
+        "Security": 20,
+        "Logic": 17,
+        "Performance": 17,
+        "Observability": 15,
+        "Maintainability": 15
+      },
+      "required_features": ["RuleEngine.composite", "ExportStreaming", "CorrelationID"],
+      "completion_target": 84
+    },
+    "POLISH": {
+      "metrics": {
+        "Security": 22,
+        "Logic": 18,
+        "Performance": 18,
+        "Observability": 16,
+        "Maintainability": 16
+      },
+      "completion_target": 90
+    }
+  }
+}

--- a/metrics/2024-09-01.json
+++ b/metrics/2024-09-01.json
@@ -1,0 +1,7 @@
+{
+  "Security": 20,
+  "Logic": 14,
+  "Performance": 13,
+  "Observability": 11,
+  "Maintainability": 16
+}

--- a/metrics/current.json
+++ b/metrics/current.json
@@ -1,0 +1,7 @@
+{
+  "Security": 20,
+  "Logic": 15,
+  "Performance": 14,
+  "Observability": 12,
+  "Maintainability": 17
+}

--- a/scripts/baseline-check.php
+++ b/scripts/baseline-check.php
@@ -1,0 +1,89 @@
+#!/usr/bin/env php
+<?php
+/**
+ * SmartAlloc Baseline Verification Tool.
+ * Usage: php scripts/baseline-check.php --current-phase=EXPANSION
+ */
+
+namespace SmartAlloc\Scripts;
+
+use RuntimeException;
+
+class BaselineException extends RuntimeException {}
+
+class BaselineChecker
+{
+    private const BASELINE_CONFIG = __DIR__ . '/../config/baseline.json';
+    private const METRICS_FILE    = __DIR__ . '/../metrics/current.json';
+
+    private array $baseline;
+    private array $currentMetrics;
+
+    public function __construct()
+    {
+        if (! is_file(self::BASELINE_CONFIG)) {
+            throw new BaselineException('Baseline config missing');
+        }
+
+        $data            = json_decode(file_get_contents(self::BASELINE_CONFIG), true);
+        $this->baseline  = is_array($data) ? $data : [];
+        $this->currentMetrics = $this->loadMetrics();
+    }
+
+    public function verifyPhase(string $phase): array
+    {
+        $phaseData = $this->baseline['phases'][$phase] ?? ['metrics' => []];
+        $gaps      = [];
+
+        foreach ($phaseData['metrics'] as $dimension => $required) {
+            $current = $this->currentMetrics[$dimension] ?? 0;
+            if ($current < $required) {
+                $gaps[$dimension] = [
+                    'required' => $required,
+                    'current'  => $current,
+                    'gap'      => $required - $current,
+                ];
+            }
+        }
+
+        return [
+            'phase'            => $phase,
+            'valid'            => empty($gaps),
+            'gaps'             => $gaps,
+            'overall_progress' => $this->calculateProgress($phaseData['metrics']),
+        ];
+    }
+
+    private function loadMetrics(): array
+    {
+        if (! is_file(self::METRICS_FILE)) {
+            return [];
+        }
+
+        $data = json_decode(file_get_contents(self::METRICS_FILE), true);
+        return is_array($data) ? $data : [];
+    }
+
+    private function calculateProgress(array $requirements): float
+    {
+        $requiredTotal = array_sum($requirements);
+        if ($requiredTotal <= 0) {
+            return 0.0;
+        }
+
+        $current = 0;
+        foreach ($requirements as $dimension => $required) {
+            $current += min($this->currentMetrics[$dimension] ?? 0, $required);
+        }
+
+        return round(($current / $requiredTotal) * 100, 2);
+    }
+}
+
+$options = getopt('', ['current-phase:']);
+$phase   = $options['current-phase'] ?? 'FOUNDATION';
+$checker = new BaselineChecker();
+$result  = $checker->verifyPhase($phase);
+
+echo json_encode($result, JSON_PRETTY_PRINT) . PHP_EOL;
+exit($result['valid'] ? 0 : 1);

--- a/scripts/baseline-compare.php
+++ b/scripts/baseline-compare.php
@@ -1,0 +1,64 @@
+#!/usr/bin/env php
+<?php
+/**
+ * Baseline Comparison Tool.
+ * Usage: php scripts/baseline-compare.php --from=2024-09-01 --to=current
+ */
+
+namespace SmartAlloc\Scripts;
+
+use RuntimeException;
+
+class BaselineException extends RuntimeException {}
+
+class BaselineComparator
+{
+    private const METRICS_DIR = __DIR__ . '/../metrics/';
+
+    public function compare(string $from, string $to): array
+    {
+        $fromMetrics = $this->loadMetrics($from);
+        $toMetrics   = $this->loadMetrics($to);
+
+        $comparison = [
+            'period'       => ['from' => $from, 'to' => $to],
+            'improvements' => [],
+            'regressions'  => [],
+            'unchanged'    => [],
+        ];
+
+        foreach ($fromMetrics as $dimension => $fromValue) {
+            $toValue = $toMetrics[$dimension] ?? 0;
+            $delta   = $toValue - $fromValue;
+
+            if ($delta > 0) {
+                $comparison['improvements'][$dimension] = $delta;
+            } elseif ($delta < 0) {
+                $comparison['regressions'][$dimension] = $delta;
+            } else {
+                $comparison['unchanged'][] = $dimension;
+            }
+        }
+
+        return $comparison;
+    }
+
+    private function loadMetrics(string $name): array
+    {
+        $file = self::METRICS_DIR . $name . '.json';
+        if (! is_file($file)) {
+            throw new BaselineException("Metrics file {$name} not found");
+        }
+
+        $data = json_decode(file_get_contents($file), true);
+        return is_array($data) ? $data : [];
+    }
+}
+
+$options = getopt('', ['from:', 'to:']);
+$from    = $options['from'] ?? 'start';
+$to      = $options['to'] ?? 'current';
+$comp    = new BaselineComparator();
+$result  = $comp->compare($from, $to);
+
+echo json_encode($result, JSON_PRETTY_PRINT) . PHP_EOL;

--- a/scripts/gap-analysis.php
+++ b/scripts/gap-analysis.php
@@ -1,0 +1,68 @@
+#!/usr/bin/env php
+<?php
+/**
+ * Gap Analysis & Recommendation Engine.
+ * Usage: php scripts/gap-analysis.php --target-phase=POLISH
+ */
+
+namespace SmartAlloc\Scripts;
+
+use RuntimeException;
+
+class BaselineException extends RuntimeException {}
+
+class GapAnalyzer
+{
+    private const BASELINE_CONFIG = __DIR__ . '/../config/baseline.json';
+    private const EFFORT_MATRIX   = [
+        'Security'       => ['effort_per_point' => 8,  'risk' => 'HIGH'],
+        'Logic'          => ['effort_per_point' => 6,  'risk' => 'MEDIUM'],
+        'Performance'    => ['effort_per_point' => 10, 'risk' => 'HIGH'],
+        'Observability'  => ['effort_per_point' => 4,  'risk' => 'LOW'],
+        'Maintainability'=> ['effort_per_point' => 5,  'risk' => 'MEDIUM'],
+    ];
+
+    private array $baseline;
+
+    public function __construct()
+    {
+        if (! is_file(self::BASELINE_CONFIG)) {
+            throw new BaselineException('Baseline config missing');
+        }
+
+        $data           = json_decode(file_get_contents(self::BASELINE_CONFIG), true);
+        $this->baseline = is_array($data) ? $data : [];
+    }
+
+    public function analyze(string $targetPhase): array
+    {
+        $phaseData = $this->baseline['phases'][$targetPhase] ?? ['metrics' => []];
+        $gaps      = $phaseData['metrics'];
+        $recommendations = [];
+        $totalEffort     = 0;
+
+        foreach ($gaps as $dimension => $required) {
+            $effort = $required * self::EFFORT_MATRIX[$dimension]['effort_per_point'];
+            $totalEffort += $effort;
+            $recommendations[] = [
+                'dimension'    => $dimension,
+                'gap'          => $required,
+                'effort_hours' => $effort,
+                'priority'     => self::EFFORT_MATRIX[$dimension]['risk'],
+            ];
+        }
+
+        return [
+            'target_phase'        => $targetPhase,
+            'total_effort_hours'  => $totalEffort,
+            'recommendations'     => $recommendations,
+        ];
+    }
+}
+
+$options = getopt('', ['target-phase:']);
+$target  = $options['target-phase'] ?? 'FOUNDATION';
+$analyzer = new GapAnalyzer();
+$result   = $analyzer->analyze($target);
+
+echo json_encode($result, JSON_PRETTY_PRINT) . PHP_EOL;


### PR DESCRIPTION
## Summary
- add baseline-check, compare, and gap analysis CLI tools
- track baseline metrics in config and sample data
- wire Makefile helpers for baseline verification

## Testing
- `composer phpcs` (fails: Tabs must be used to indent lines; spaces are not allowed)
- `composer test` (fails: Tests: 46, Assertions: 109, Errors: 4.)
- `php scripts/baseline-check.php --current-phase=EXPANSION`
- `php scripts/baseline-compare.php --from=2024-09-01 --to=current`
- `php scripts/gap-analysis.php --target-phase=POLISH`


------
https://chatgpt.com/codex/tasks/task_e_68b68ca6d36883219482bcd520e2b1a1