### PR TITLE
fix(notification): sanitize mail payload and add notification docs

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -19,7 +19,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-03T10:49:18Z
+Last Updated (UTC): 2025-09-03T10:49:21Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -19,7 +19,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-03T10:49:13Z
+Last Updated (UTC): 2025-09-03T10:49:18Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -19,7 +19,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-03T10:38:52Z
+Last Updated (UTC): 2025-09-03T10:49:13Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-03T10:49:13Z",
+  "last_update_utc": "2025-09-03T10:49:18Z",
   "repo": {
     "default_branch": "codex/complete-notificationservice-implementation-tasks",
-    "last_commit": "337f236aa4b629a511e2e166fb426f4ea9e0ca57",
-    "commits_total": 859,
+    "last_commit": "c6d8a65ccebbf1a6d09db2ec04844d01a9eff3cd",
+    "commits_total": 860,
     "files_tracked": 719
   },
   "quality_gate": {

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,10 +1,10 @@
 {
-  "last_update_utc": "2025-09-03T10:38:52Z",
+  "last_update_utc": "2025-09-03T10:49:13Z",
   "repo": {
-    "default_branch": "main",
-    "last_commit": "2b4e3994428a4a5ada497f7ee391d12e6a6732cf",
-    "commits_total": 857,
-    "files_tracked": 717
+    "default_branch": "codex/complete-notificationservice-implementation-tasks",
+    "last_commit": "337f236aa4b629a511e2e166fb426f4ea9e0ca57",
+    "commits_total": 859,
+    "files_tracked": 719
   },
   "quality_gate": {
     "weighted_threshold": 0.85,

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-03T10:49:18Z",
+  "last_update_utc": "2025-09-03T10:49:22Z",
   "repo": {
     "default_branch": "codex/complete-notificationservice-implementation-tasks",
-    "last_commit": "c6d8a65ccebbf1a6d09db2ec04844d01a9eff3cd",
-    "commits_total": 860,
+    "last_commit": "843ccb6b62ca10af921349da6e06e3e84d60c016",
+    "commits_total": 861,
     "files_tracked": 719
   },
   "quality_gate": {

--- a/docs/NOTIFY_CONFIG.md
+++ b/docs/NOTIFY_CONFIG.md
@@ -1,0 +1,7 @@
+# Notification Service Configuration
+
+| Constant Name | Default Value | Description | Tuning Guidance |
+| --- | --- | --- | --- |
+| `SMARTALLOC_NOTIFY_MAX_TRIES` | `5` | Maximum number of notification retry attempts before message is pushed to the DLQ. | Increase for transient downstream issues; lower for faster failure. |
+| `SMARTALLOC_NOTIFY_BASE_DELAY` | `5` | Base delay in seconds used for exponential backoff between mail retries. | Adjust to control initial retry wait; lower for quicker retries. |
+| `SMARTALLOC_NOTIFY_BACKOFF_CAP` | `600` | Maximum delay in seconds for backoff between retries. | Raise to allow longer wait during prolonged outages. |

--- a/docs/NOTIFY_METRICS.md
+++ b/docs/NOTIFY_METRICS.md
@@ -1,0 +1,7 @@
+# Notification Service Metrics
+
+| Metric Name | Description | Units | Labels |
+| --- | --- | --- | --- |
+| `notify_success_total` | Count of notifications processed successfully. | count | none |
+| `notify_failed_total` | Count of notifications that failed processing. | count | none |
+| `dlq_push_total` | Number of messages pushed to the dead letter queue. | count | none |


### PR DESCRIPTION
## Summary
- document NotificationService usage and rate limit filter
- sanitize mail payload inputs before dispatch and logging
- document notification constants and metrics

## Testing
- `composer lint:php`
- `vendor/bin/phpcs src/Services/NotificationService.php`
- `composer test`
- `./baseline-check --current-phase=foundation`


------
https://chatgpt.com/codex/tasks/task_e_68b81be7c5fc8321929a0f854c58f1e2