### PR TITLE
feat: activate project history system

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -2,4 +2,24 @@
 set -euo pipefail
 echo "▶ pre-commit: php syntax & smoke"
 composer lint:php
-composer smoke || { echo "Smoke failed; fix before commit."; exit 1; }
+composer test:smoke || { echo "Smoke failed; fix before commit."; exit 1; }
+if [ ! -f ai_outputs/last_state.yml ]; then echo "⚠️ ai_outputs/last_state.yml not found. Run scripts/status-auditor.sh."; exit 0; fi
+[ -f docs/PROJECT_STATE.yml ] || { mkdir -p docs; cat <<'EOT' > docs/PROJECT_STATE.yml
+# تاریخچهٔ انسانی پروژه SmartAlloc
+# هر ورودی با تاریخ و وضعیت پروژه در زمان commit ذخیره می‌شود
+# این فایل به صورت خودکار توسط pre-commit hook به‌روز می‌شود
+# هرگز به صورت دستی ویرایش نشود
+EOT
+}
+TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+COMMIT_HASH=$(git rev-parse --short HEAD 2>/dev/null || echo "N/A")
+BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "N/A")
+{
+  echo ""
+  echo "timestamp: \"$TIMESTAMP\""
+  echo "commit: \"$COMMIT_HASH\""
+  echo "branch: \"$BRANCH\""
+  cat ai_outputs/last_state.yml
+} >> docs/PROJECT_STATE.yml
+git add docs/PROJECT_STATE.yml
+echo "✅ وضعیت پروژه به docs/PROJECT_STATE.yml الحاق شد"

--- a/ai_outputs/last_state.yml
+++ b/ai_outputs/last_state.yml
@@ -1,12 +1,13 @@
-timestamp: 2025-08-30T11:00:39Z
-feature: DLQ replay action and perf budget tests
-selected_option: C
-scores:
-  security: 21
-  logic: 18
-  performance: 18
-  readability: 19
-  goal: 17
-weighted_percent: 93
-status: completed
-notes: Added retry-based mailer, admin DLQ replay action, circuit breaker protection, and performance budget test.
+phase: "foundation"
+phase_status: "foundation"
+completion_percent: 11
+timeline_deviation: "+0"
+critical_gaps: ["Rule Engine lacks failure mode tests","Notifications need retry with wp_mail"]
+risks: []
+5d_scores:
+  security: 25
+  logic: 25
+  performance: 25
+  readability: 15
+  goal: 20
+weighted_percent: 95.0

--- a/docs/PROJECT_STATE.yml
+++ b/docs/PROJECT_STATE.yml
@@ -1,11 +1,22 @@
-- date: '2025-08-30'
-  status: 93
-  phase: 'expansion'
-  scores:
-    security: 21
-    logic: 18
-    performance: 18
-    readability: 19
-    goal: 17
-  action: 'DLQ replay action and perf budget tests → Added retry-based mailer, admin DLQ replay action, circuit breaker protection, and performance budget test.'
-  risk: 'none → none'
+# تاریخچهٔ انسانی پروژه SmartAlloc
+# هر ورودی با تاریخ و وضعیت پروژه در زمان commit ذخیره می‌شود
+
+# این فایل به صورت خودکار توسط pre-commit hook به‌روز می‌شود
+# هرگز به صورت دستی ویرایش نشود
+
+timestamp: "2025-09-02T17:30:34Z"
+commit: "07fd352"
+branch: "work"
+phase: "foundation"
+phase_status: "foundation"
+completion_percent: 11
+timeline_deviation: "+0"
+critical_gaps: ["Rule Engine lacks failure mode tests","Notifications need retry with wp_mail"]
+risks: []
+5d_scores:
+  security: 25
+  logic: 25
+  performance: 25
+  readability: 15
+  goal: 20
+weighted_percent: 95.0

