### PR TITLE
test(rule-engine): add composite rule tests

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -19,7 +19,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-02T06:44:47Z
+Last Updated (UTC): 2025-09-02T06:44:50Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -19,7 +19,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-02T06:34:52Z
+Last Updated (UTC): 2025-09-02T06:44:47Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -19,7 +19,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-02T06:44:50Z
+Last Updated (UTC): 2025-09-02T06:44:51Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-02T06:44:47Z",
+  "last_update_utc": "2025-09-02T06:44:50Z",
   "repo": {
     "default_branch": "codex/locate-ruleengineservice.php-for-review",
-    "last_commit": "7d25fb74d1631078b14d242dcf7d382c404a02aa",
-    "commits_total": 776,
+    "last_commit": "06eb38d7ec33ebeeae8fea4ad1b5c3eb9d0fd38f",
+    "commits_total": 777,
     "files_tracked": 694
   },
   "quality_gate": {

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,10 +1,10 @@
 {
-  "last_update_utc": "2025-09-02T06:34:52Z",
+  "last_update_utc": "2025-09-02T06:44:47Z",
   "repo": {
-    "default_branch": "main",
-    "last_commit": "d1e04c5d2288c6edd9264b0ce71dbf4cda14d7ad",
-    "commits_total": 774,
-    "files_tracked": 693
+    "default_branch": "codex/locate-ruleengineservice.php-for-review",
+    "last_commit": "7d25fb74d1631078b14d242dcf7d382c404a02aa",
+    "commits_total": 776,
+    "files_tracked": 694
   },
   "quality_gate": {
     "weighted_threshold": 0.85,

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-02T06:44:50Z",
+  "last_update_utc": "2025-09-02T06:44:51Z",
   "repo": {
     "default_branch": "codex/locate-ruleengineservice.php-for-review",
-    "last_commit": "06eb38d7ec33ebeeae8fea4ad1b5c3eb9d0fd38f",
-    "commits_total": 777,
+    "last_commit": "7b4fdc7bd0e087b99490205101a170516f55590d",
+    "commits_total": 778,
     "files_tracked": 694
   },
   "quality_gate": {

--- a/src/RuleEngine/RuleEngineService.php
+++ b/src/RuleEngine/RuleEngineService.php
@@ -11,6 +11,9 @@ use SmartAlloc\Rules\ExternalDependencyError;
 
 require_once __DIR__ . '/Contracts.php';
 
+/**
+ * Provides rule evaluation including nested composite logic.
+ */
 final class RuleEngineService implements RuleEngineContract
 {
     private CapacityProvider $capacity;
@@ -47,8 +50,16 @@ final class RuleEngineService implements RuleEngineContract
     }
 
     /**
-     * @param array<string,mixed> $rule
-     * @param array<string,mixed> $context
+     * Evaluate a rule tree supporting nested AND/OR logic.
+     *
+     * A rule is either a simple condition:
+     * [ 'field' => 'amount', 'operator' => '>', 'value' => 100 ]
+     * or a composite node:
+     * [ 'operator' => 'AND|OR', 'conditions' => [ ...child rules... ] ]
+     *
+     * @param array<string,mixed> $rule    Root rule or condition
+     * @param array<string,mixed> $context Data used for evaluation
+     * @throws InvalidRuleException When an unsupported operator or comparator is encountered
      */
     public function evaluateCompositeRule(array $rule, array $context): bool
     {
@@ -59,8 +70,11 @@ final class RuleEngineService implements RuleEngineContract
     }
 
     /**
-     * @param array<string,mixed> $rule
-     * @param array<string,mixed> $context
+     * Evaluate a composite node using its logical operator.
+     *
+     * @param array<string,mixed> $rule    Composite rule definition
+     * @param array<string,mixed> $context Runtime context
+     * @throws InvalidRuleException When the operator is not AND or OR
      */
     private function evaluateLogicalOperator(array $rule, array $context): bool
     {
@@ -96,8 +110,11 @@ final class RuleEngineService implements RuleEngineContract
     }
 
     /**
-     * @param array<string,mixed> $rule
-     * @param array<string,mixed> $context
+     * Evaluate a simple condition against the context.
+     *
+     * @param array<string,mixed> $rule    Condition definition
+     * @param array<string,mixed> $context Runtime context
+     * @throws InvalidRuleException When the comparator is unsupported
      */
     private function evaluateSimpleCondition(array $rule, array $context): bool
     {

--- a/tests/RuleEngine/CompositeEvaluationTest.php
+++ b/tests/RuleEngine/CompositeEvaluationTest.php
@@ -1,0 +1,58 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use SmartAlloc\RuleEngine\RuleEngineService;
+use SmartAlloc\RuleEngine\InvalidRuleException;
+
+final class CompositeEvaluationTest extends TestCase
+{
+    private RuleEngineService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new RuleEngineService();
+    }
+
+    public function test_nested_and_or_logic(): void
+    {
+        $rule = [
+            'operator' => 'OR',
+            'conditions' => [
+                [
+                    'operator' => 'AND',
+                    'conditions' => [
+                        ['field' => 'amount', 'operator' => '>', 'value' => 100],
+                        ['field' => 'category', 'operator' => '=', 'value' => 'premium'],
+                    ],
+                ],
+                ['field' => 'priority', 'operator' => '=', 'value' => 'urgent'],
+            ],
+        ];
+
+        $context1 = ['amount' => 150, 'category' => 'premium', 'priority' => 'low'];
+        $context2 = ['amount' => 50, 'category' => 'standard', 'priority' => 'urgent'];
+        $context3 = ['amount' => 50, 'category' => 'standard', 'priority' => 'low'];
+
+        $this->assertTrue($this->service->evaluateCompositeRule($rule, $context1));
+        $this->assertTrue($this->service->evaluateCompositeRule($rule, $context2));
+        $this->assertFalse($this->service->evaluateCompositeRule($rule, $context3));
+    }
+
+    public function test_invalid_operator_throws_exception(): void
+    {
+        $this->expectException(InvalidRuleException::class);
+        $this->expectExceptionMessage('Unsupported operator: XOR');
+        $rule = ['operator' => 'XOR', 'conditions' => []];
+        $this->service->evaluateCompositeRule($rule, []);
+    }
+
+    public function test_invalid_comparator_throws_exception(): void
+    {
+        $this->expectException(InvalidRuleException::class);
+        $this->expectExceptionMessage('Unsupported comparator: LIKE');
+        $rule = ['field' => 'amount', 'operator' => 'LIKE', 'value' => 100];
+        $this->service->evaluateCompositeRule($rule, ['amount' => 100]);
+    }
+}


### PR DESCRIPTION
## Summary
- document composite evaluation behavior with detailed docblocks
- add unit tests covering nested AND/OR rules and invalid operators/comparators

## Testing
- `vendor/bin/phpcs src/RuleEngine/RuleEngineService.php tests/RuleEngine/CompositeEvaluationTest.php`
- `vendor/bin/phpunit tests/RuleEngine/CompositeEvaluationTest.php`

------
https://chatgpt.com/codex/tasks/task_e_68b690a7882c832187a3fc8d7387f81c