### PR TITLE
feat(notify): track retry metrics for mail retries

### DIFF
--- a/tests/Unit/Services/NotificationServiceTest.php
+++ b/tests/Unit/Services/NotificationServiceTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SmartAlloc\Tests\Unit\Services;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use SmartAlloc\Services\{NotificationService,CircuitBreaker,Logging,DlqService};
+use SmartAlloc\Tests\BaseTestCase;
+use SmartAlloc\Tests\TestDoubles\SpyDlq;
+use SmartAlloc\Services\Metrics;
+
+final class SpyMetrics extends Metrics
+{
+    public array $counters = [];
+    public function __construct() {}
+    public function inc(string $key, float $value = 1.0, array $labels = []): void
+    {
+        $this->counters[$key] = (int) (($this->counters[$key] ?? 0) + $value);
+    }
+    public function observe(string $key, int $milliseconds, array $labels = []): void {}
+}
+
+if (!defined('SMARTALLOC_NOTIFY_MAX_TRIES')) {
+    define('SMARTALLOC_NOTIFY_MAX_TRIES', 3);
+}
+if (!defined('SMARTALLOC_NOTIFY_BASE_DELAY')) {
+    define('SMARTALLOC_NOTIFY_BASE_DELAY', 5);
+}
+if (!defined('SMARTALLOC_NOTIFY_BACKOFF_CAP')) {
+    define('SMARTALLOC_NOTIFY_BACKOFF_CAP', 600);
+}
+if (!defined('DAY_IN_SECONDS')) {
+    define('DAY_IN_SECONDS', 86400);
+}
+
+final class NotificationServiceTest extends BaseTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Monkey\setUp();
+        Functions\when('sanitize_textarea_field')->alias(fn($v) => $v);
+        Functions\when('get_transient')->alias(function ($k) { global $t; return $t[$k] ?? false; });
+        Functions\when('set_transient')->alias(function ($k, $v, $e) { global $t; $t[$k] = $v; });
+        Functions\when('as_enqueue_single_action')->alias(function () {});
+        Functions\when('as_enqueue_async_action')->alias(function () {});
+        Functions\when('wp_schedule_single_event')->alias(function () {});
+    }
+
+    protected function tearDown(): void
+    {
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    public function testRetryMetricIncrementsOnFailure(): void
+    {
+        global $t; $t = [];
+        Functions\expect('wp_mail')->once()->andReturn(false);
+        $metrics = new SpyMetrics();
+        $dlq = new DlqService(new SpyDlq());
+        $svc = new NotificationService(new CircuitBreaker(), new Logging(), $metrics, null, $dlq);
+        $res = $svc->sendMail(['to' => 'test@example.com', 'subject' => 'Test', 'message' => 'Test message']);
+        $this->assertFalse($res);
+        $this->assertSame(1, $metrics->counters['notify_retry_total'] ?? 0);
+    }
+
+    public function testRetryMetricNotIncrementedOnSuccess(): void
+    {
+        global $t; $t = [];
+        Functions\expect('wp_mail')->once()->andReturn(true);
+        $metrics = new SpyMetrics();
+        $dlq = new DlqService(new SpyDlq());
+        $svc = new NotificationService(new CircuitBreaker(), new Logging(), $metrics, null, $dlq);
+        $res = $svc->sendMail(['to' => 'test@example.com', 'subject' => 'Test', 'message' => 'Test message']);
+        $this->assertTrue($res);
+        $this->assertArrayNotHasKey('notify_retry_total', $metrics->counters);
+        $this->assertSame(1, $metrics->counters['notify_success_total'] ?? 0);
+    }
+
+    public function testRetryMetricNotIncrementedOnMaxRetriesExceeded(): void
+    {
+        global $t; $t = [];
+        Functions\expect('wp_mail')->once()->andReturn(false);
+        $metrics = new SpyMetrics();
+        $spyDlq = new SpyDlq();
+        $dlq = new DlqService($spyDlq);
+        $svc = new NotificationService(new CircuitBreaker(), new Logging(), $metrics, null, $dlq);
+        $res = $svc->sendMail([
+            'to' => 'test@example.com',
+            'subject' => 'Test',
+            'message' => 'Test message',
+            '_attempt' => SMARTALLOC_NOTIFY_MAX_TRIES,
+        ]);
+        $this->assertFalse($res);
+        $this->assertArrayNotHasKey('notify_retry_total', $metrics->counters);
+        $this->assertTrue($spyDlq->has('mail'));
+    }
+}


### PR DESCRIPTION
## Summary
- increment `notify_retry_total` metric before scheduling email retry
- add tests for retry metric behavior in NotificationService

## Testing
- `composer test -- --filter=NotificationServiceTest`
- `php baseline-check --current-phase=foundation`
- `php baseline-compare --feature=notifications`
- `php gap-analysis --target=notifications`
- `vendor/bin/phpcs src/Services/NotificationService.php tests/Unit/Services/NotificationServiceTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68b831eae9ac83219cc681c22ef67ed1