--- a/scripts/status-auditor.sh
+++ b/scripts/status-auditor.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# scripts/status-auditor.sh - تولید وضعیت نهایی پروژه برای سیستم 5D
+
+set -euo pipefail
+OUT=ai_outputs/last_state.yml
+mkdir -p ai_outputs
+[ -f ai_outputs/status_pack.txt ] || scripts/status-pack.sh
+PHASE=$(jq -r '.current_phase//"foundation"' ai_context.json 2>/dev/null || echo foundation)
+SECURITY=$(jq -r '.current_scores.security//0' ai_context.json 2>/dev/null || echo 0)
+LOGIC=$(jq -r '.current_scores.logic//0' ai_context.json 2>/dev/null || echo 0)
+PERFORMANCE=$(jq -r '.current_scores.performance//0' ai_context.json 2>/dev/null || echo 0)
+READABILITY=$(jq -r '.current_scores.readability//0' ai_context.json 2>/dev/null || echo 0)
+GOAL=$(jq -r '.current_scores.goal//0' ai_context.json 2>/dev/null || echo 0)
+WEIGHTED=$(jq -r '.current_scores.weighted_percent//0' ai_context.json 2>/dev/null || echo 0)
+COMPLETION=$(echo "scale=0; ($SECURITY+$LOGIC+$PERFORMANCE+$READABILITY+$GOAL)/10" | bc)
+GAPS=$(jq -c '.gaps//[]' ai_context.json 2>/dev/null || echo [])
+cat <<YAML >"$OUT"
+phase: "$PHASE"
+phase_status: "$PHASE"
+completion_percent: $COMPLETION
+timeline_deviation: "+0"
+critical_gaps: $GAPS
+risks: []
+5d_scores:
+  security: $SECURITY
+  logic: $LOGIC
+  performance: $PERFORMANCE
+  readability: $READABILITY
+  goal: $GOAL
+weighted_percent: $WEIGHTED
+YAML
+echo "✅ وضعیت پروژه در $OUT ذخیره شد"

--- a/scripts/status-pack.sh
+++ b/scripts/status-pack.sh
@@ -1,11 +1,33 @@
 #!/usr/bin/env bash
+# scripts/status-pack.sh - جمع‌آوری وضعیت پروژه برای سیستم 5D
+
 set -euo pipefail
-
-# Parse baseline YAML if exists
-BASELINE_FILE=$(find docs -name "BASELINE-*.md" -type f | sort -r | head -1)
-if [ -f "$BASELINE_FILE" ]; then
-    BASELINE_YAML=$(sed -n '/^```yaml$/,/^```$/p' "$BASELINE_FILE" | sed '1d;$d')
-    echo "$BASELINE_YAML" > /tmp/baseline.yaml
-fi
-
-# Placeholder for existing status pack logic
+OUT=ai_outputs/status_pack.txt
+mkdir -p ai_outputs
+{
+ echo "## GIT STATUS"
+ git status -sb 2>/dev/null || echo "Git status not available"
+ echo
+ echo "## DIFF (NAMES ONLY)"
+ git diff --name-only 2>/dev/null || echo "No diff available"
+ echo
+ echo "## PHPCS SUMMARY"
+ if command -v vendor/bin/phpcs >/dev/null 2>&1; then
+   vendor/bin/phpcs -q --report=summary || echo "PHPCS analysis failed"
+ else
+   echo "PHPCS not installed (run: composer require --dev squizlabs/php_codesniffer)"
+ fi
+ echo
+ echo "## TEST SUMMARY"
+ if command -v vendor/bin/phpunit >/dev/null 2>&1; then
+   vendor/bin/phpunit --testdox --colors=never 2>&1 | sed -E 's/\x1B\[[0-9;]*[mK]//g' || echo "PHPUnit tests failed"
+ else
+   echo "PHPUnit not installed (run: composer require --dev phpunit/phpunit)"
+ fi
+ echo
+ echo "## PROJECT METADATA"
+ echo "Timestamp: $(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+ echo "Commit: $(git rev-parse --short HEAD 2>/dev/null || echo \"N/A\")"
+ echo "Branch: $(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo \"N/A\")"
+} >"$OUT"
+echo "Wrote $OUT"


### PR DESCRIPTION
## Summary
- add `status-auditor` to build 5D progress snapshots
- gather repo diagnostics via `status-pack`
- extend pre-commit hook to append snapshots into `docs/PROJECT_STATE.yml`

## Testing
- `composer lint:php`
- `composer test:smoke`
- `php scripts/baseline-check.php`
- `php scripts/baseline-compare.php --from=2024-09-01 --to=current`
- `php scripts/gap-analysis.php`


------
https://chatgpt.com/codex/tasks/task_e_68b72662cddc8321872b1e640c4147fd