### PR TITLE
chore(ci): add script to activate git hooks automatically

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -19,7 +19,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-02T19:36:24Z
+Last Updated (UTC): 2025-09-02T19:47:58Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -19,7 +19,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-02T19:47:58Z
+Last Updated (UTC): 2025-09-02T19:48:02Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,10 +1,10 @@
 {
-  "last_update_utc": "2025-09-02T19:36:24Z",
+  "last_update_utc": "2025-09-02T19:47:58Z",
   "repo": {
-    "default_branch": "main",
-    "last_commit": "a20329191add8ad4ed0f1aefcdf05bef7139c612",
-    "commits_total": 825,
-    "files_tracked": 703
+    "default_branch": "codex/activate-pre-commit-hook-manually",
+    "last_commit": "1b3f36bf3dad80e4b16f76c3b8713f791d5ab88e",
+    "commits_total": 827,
+    "files_tracked": 704
   },
   "quality_gate": {
     "weighted_threshold": 0.85,

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-02T19:47:58Z",
+  "last_update_utc": "2025-09-02T19:48:02Z",
   "repo": {
     "default_branch": "codex/activate-pre-commit-hook-manually",
-    "last_commit": "1b3f36bf3dad80e4b16f76c3b8713f791d5ab88e",
-    "commits_total": 827,
+    "last_commit": "97bfbaf0f5826f3412547369d6ca40df6c83dba3",
+    "commits_total": 828,
     "files_tracked": 704
   },
   "quality_gate": {

--- a/scripts/activate-hooks.sh
+++ b/scripts/activate-hooks.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# scripts/activate-hooks.sh - activate git hooks automatically
+
+set -euo pipefail
+
+echo "🚀 فعال‌سازی خودکار git hooks..."
+
+# Ensure .githooks/pre-commit exists
+if [ ! -f ".githooks/pre-commit" ]; then
+    echo "❌ فایل .githooks/pre-commit یافت نشد"
+    exit 1
+fi
+
+# Create hooks directory if it does not exist
+mkdir -p .git/hooks
+
+# Copy and enable pre-commit hook
+cp .githooks/pre-commit .git/hooks/pre-commit
+chmod +x .git/hooks/pre-commit
+
+# Verify activation success
+if [ -x ".git/hooks/pre-commit" ]; then
+    echo "✅ pre-commit hook با موفقیت فعال شد"
+    echo "   مسیر: .git/hooks/pre-commit"
+else
+    echo "❌ خطای فعال‌سازی pre-commit hook"
+    exit 1
+fi
+
+# Show current hook status
+echo ""
+echo "🔍 وضعیت فعلی git hooks:"
+ls -la .git/hooks/pre-commit 2>/dev/null || echo "   ❌ pre-commit hook فعال نیست"
+
+echo ""
+echo "✅ سیستم تاریخچه پروژه آماده است. از این پس هر commit وضعیت را به docs/PROJECT_STATE.yml اضافه خواهد کرد."


### PR DESCRIPTION
## Summary
- add `scripts/activate-hooks.sh` to copy `.githooks/pre-commit` into `.git/hooks`

## Testing
- `php scripts/baseline-check.php --current-phase=FOUNDATION` *(fails: gap in Logic, Performance, Observability)*
- `php scripts/baseline-compare.php --from=start --to=current`
- `php scripts/gap-analysis.php --target-phase=FOUNDATION`
- `composer lint:php`
- `composer test` *(fails: RuleEngineServiceTest and NotificationRateLimitTest)*
- `vendor/bin/phpcs --standard=WordPress --extensions=php src` *(timed out)*

------
https://chatgpt.com/codex/tasks/task_e_68b747ed7e6083219a85af16f4aff6e2