### PR TITLE
feat(cli): add baseline wrappers and composer shortcuts

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -19,7 +19,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-03T07:05:50Z
+Last Updated (UTC): 2025-09-03T07:05:52Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -19,7 +19,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-02T20:29:24Z
+Last Updated (UTC): 2025-09-03T07:05:50Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |
@@ -39,5 +39,5 @@ Last Updated (UTC): 2025-09-02T20:29:24Z
 | rag-template-automation | 🟡 Amber |  |
 | project-history | ⚪ Unknown |  |
 
-_Last Updated (UTC): 2025-09-02_
+_Last Updated (UTC): 2025-09-03_
 <!-- AUTO-GEN:RAG END -->

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,6 +1,6 @@
 
 <!-- AUTO-GEN:STATE START -->
-# PROJECT_STATE — 2025-09-02
+# PROJECT_STATE — 2025-09-03
 ## Implemented Features
 - project-history
 

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,10 +1,10 @@
 {
-  "last_update_utc": "2025-09-02T20:29:24Z",
+  "last_update_utc": "2025-09-03T07:05:50Z",
   "repo": {
-    "default_branch": "main",
-    "last_commit": "18ccc8203c27f2ee2ac6a8ce72320181b924241d",
-    "commits_total": 836,
-    "files_tracked": 710
+    "default_branch": "codex/implement-root-level-cli-wrappers-for-scripts",
+    "last_commit": "d8ace722be125655d90402e6b4bf9fe7e8ab59e8",
+    "commits_total": 838,
+    "files_tracked": 714
   },
   "quality_gate": {
     "weighted_threshold": 0.85,

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-03T07:05:50Z",
+  "last_update_utc": "2025-09-03T07:05:52Z",
   "repo": {
     "default_branch": "codex/implement-root-level-cli-wrappers-for-scripts",
-    "last_commit": "d8ace722be125655d90402e6b4bf9fe7e8ab59e8",
-    "commits_total": 838,
+    "last_commit": "d0eac2359eb228e2dbee0885ac507a256c876034",
+    "commits_total": 839,
     "files_tracked": 714
   },
   "quality_gate": {

--- a/baseline-check
+++ b/baseline-check
@@ -1,0 +1,14 @@
+#!/usr/bin/env php
+<?php
+declare(strict_types=1);
+
+$script = __DIR__ . '/scripts/baseline-check.php';
+
+if (!is_file($script)) {
+    fwrite(STDERR, "Error: $script missing\n");
+    exit(1);
+}
+
+$cmd = array_merge(['php', $script], array_slice($argv, 1));
+$proc = proc_open($cmd, [0 => STDIN, 1 => STDOUT, 2 => STDERR], $pipes);
+exit(is_resource($proc) ? proc_close($proc) : 1);

--- a/baseline-compare
+++ b/baseline-compare
@@ -1,0 +1,14 @@
+#!/usr/bin/env php
+<?php
+declare(strict_types=1);
+
+$script = __DIR__ . '/scripts/baseline-compare.php';
+
+if (!is_file($script)) {
+    fwrite(STDERR, "Error: $script missing\n");
+    exit(1);
+}
+
+$cmd = array_merge(['php', $script], array_slice($argv, 1));
+$proc = proc_open($cmd, [0 => STDIN, 1 => STDOUT, 2 => STDERR], $pipes);
+exit(is_resource($proc) ? proc_close($proc) : 1);

--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,21 @@
     "test": "vendor/bin/phpunit --testsuite Unit,WordPress,VIP,Integration",
     "test:smoke": "vendor/bin/phpunit tests/Unit/BrainMonkeySmokeTest.php tests/WordPress/Smoke/BootTest.php",
     "gen:features": "php scripts/generate_features_md.php",
-    "gen:context": "php scripts/ai_context_sync.php"
+    "gen:context": "php scripts/ai_context_sync.php",
+    "baseline:check": "php scripts/baseline-check.php",
+    "baseline:compare": "php scripts/baseline-compare.php",
+    "baseline:gap-analysis": "php scripts/gap-analysis.php",
+    "baseline:foundation": "php scripts/baseline-check.php --current-phase=foundation",
+    "baseline:expansion": "php scripts/baseline-check.php --current-phase=expansion",
+    "baseline:polish": "php scripts/baseline-check.php --current-phase=polish"
+  },
+  "scripts-descriptions": {
+    "baseline:check": "Run baseline compliance check for current phase",
+    "baseline:compare": "Compare current state with baseline reference",
+    "baseline:gap-analysis": "Analyze gaps between current and target state",
+    "baseline:foundation": "Quick foundation phase validation",
+    "baseline:expansion": "Quick expansion phase validation",
+    "baseline:polish": "Quick polish phase validation"
   },
   "autoload-dev": {
     "psr-4": {

--- a/docs/BASELINE_USAGE.md
+++ b/docs/BASELINE_USAGE.md
@@ -1,0 +1,26 @@
+# Baseline Verification Usage
+
+## Direct Execution
+```
+./baseline-check --current-phase=foundation
+./baseline-compare --help
+./gap-analysis --target-phase=foundation
+```
+
+## Composer Scripts
+```
+composer run baseline:foundation
+composer run baseline:check -- --help
+composer run baseline:gap-analysis -- --help
+```
+
+## Legacy Usage
+```
+php scripts/baseline-check.php --current-phase=foundation
+php scripts/baseline-compare.php --help
+php scripts/gap-analysis.php --target-phase=foundation
+```
+
+## Troubleshooting
+- **Permission denied**: run `chmod +x baseline-check baseline-compare gap-analysis`
+- **Script not found**: ensure you are in project root.

--- a/gap-analysis
+++ b/gap-analysis
@@ -1,0 +1,14 @@
+#!/usr/bin/env php
+<?php
+declare(strict_types=1);
+
+$script = __DIR__ . '/scripts/gap-analysis.php';
+
+if (!is_file($script)) {
+    fwrite(STDERR, "Error: $script missing\n");
+    exit(1);
+}
+
+$cmd = array_merge(['php', $script], array_slice($argv, 1));
+$proc = proc_open($cmd, [0 => STDIN, 1 => STDOUT, 2 => STDERR], $pipes);
+exit(is_resource($proc) ? proc_close($proc) : 1);


### PR DESCRIPTION
## Summary
- add root-level wrappers for baseline-check, baseline-compare, and gap-analysis scripts
- wire composer script shortcuts for baseline utilities
- document baseline verification usage

## Testing
- `./baseline-check --help`
- `./baseline-compare --help`
- `./gap-analysis --help`
- `composer test` *(fails: Script vendor/bin/phpunit --testsuite Unit,WordPress,VIP,Integration handling the test event returned with error code 2)*

------
https://chatgpt.com/codex/tasks/task_e_68b7e5e480e08321926bdc0a3d13d9c9