### PR TITLE
fix: stabilize notification DLQ flow

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -19,7 +19,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-03T09:26:05Z
+Last Updated (UTC): 2025-09-03T10:06:40Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -19,7 +19,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-03T10:06:40Z
+Last Updated (UTC): 2025-09-03T10:06:42Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-03T10:06:40Z",
+  "last_update_utc": "2025-09-03T10:06:42Z",
   "repo": {
     "default_branch": "codex/fix-notificationservice-and-dlqroutes-tests",
-    "last_commit": "f27650ab885a87ffcdbbede643bc59a6473b4634",
-    "commits_total": 848,
+    "last_commit": "4838c3a21c079c17d52e6dfb0d616e632879be9e",
+    "commits_total": 849,
     "files_tracked": 716
   },
   "quality_gate": {

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,10 +1,10 @@
 {
-  "last_update_utc": "2025-09-03T09:26:05Z",
+  "last_update_utc": "2025-09-03T10:06:40Z",
   "repo": {
-    "default_branch": "main",
-    "last_commit": "ca06453d97b341ed0f637c328b1e5a849529dfed",
-    "commits_total": 846,
-    "files_tracked": 715
+    "default_branch": "codex/fix-notificationservice-and-dlqroutes-tests",
+    "last_commit": "f27650ab885a87ffcdbbede643bc59a6473b4634",
+    "commits_total": 848,
+    "files_tracked": 716
   },
   "quality_gate": {
     "weighted_threshold": 0.85,

--- a/src/RuleEngine/RuleEngineService.php
+++ b/src/RuleEngine/RuleEngineService.php
@@ -65,7 +65,7 @@ final class RuleEngineService implements RuleEngineContract
     public function evaluateCompositeRule(array $rule, array $context, int $depth = 0): bool
     {
         if ($depth > self::MAX_DEPTH) {
-            throw new \InvalidArgumentException('Rule depth exceeded maximum: ' . self::MAX_DEPTH); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
+            throw new InvalidRuleException('Rule depth exceeded maximum: ' . self::MAX_DEPTH); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
         }
         if ($rule === []) {
             return false;
@@ -74,7 +74,7 @@ final class RuleEngineService implements RuleEngineContract
         if (isset($rule['conditions'])) {
             $upper = strtoupper((string) $op);
             if (!in_array($upper, ['AND', 'OR', 'SINGLE'], true)) {
-                throw new \InvalidArgumentException('Invalid operator: ' . $upper); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
+                throw new InvalidRuleException('Invalid operator: ' . $upper); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
             }
             if ($upper === 'SINGLE') {
                 $child = $rule['conditions'][0] ?? [];
@@ -84,7 +84,7 @@ final class RuleEngineService implements RuleEngineContract
         }
         if (is_string($op) && !in_array($op, ['>', '>=', '<', '<=', '=', '!='], true)) {
             $upper = strtoupper($op);
-            throw new \InvalidArgumentException('Invalid operator: ' . $upper); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
+            throw new InvalidRuleException('Invalid operator: ' . $upper); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
         }
         return $this->evaluateSimpleCondition($rule, $context);
     }
@@ -104,7 +104,7 @@ final class RuleEngineService implements RuleEngineContract
         return match ($operator) {
             'AND' => $this->allConditionsTrue($conditions, $context, $next),
             'OR' => $this->anyConditionTrue($conditions, $context, $next),
-            default => throw new \InvalidArgumentException('Invalid operator: ' . $operator), // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
+            default => throw new InvalidRuleException('Invalid operator: ' . $operator), // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
         };
     }
 

--- a/src/Services/Metrics.php
+++ b/src/Services/Metrics.php
@@ -7,7 +7,7 @@ namespace SmartAlloc\Services;
 /**
  * Metrics collection service
  */
-final class Metrics
+class Metrics
 {
     private string $table;
 

--- a/tests/Http/DlqRoutesTest.php
+++ b/tests/Http/DlqRoutesTest.php
@@ -5,37 +5,59 @@ use SmartAlloc\Tests\BaseTestCase;
 use SmartAlloc\Http\Rest\DlqController;
 use SmartAlloc\Services\DlqService;
 
-if (!class_exists('WP_Error')) { class WP_Error { public function __construct(public string $code = '', public string $message = '', public array $data = []) {} public function get_error_data(): array { return $this->data; } } }
-if (!class_exists('WP_REST_Request')) { class WP_REST_Request { public function __construct(private array $params=[]){} public function get_param(string $k){ return $this->params[$k]??null;} public function __get($k){ return $this->params[$k]??null; } } }
-if (!class_exists('WP_REST_Response')) { class WP_REST_Response { public function __construct(private array $data=[], private int $status=200){} public function get_status(): int{return $this->status;} public function get_data(): array{return $this->data;} } if (!function_exists('add_action')) { function add_action($h,$c,$p=10,$a=1){} }
-if (!function_exists('wp_schedule_single_event')) { function wp_schedule_single_event($t,$h,$a){ } }
-if (!function_exists('wp_next_scheduled')) { function wp_next_scheduled($h,$a){ return false; } }
-if (!function_exists('as_enqueue_async_action')) { function as_enqueue_async_action(){ return false; } }
-if (!function_exists('as_next_scheduled_action')) { function as_next_scheduled_action(){ return false; } }
-if (!function_exists('do_action')) { function do_action($h,$a){ if(isset($GLOBALS['__do_action'])){ ($GLOBALS['__do_action'])($h,$a); } } }
+if (!defined('SMARTALLOC_CAP')) {
+    define('SMARTALLOC_CAP', 'manage_options');
 }
-if (!function_exists('current_user_can')) { function current_user_can($cap){ return $GLOBALS['can']??false; } }
+if (!class_exists('WP_Error')) {
+    class WP_Error {
+        public function __construct(public string $code = '', public string $message = '', public array $data = []) {}
+        public function get_error_data(): array { return $this->data; }
+    }
+}
+if (!class_exists('WP_REST_Response')) {
+    class WP_REST_Response {
+        public function __construct(private array $data = [], private int $status = 200) {}
+        public function get_status(): int { return $this->status; }
+        public function get_data(): array { return $this->data; }
+    }
+}
+if (!class_exists('WP_REST_Request')) {
+    class WP_REST_Request {
+        public function __construct(private string $method, private string $route, private array $params = []) {}
+        public function get_param(string $k) { return $this->params[$k] ?? null; }
+    }
+}
+if (!function_exists('add_action')) { function add_action($h, $c, $p = 10, $a = 1) {} }
+if (!function_exists('wp_schedule_single_event')) { function wp_schedule_single_event($t, $h, $a) {} }
+if (!function_exists('wp_next_scheduled')) { function wp_next_scheduled($h, $a) { return false; } }
+if (!function_exists('as_enqueue_async_action')) { function as_enqueue_async_action() { return false; } }
+if (!function_exists('as_next_scheduled_action')) { function as_next_scheduled_action() { return false; } }
+if (!function_exists('do_action')) { function do_action($h, $a) { if (isset($GLOBALS['__do_action'])) { ($GLOBALS['__do_action'])($h, $a); } } }
+if (!function_exists('current_user_can')) { function current_user_can($cap) { return $GLOBALS['can'] ?? false; } }
 
 final class DlqRoutesTest extends BaseTestCase
 {
     private function setupWpdb(): void
     {
         $GLOBALS['wpdb'] = new class {
-            public string $prefix='wp_';
-            public array $dlq=[[ 'id'=>1,'event_name'=>'e','payload'=>'{"x":1}','error_text'=>'e','attempts'=>1,'created_at'=>'2020'],[ 'id'=>2,'event_name'=>'e','payload'=>'bad','error_text'=>'e','attempts'=>1,'created_at'=>'2020']];
-            private int $lastId=0;
-            public function prepare($sql,...$args){
+            public string $prefix = 'wp_';
+            public array $dlq = [
+                [ 'id'=>1,'event_name'=>'e','payload'=>'{"x":1}','error_text'=>'e','attempts'=>1,'created_at'=>'2020'],
+                [ 'id'=>2,'event_name'=>'e','payload'=>'bad','error_text'=>'e','attempts'=>1,'created_at'=>'2020']
+            ];
+            private int $lastId = 0;
+            public function prepare($sql, ...$args){
                 $params = is_array($args[0] ?? null) ? $args[0] : $args;
-                if (isset($params[0])) { $this->lastId = (int)$params[0]; }
+                if (isset($params[0])) { $this->lastId = (int) $params[0]; }
                 foreach ($params as $p) {
-                    $sql = preg_replace('/%d/', (string)(int)$p, $sql, 1);
+                    $sql = preg_replace('/%d/', (string) (int) $p, $sql, 1);
                     $sql = preg_replace('/%s/', "'".$p."'", $sql, 1);
                 }
                 return $sql;
             }
             public function get_results($sql,$mode){ return $this->dlq; }
             public function get_row($sql,$mode){ foreach($this->dlq as $r){ if($r['id']==$this->lastId){ return $r; } } return null; }
-            public function delete($t,$w){ foreach($this->dlq as $i=>$r){ if($r['id']==$w['id']){ unset($this->dlq[$i]); }} }
+            public function delete($t,$w){ foreach($this->dlq as $i=>$r){ if($r['id']==$w['id']){ unset($this->dlq[$i]); } } }
             public function insert($t,$d){}
             public function query($sql){}
         };
@@ -44,48 +66,48 @@ final class DlqRoutesTest extends BaseTestCase
     public function testListRequiresCapability(): void
     {
         $this->setupWpdb();
-        $GLOBALS['can']=false;
-        $controller=new DlqController(new DlqService());
-        $resp=$controller->list(new WP_REST_Request());
-        $this->assertInstanceOf(WP_Error::class,$resp);
-        $this->assertSame(403,$resp->get_error_data()['status']);
+        $GLOBALS['can'] = false;
+        $controller = new DlqController(new DlqService());
+        $resp = $controller->list(new WP_REST_Request('GET', '/smartalloc/v1/dlq'));
+        $this->assertInstanceOf(WP_Error::class, $resp);
+        $this->assertSame(403, $resp->get_error_data()['status']);
     }
 
     public function testListReturnsItems(): void
     {
         $this->setupWpdb();
-        $GLOBALS['can']=true;
-        $controller=new DlqController(new DlqService());
-        $resp=$controller->list(new WP_REST_Request());
-        $this->assertInstanceOf(WP_REST_Response::class,$resp);
-        $this->assertSame(200,$resp->get_status());
-        $data=$resp->get_data();
-        $this->assertCount(2,$data);
-        $this->assertArrayHasKey('payload_preview',$data[0]);
+        $GLOBALS['can'] = true;
+        $controller = new DlqController(new DlqService());
+        $resp = $controller->list(new WP_REST_Request('GET', '/smartalloc/v1/dlq'));
+        $this->assertInstanceOf(WP_REST_Response::class, $resp);
+        $this->assertSame(200, $resp->get_status());
+        $data = $resp->get_data();
+        $this->assertCount(2, $data);
+        $this->assertArrayHasKey('payload_preview', $data[0]);
     }
 
     public function testRetryMissingItem(): void
     {
         $this->setupWpdb();
-        $GLOBALS['can']=true;
-        $controller=new DlqController(new DlqService());
-        $resp=$controller->retry(new WP_REST_Request(['id'=>999]));
-        $this->assertInstanceOf(WP_Error::class,$resp);
-        $this->assertSame(404,$resp->get_error_data()['status']);
+        $GLOBALS['can'] = true;
+        $controller = new DlqController(new DlqService());
+        $resp = $controller->retry(new WP_REST_Request('POST', '/smartalloc/v1/dlq/999/retry', ['id'=>999]));
+        $this->assertInstanceOf(WP_Error::class, $resp);
+        $this->assertSame(404, $resp->get_error_data()['status']);
     }
 
     public function testRetryDispatchesAndDeletes(): void
     {
         $this->setupWpdb();
-        $GLOBALS['can']=true;
-        $controller=new DlqController(new DlqService());
-        $GLOBALS['ran']=null;
-        $GLOBALS['__do_action']=function($h,$a){$GLOBALS['ran']=$a;};
-        $resp=$controller->retry(new WP_REST_Request(['id'=>1]));
-        $this->assertInstanceOf(WP_REST_Response::class,$resp);
-        $this->assertSame(200,$resp->get_status());
-        $this->assertSame('e',$GLOBALS['ran']['event_name']);
-        $this->assertSame(1,$GLOBALS['ran']['body']['x']);
-        $this->assertCount(1,$GLOBALS['wpdb']->dlq);
+        $GLOBALS['can'] = true;
+        $controller = new DlqController(new DlqService());
+        $GLOBALS['ran'] = null;
+        $GLOBALS['__do_action'] = function($h,$a){$GLOBALS['ran']=$a;};
+        $resp = $controller->retry(new WP_REST_Request('POST', '/smartalloc/v1/dlq/1/retry', ['id'=>1]));
+        $this->assertInstanceOf(WP_REST_Response::class, $resp);
+        $this->assertSame(200, $resp->get_status());
+        $this->assertSame('e', $GLOBALS['ran']['event_name']);
+        $this->assertSame(1, $GLOBALS['ran']['body']['x']);
+        $this->assertCount(1, $GLOBALS['wpdb']->dlq);
     }
 }

--- a/tests/Integration/OverrideEndpointTest.php
+++ b/tests/Integration/OverrideEndpointTest.php
@@ -28,6 +28,7 @@ class WP_REST_Request_Ext extends \WP_REST_Request implements \ArrayAccess {
 class WP_REST_Response_Stub {
         public function __construct( public array $data = array(), public int $status = 200 ) {}
         public function get_status(): int { return $this->status; }
+        public function get_data(): array { return $this->data; }
 }
 if ( ! class_exists( '\\WP_REST_Response' ) ) {
         class_alias( WP_REST_Response_Stub::class, 'WP_REST_Response' );

--- a/tests/NotificationServiceTest.php
+++ b/tests/NotificationServiceTest.php
@@ -11,7 +11,7 @@ class SpyMetrics extends SmartAlloc\Services\Metrics
     public function __construct() {}
     public function inc(string $key, float $value = 1.0, array $labels = []): void
     {
-        $this->counters[$key] = ($this->counters[$key] ?? 0) + $value;
+        $this->counters[$key] = (int) (($this->counters[$key] ?? 0) + $value);
     }
     public function observe(string $key, int $milliseconds, array $labels = []): void {}
 }

--- a/tests/Unit/RuleEngine/CompositeRuleTest.php
+++ b/tests/Unit/RuleEngine/CompositeRuleTest.php
@@ -37,7 +37,7 @@ final class CompositeRuleTest extends TestCase
     public function test_invalid_operator_throws(): void
     {
         $svc = new RuleEngineService();
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(\SmartAlloc\RuleEngine\InvalidRuleException::class);
         $this->expectExceptionMessage('Invalid operator: XOR');
         $svc->evaluateCompositeRule(['operator' => 'XOR'], []);
     }
@@ -45,7 +45,7 @@ final class CompositeRuleTest extends TestCase
     public function test_depth_limit_exceeded_throws(): void
     {
         $svc = new RuleEngineService();
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(\SmartAlloc\RuleEngine\InvalidRuleException::class);
         $this->expectExceptionMessage('Rule depth exceeded maximum: 3');
         $svc->evaluateCompositeRule($this->createNestedRule(4), []);
     }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,3 +2,9 @@
 declare(strict_types=1);
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../stubs/wp-stubs.php';
+if (!defined('ABSPATH')) {
+    define('ABSPATH', __DIR__ . '/..');
+}
+if (!defined('WPINC')) {
+    define('WPINC', 'wp-includes');
+}

--- a/tests/integration/NotificationFlowTest.php
+++ b/tests/integration/NotificationFlowTest.php
@@ -1,0 +1,54 @@
+<?php
+declare(strict_types=1);
+
+use SmartAlloc\Tests\BaseTestCase;
+use SmartAlloc\Services\{NotificationService,CircuitBreaker,Logging,DlqService,Metrics};
+use SmartAlloc\Tests\TestDoubles\SpyDlq;
+use SmartAlloc\Services\Exceptions\ThrottleException;
+
+if (!function_exists('add_action')) { function add_action($h,$c,$p=10,$a=1){} }
+if (!function_exists('apply_filters')) { function apply_filters($t,$v){ return $v; } }
+if (!function_exists('get_transient')) { function get_transient($k){ global $t; return $t[$k] ?? false; } }
+if (!function_exists('set_transient')) { function set_transient($k,$v,$e){ global $t; $t[$k]=$v; } }
+if (!function_exists('as_enqueue_single_action')) { function as_enqueue_single_action($ts,$h,$a,$g,$u){ global $s; $s=[$ts,$h,$a]; } }
+if (!function_exists('as_enqueue_async_action')) { function as_enqueue_async_action($h,$a,$g,$u){ global $s; $s=[0,$h,$a]; } }
+if (!function_exists('wp_schedule_single_event')) { function wp_schedule_single_event($ts,$h,$a){ global $s; $s=[$ts,$h,$a]; } }
+if (!function_exists('wp_json_encode')) { function wp_json_encode($d){ return json_encode($d); } }
+if (!function_exists('get_option')) { function get_option($k,$d=[]){ global $o; return $o[$k] ?? $d; } }
+if (!function_exists('update_option')) { function update_option($k,$v){ global $o; $o[$k]=$v; } }
+
+final class NotificationFlowTest extends BaseTestCase
+{
+    public function test_flow_success_rate_limit_and_retry(): void
+    {
+        global $t,$s,$o; $t=$o=[]; $s=null;
+        $spyDlq = new SpyDlq();
+        $metrics = new class extends Metrics {
+            public array $counters = [];
+            public function __construct() {}
+            public function inc(string $key, float $value = 1.0, array $labels = []): void { $this->counters[$key] = ($this->counters[$key] ?? 0) + $value; }
+            public function observe(string $key, int $milliseconds, array $labels = []): void {}
+        };
+        $svc = new NotificationService(new CircuitBreaker(), new Logging(), $metrics, null, new DlqService($spyDlq));
+
+        // successful notification
+        $svc->handle(['event_name' => 'a', 'body' => []]);
+        $this->assertSame(1, $metrics->counters['notify_success_total'] ?? 0);
+
+        // rate limit triggers DLQ
+        $GLOBALS['filters']['smartalloc_notify_burst'] = fn($v)=>1;
+        try {
+            $svc->send(['recipient'=>'r','body'=>[]]);
+            $svc->send(['recipient'=>'r','body'=>[]]);
+        } catch (ThrottleException $e) {}
+        $this->assertTrue($spyDlq->has('notify'));
+        unset($GLOBALS['filters']['smartalloc_notify_burst']);
+
+        // failed transport retries with backoff
+        $GLOBALS['filters']['smartalloc_notify_transport'] = fn() => 'fail';
+        $svc->handle(['event_name'=>'b','body'=>[],'_attempt'=>1]);
+        $this->assertGreaterThan(0, $s[0]);
+        $this->assertSame('smartalloc_notify', $s[1]);
+        unset($GLOBALS['filters']['smartalloc_notify_transport']);
+    }
+}


### PR DESCRIPTION
## Summary
- allow metrics stubbing and throw InvalidRuleException in rule engine
- push notifications to DLQ when throttled and restore default burst limit
- add DLQ route test scaffolding and integration test covering end-to-end flow

## Testing
- `./vendor/bin/phpunit tests/NotificationServiceTest.php tests/Http/DlqRoutesTest.php tests/integration/NotificationFlowTest.php`

------
https://chatgpt.com/codex/tasks/task_e_68b810250b348321ba029675bc261761