### PR TITLE
fix(baseline): base gate on overall score

### DIFF
--- a/docs/BASELINE_USAGE.md
+++ b/docs/BASELINE_USAGE.md
@@ -7,7 +7,9 @@
 ./gap-analysis --target-phase=foundation
 ```
 
-Baseline check reports now include `overall_score` and `phase_gate_status` fields for easier automation.
+Baseline check reports now include `overall_score` and `phase_gate_status` fields for easier automation. `phase_gate_status`
+returns `PASS` when the weighted overall score meets or exceeds the phase's `completion_target`, even if some individual
+metrics are still below their required values.
 
 ## Composer Scripts
 ```

--- a/scripts/baseline-check.php
+++ b/scripts/baseline-check.php
@@ -55,7 +55,7 @@ class BaselineChecker
 
         $overallScore    = $this->calculateScore($phaseData['metrics']);
         $completionTarget = $phaseData['completion_target'] ?? 0;
-        $status           = ($overallScore >= $completionTarget && empty($gaps)) ? 'PASS' : 'FAIL';
+        $status           = ($overallScore >= $completionTarget) ? 'PASS' : 'FAIL';
 
         return [
             'phase'             => $phase,


### PR DESCRIPTION
## Summary
- base `phase_gate_status` solely on `overall_score >= completion_target`
- document gate logic in baseline usage guide

## Testing
- `php scripts/baseline-check.php --current-phase=FOUNDATION`
- `php scripts/baseline-compare.php --from=start --to=current`
- `composer lint:php`
- `composer test`
- `php scripts/coverage-import.php`
- `php scripts/artifact-schema-validate.php`
- `php scripts/ga-enforcer.php --profile=rc --junit`


------
https://chatgpt.com/codex/tasks/task_e_68b97fce0d108321a8d650a15cdf8391