### PR TITLE
fix(notification): allow NotifyListener events

### DIFF
--- a/src/Services/NotificationService.php
+++ b/src/Services/NotificationService.php
@@ -320,10 +320,21 @@ final class NotificationService
             $errors[] = 'body is required and must be an array';
         }
         $allowedEvents = [
-            'user_registered', 'password_reset', 'order_completed',
-            'subscription_renewed', 'payment_failed',
+            'user_registered',
+            'password_reset',
+            'order_completed',
+            'subscription_renewed',
+            'payment_failed',
+            'MentorAssigned',
         ];
-        if (isset($payload['event_name']) && !in_array($payload['event_name'], $allowedEvents, true)) {
+        if (function_exists('apply_filters')) {
+            /** @var string[] $allowedEvents */
+            $allowedEvents = apply_filters('smartalloc_notify_event_allowlist', $allowedEvents);
+        }
+        if (
+            isset($payload['event_name'])
+            && !in_array($payload['event_name'], $allowedEvents, true)
+        ) {
             $errors[] = 'event_name not in allowed list: ' . implode(', ', $allowedEvents);
         }
         if (isset($payload['event_name'], $payload['body'])) {

--- a/tests/NotificationServiceTest.php
+++ b/tests/NotificationServiceTest.php
@@ -188,6 +188,16 @@ final class NotificationServiceTest extends BaseTestCase
         unset($GLOBALS['filters']['smartalloc_notify_transport']);
     }
 
+    public function test_notify_listener_event_allowed(): void
+    {
+        global $s, $t;
+        $s = null;
+        $t = [];
+        $svc = new NotificationService(new CircuitBreaker(), new Logging(), new NullMetrics());
+        $svc->send(['event_name' => 'MentorAssigned', 'body' => ['user_id' => 1]]);
+        $this->assertSame('smartalloc_notify', $s[0]);
+    }
+
     public function test_invalid_event_rejected(): void
     {
         $svc = new NotificationService(new CircuitBreaker(), new Logging(), new NullMetrics());


### PR DESCRIPTION
## Summary
- extend NotificationService event allowlist with `MentorAssigned` and allow filtering
- test that NotifyListener events are accepted

## Testing
- `composer lint:php`
- `composer test`
- `php baseline-check --current-phase=foundation`


------
https://chatgpt.com/codex/tasks/task_e_68b8279d04c08321af2b1627b561c78f