### PR TITLE
feat: activate project history system

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -14,30 +14,9 @@
 
 ### ⛔ Red Flags:
 - {
-  "message": "Unsanitized superglobal access /home/runner/work/SmartAlloc/SmartAlloc/src/Debug/ErrorCollector.php:80",
+  "message": "Unsanitized superglobal access /workspace/SmartAlloc/src/Debug/ErrorCollector.php:80",
   "severity": 15
 }
 
 ---
-Last Updated (UTC): 2025-09-02T18:53:05Z
-
-<!-- AUTO-GEN:RAG START -->
-| Feature | Status | Notes |
-| --- | --- | --- |
-| DB Safety | 🟢 Green | All queries DbSafe::mustPrepare |
-| Logging | 🟢 Green | Structured Monolog |
-| Exporter | 🟢 Green | Export endpoints live |
-| Gravity Forms | 🟢 Green | Bridge deployed |
-| Allocation Core | 🟢 Green | Stable allocations |
-| Rule Engine | 🟡 Amber | Edge-case handling pending |
-| Notifications | 🟡 Amber | Delivery flow partial |
-| Circuit Breaker | 🔴 Red | Not started |
-| Observability | 🟢 Green | Metrics & tracing enabled |
-| Performance Budgets | 🔴 Red | Not started |
-| CI/CD | 🟢 Green | 5D gate with AUTO-FIX loop |
-| rule-engine-reliability-gates | 🟡 Amber |  |
-| rag-template-automation | 🟡 Amber |  |
-| project-history | ⚪ Unknown | baseline project history snapshot |
-
-_Last Updated (UTC): 2025-09-02_
-<!-- AUTO-GEN:RAG END -->
+Last Updated (UTC): 2025-09-02T18:56:05Z

--- a/ai_context.json
+++ b/ai_context.json
@@ -15,7 +15,10 @@
   },
   "ci": {
     "remote_connected": true,
-    "workflows": ["ci.yml", "nightly.yml"]
+    "workflows": [
+      "ci.yml",
+      "nightly.yml"
+    ]
   },
   "gaps": [
     "Rule Engine lacks failure mode tests",
@@ -28,18 +31,35 @@
   ],
   "current_scores": {
     "security": 25,
-    "logic": 25,
+    "logic": 20,
     "performance": 25,
-    "readability": 15,
-    "goal": 20,
-    "weighted_percent": 95.0,
-    "red_flags": []
+    "readability": 20,
+    "goal": 25,
+    "total": 100,
+    "weighted_percent": 92.00,
+    "red_flags": [
+      {
+        "message": "Unsanitized superglobal access /workspace/SmartAlloc/src/Debug/ErrorCollector.php:80",
+        "severity": 15
+      }
+    ]
   },
   "features": [
-  {
-    "name": "project-history",
-    "status": "implemented",
-    "notes": "baseline project history snapshot"
-  }
-]
+    {
+      "name": "project-history",
+      "status": "implemented",
+      "notes": "baseline project history snapshot"
+    }
+  ],
+  "analysis": {
+    "security_errors": 0,
+    "logic_errors": 0
+  },
+  "perf_timing": {
+    "max_duration_ms": 0,
+    "default_budget_ms": 2500,
+    "scenarios": [],
+    "penalized": false
+  },
+  "last_updated_utc": "2025-09-02T18:56:05Z"
 }

--- a/ai_outputs/last_state.yml
+++ b/ai_outputs/last_state.yml
@@ -13,4 +13,4 @@ risks: []
 weighted_percent: 92.00
 feature: "project-history"
 status: "implemented"
-notes: "baseline project history snapshot"
+notes: ""

--- a/docs/PROJECT_STATE.yml
+++ b/docs/PROJECT_STATE.yml
@@ -1,3 +1,23 @@
 # تاریخچهٔ انسانی پروژه SmartAlloc
 # هر ورودی با تاریخ و وضعیت پروژه در زمان commit ذخیره می‌شود
 
+
+timestamp: "2025-09-02T18:57:01Z"
+commit: "747ed8b"
+branch: "work"
+phase: "foundation"
+phase_status: "foundation"
+completion_percent: 11
+timeline_deviation: "+0"
+critical_gaps: ["Rule Engine lacks failure mode tests","Notifications need retry with wp_mail"]
+risks: []
+5d_scores:
+  security: 25
+  logic: 20
+  performance: 25
+  readability: 20
+  goal: 25
+weighted_percent: 92.00
+feature: "project-history"
+status: "implemented"
+notes: ""


### PR DESCRIPTION
## Summary
- activate project history pre-commit hook
- record first project state entry

## Testing
- `scripts/update_state.sh`
- `scripts/status-auditor.sh`
- `php scripts/baseline-check.php --current-phase=FOUNDATION` (fails: gaps)
- `php scripts/baseline-compare.php --from=2024-09-01 --to=current`
- `php scripts/gap-analysis.php --target-phase=POLISH`
- `composer install`
- `vendor/bin/phpunit` (fails: Tests: 54, Errors: 4, Failures: 3)


------
https://chatgpt.com/codex/tasks/task_e_68b73d9956788321a3e3646662157f95