### PR TITLE
feat(notification): track throttled notices as failures

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -19,7 +19,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-03T12:36:22Z
+Last Updated (UTC): 2025-09-03T12:36:24Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -19,7 +19,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-03T12:36:19Z
+Last Updated (UTC): 2025-09-03T12:36:22Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -19,7 +19,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-03T12:26:09Z
+Last Updated (UTC): 2025-09-03T12:36:19Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,10 +1,10 @@
 {
-  "last_update_utc": "2025-09-03T12:26:09Z",
+  "last_update_utc": "2025-09-03T12:36:20Z",
   "repo": {
-    "default_branch": "main",
-    "last_commit": "61d69ecf20a554236c1df4847e8f681b4e240989",
-    "commits_total": 882,
-    "files_tracked": 720
+    "default_branch": "codex/add-failed-metric-tracking-for-throttled-notifications",
+    "last_commit": "6ee18374d32ed46eee4ed26de20eacab4d338447",
+    "commits_total": 884,
+    "files_tracked": 721
   },
   "quality_gate": {
     "weighted_threshold": 0.85,

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-03T12:36:22Z",
+  "last_update_utc": "2025-09-03T12:36:25Z",
   "repo": {
     "default_branch": "codex/add-failed-metric-tracking-for-throttled-notifications",
-    "last_commit": "3bfb7e3a0724b7a86c8363adfb5201717994ab1e",
-    "commits_total": 885,
+    "last_commit": "0985b014d5ff48d59c0a3ff7d5a1ed4455ec5a9b",
+    "commits_total": 886,
     "files_tracked": 721
   },
   "quality_gate": {

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-03T12:36:20Z",
+  "last_update_utc": "2025-09-03T12:36:22Z",
   "repo": {
     "default_branch": "codex/add-failed-metric-tracking-for-throttled-notifications",
-    "last_commit": "6ee18374d32ed46eee4ed26de20eacab4d338447",
-    "commits_total": 884,
+    "last_commit": "3bfb7e3a0724b7a86c8363adfb5201717994ab1e",
+    "commits_total": 885,
     "files_tracked": 721
   },
   "quality_gate": {

--- a/src/Services/NotificationService.php
+++ b/src/Services/NotificationService.php
@@ -86,6 +86,8 @@ final class NotificationService
                 ]);
                 $this->metrics->inc('notify_throttled_total');
                 $this->metrics->inc('dlq_push_total');
+                // count throttled notifications as failures
+                $this->metrics->inc('notify_failed_total');
                 throw new Exceptions\ThrottleException('Rate limit exceeded');
             }
             $payload['_attempt'] = (int) ($payload['_attempt'] ?? 1);

--- a/tests/Integration/NotificationThrottleTest.php
+++ b/tests/Integration/NotificationThrottleTest.php
@@ -1,0 +1,111 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use SmartAlloc\Services\{NotificationService,CircuitBreaker,Logging,Metrics};
+
+if (!function_exists('wp_json_encode')) {
+    function wp_json_encode($data) { return json_encode($data); }
+}
+if (!function_exists('get_transient')) {
+    function get_transient($k) { global $transients; return $transients[$k] ?? false; }
+}
+if (!function_exists('set_transient')) {
+    function set_transient($k, $v, $e) { global $transients; $transients[$k] = $v; return true; }
+}
+if (!function_exists('add_filter')) {
+    function add_filter($hook, $callback) { $GLOBALS['filters'][$hook] = $callback; return true; }
+}
+if (!function_exists('remove_all_filters')) {
+    function remove_all_filters($hook) { unset($GLOBALS['filters'][$hook]); }
+}
+
+final class NotificationThrottleTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+        global $wpdb, $filters, $t, $o;
+        $t = [];
+        $o = [];
+        $filters = [];
+        if (!defined('SMARTALLOC_NOTIFY_LIMIT_PER_MIN')) {
+            define('SMARTALLOC_NOTIFY_LIMIT_PER_MIN', 2);
+        }
+        $wpdb = new class {
+            public string $prefix = 'wp_';
+            public array $inserted = [];
+            public function insert(string $table, array $data): void { $this->inserted[] = $data; }
+            public function query(string $sql): void {}
+            public function get_results($q, $o = OBJECT) { return []; }
+            public function prepare(string $q, ...$args): string { if (isset($args[0]) && is_array($args[0])) $args = $args[0]; return vsprintf($q, $args); }
+            public function get_var($q) { return 0; }
+        };
+        \Patchwork\replace('as_enqueue_single_action', fn() => null);
+        \Patchwork\replace('as_enqueue_async_action', fn() => null);
+        \Patchwork\replace('wp_schedule_single_event', fn() => null);
+    }
+
+    public function testThrottledNotificationsIncrementFailedMetric(): void
+    {
+        global $wpdb;
+        $svc = new NotificationService(new CircuitBreaker(), new Logging(), new Metrics());
+
+        $results = [];
+        for ($i = 0; $i < 4; $i++) {
+            try {
+                $svc->send([
+                    'event_name' => 'user_registered',
+                    'body' => ['user_id' => $i],
+                    'recipient' => 'u@example.com',
+                ]);
+                $results[] = true;
+            } catch (Throwable $e) {
+                $results[] = false;
+            }
+        }
+
+        $this->assertTrue($results[0]);
+        $this->assertTrue($results[1]);
+        $this->assertFalse($results[2]);
+        $this->assertFalse($results[3]);
+
+        $counts = ['notify_failed_total'=>0,'notify_throttled_total'=>0,'dlq_push_total'=>0];
+        foreach ($wpdb->inserted as $row) {
+            if (isset($row['metric_key']) && isset($counts[$row['metric_key']])) {
+                $counts[$row['metric_key']] += (int) $row['value'];
+            }
+        }
+        $this->assertSame(2, $counts['notify_failed_total']);
+        $this->assertSame(2, $counts['notify_throttled_total']);
+        $this->assertSame(2, $counts['dlq_push_total']);
+
+        // no filters to clean up
+    }
+
+    public function testFailedMetricConsistency(): void
+    {
+        global $wpdb, $filters;
+        $svc = new NotificationService(new CircuitBreaker(), new Logging(), new Metrics());
+
+        $this->assertNull($svc->send(['event_name' => 'invalid']));
+
+        set_transient('smartalloc_notify_throttle_' . md5('a'), 2, 60);
+        try {
+            $svc->send(['event_name' => 'user_registered', 'body' => ['user_id' => 1], 'recipient' => 'a']);
+        } catch (Throwable $e) {
+        }
+
+        $filters['smartalloc_notify_transport'] = fn($r, $body, $attempt) => false;
+        $svc->handle(['event_name' => 'password_reset', 'body' => ['email' => 'x@example.com']]);
+        remove_all_filters('smartalloc_notify_transport');
+
+        $counts = 0;
+        foreach ($wpdb->inserted as $row) {
+            if (isset($row['metric_key']) && $row['metric_key'] === 'notify_failed_total') {
+                $counts += (int) $row['value'];
+            }
+        }
+        $this->assertGreaterThanOrEqual(3, $counts);
+    }
+}


### PR DESCRIPTION
## Summary
- count throttled notifications as failed
- cover throttled failure metrics with integration tests

## Testing
- `composer test -- --filter=NotificationThrottleTest`
- `composer test -- --filter=Notification`


------
https://chatgpt.com/codex/tasks/task_e_68b833f2514c8321bf6ffe662545302c