### PR TITLE
fix(notification): mask PII and validate payload

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -19,7 +19,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-03T10:49:34Z
+Last Updated (UTC): 2025-09-03T11:25:27Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -19,7 +19,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-03T11:25:27Z
+Last Updated (UTC): 2025-09-03T11:25:31Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-03T11:25:27Z",
+  "last_update_utc": "2025-09-03T11:25:31Z",
   "repo": {
     "default_branch": "codex/implement-pii-masking-and-validation-in-notificationservice",
-    "last_commit": "d231c91d56b1cba98a34565a4b3364304648db82",
-    "commits_total": 865,
+    "last_commit": "58940e2f7f2aa8f916dadfd99eafd54486a9a218",
+    "commits_total": 866,
     "files_tracked": 719
   },
   "quality_gate": {

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-03T10:49:35Z",
+  "last_update_utc": "2025-09-03T11:25:27Z",
   "repo": {
-    "default_branch": "main",
-    "last_commit": "abe144047c7d03f5a9498426d9e8fcd4c497f79c",
-    "commits_total": 863,
+    "default_branch": "codex/implement-pii-masking-and-validation-in-notificationservice",
+    "last_commit": "d231c91d56b1cba98a34565a4b3364304648db82",
+    "commits_total": 865,
     "files_tracked": 719
   },
   "quality_gate": {

--- a/tests/Integration/Services/NotificationServiceIntegrationTest.php
+++ b/tests/Integration/Services/NotificationServiceIntegrationTest.php
@@ -29,7 +29,13 @@ final class NotificationServiceIntegrationTest extends TestCase
         $svc = new NotificationService(new CircuitBreaker(), new Logging(), new Metrics());
         for ($i = 0; $i < 11; $i++) {
             if ($i === 3) { global $t; $t['smartalloc_notify_rate'] = 0; }
-            try { $svc->send(['recipient' => 'r', 'body' => []]); } catch (\Throwable $e) {}
+            try {
+                $svc->send([
+                    'event_name' => 'user_registered',
+                    'body' => ['user_id' => $i],
+                    'recipient' => 'r',
+                ]);
+            } catch (\Throwable $e) {}
         }
         $ctrl = new HealthController(new RateLimiter());
         $data = $ctrl->handle(new WP_REST_Request())->get_data();

--- a/tests/Unit/Services/NotificationRateLimitTest.php
+++ b/tests/Unit/Services/NotificationRateLimitTest.php
@@ -40,10 +40,10 @@ final class NotificationRateLimitTest extends TestCase
         $GLOBALS['wpdb'] = new wpdb();
         $svc = new NotificationService(new CircuitBreaker(), new Logging(), new Metrics());
         for ($i = 0; $i < 10; $i++) {
-            $svc->send(['body' => []]);
+            $svc->send(['event_name' => 'user_registered', 'body' => ['user_id' => $i]]);
         }
         $this->assertSame(10, get_transient('smartalloc_notify_rate'));
-        $svc->send(['body' => []]);
+        $svc->send(['event_name' => 'user_registered', 'body' => ['user_id' => 99]]);
         $this->assertSame(10, get_transient('smartalloc_notify_rate'));
     }
 
@@ -52,10 +52,10 @@ final class NotificationRateLimitTest extends TestCase
         global $t; $t = ['smartalloc_notify_rate' => 10];
         $GLOBALS['wpdb'] = new wpdb();
         $svc = new NotificationService(new CircuitBreaker(), new Logging(), new Metrics());
-        $svc->send(['body' => []]);
+        $svc->send(['event_name' => 'user_registered', 'body' => ['user_id' => 1]]);
         $this->assertSame(10, get_transient('smartalloc_notify_rate'));
         unset($t['smartalloc_notify_rate']);
-        $svc->send(['body' => []]);
+        $svc->send(['event_name' => 'user_registered', 'body' => ['user_id' => 1]]);
         $this->assertSame(1, get_transient('smartalloc_notify_rate'));
     }
 }


### PR DESCRIPTION
## Summary
- add payload validation and PII masking to NotificationService
- ensure DlqService stores masked payloads
- update tests for event allowlist and masked data

## Testing
- `composer lint:php`
- `composer test`
- `php baseline-check --current-phase=foundation`


------
https://chatgpt.com/codex/tasks/task_e_68b81f11c9ec832197def3e3c7274b6d