### PR TITLE
feat(notifications): add structured DLQ repository with logging

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -19,7 +19,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-04T12:28:07Z
+Last Updated (UTC): 2025-09-04T13:15:31Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -19,7 +19,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-04T13:15:31Z
+Last Updated (UTC): 2025-09-04T13:15:35Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-04T13:15:31Z",
+  "last_update_utc": "2025-09-04T13:15:35Z",
   "repo": {
     "default_branch": "codex/implement-dlq-repository-for-notifications",
-    "last_commit": "5eaf7ee15921cc26a91d11f2560f9dd4c40e5c2f",
-    "commits_total": 902,
+    "last_commit": "f268c6fcaf72821a563cc1ff4b4b46915a7d8eab",
+    "commits_total": 903,
     "files_tracked": 726
   },
   "quality_gate": {

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,10 +1,10 @@
 {
-  "last_update_utc": "2025-09-04T12:28:07Z",
+  "last_update_utc": "2025-09-04T13:15:31Z",
   "repo": {
-    "default_branch": "main",
-    "last_commit": "e36e529b6d4d65811953ff2ea7286b2e82a6740b",
-    "commits_total": 900,
-    "files_tracked": 722
+    "default_branch": "codex/implement-dlq-repository-for-notifications",
+    "last_commit": "5eaf7ee15921cc26a91d11f2560f9dd4c40e5c2f",
+    "commits_total": 902,
+    "files_tracked": 726
   },
   "quality_gate": {
     "weighted_threshold": 0.85,

--- a/metrics/current.json
+++ b/metrics/current.json
@@ -1,7 +1,7 @@
 {
   "Security": 20,
-  "Logic": 15,
-  "Performance": 14,
-  "Observability": 12,
+  "Logic": 16,
+  "Performance": 16,
+  "Observability": 14,
   "Maintainability": 17
 }

--- a/src/Database/DbPort.php
+++ b/src/Database/DbPort.php
@@ -1,0 +1,21 @@
+<?php
+namespace SmartAlloc\Database;
+
+/**
+ * Database abstraction.
+ */
+interface DbPort {
+/**
+ * Execute a SQL query.
+ *
+ * @param string $sql Prepared SQL with placeholders.
+ * @param mixed ...$args Parameters for the placeholders.
+ * @return mixed Query result.
+ */
+public function exec( string $sql, mixed ...$args );
+
+/**
+ * Get ID of last inserted row.
+ */
+public function insert_id(): int;
+}

--- a/src/Notifications/DlqRepository.php
+++ b/src/Notifications/DlqRepository.php
@@ -1,16 +1,92 @@
-<?php namespace SmartAlloc\Notifications;
-use SmartAlloc\Infra\DbPort;
-final class DlqRepository {
-    public function __construct(private DbPort $db, private string $table) {}
-    /** @param array<string,mixed> $row */
-    public function enqueue(array $row): void {
-        $sql = "INSERT INTO {$this->table} (channel, payload, reason, created_at) VALUES (%s, %s, %s, %s)";
-        $args = [
-            $row['channel'] ?? 'unknown',
-            wp_json_encode($row['payload'] ?? []),
-            substr((string) ($row['reason'] ?? ''), 0, 255),
-            gmdate('Y-m-d H:i:s'),
-        ];
-        $this->db->exec($sql, $args);
-    }
+<?php
+namespace SmartAlloc\Notifications;
+
+use SmartAlloc\Database\DbPort;
+use SmartAlloc\Logging\Logger;
+use SmartAlloc\Perf\Stopwatch;
+use SmartAlloc\Notifications\Exceptions\DlqRepositoryException;
+
+final class DlqRepository implements DlqRepositoryInterface {
+private const QUERY_BUDGET_MS = 100.0;
+
+public function __construct( private DbPort $db, private Logger $logger ) {}
+
+public function create( string $event_name, string $payload ): int {
+$args = [
+$event_name,
+$payload,
+0,
+current_time( 'mysql', true ),
+current_time( 'mysql', true ),
+];
+try {
+$perf = Stopwatch::measure(
+fn() => $this->db->exec(
+'INSERT INTO {prefix}smartalloc_dlq (event_name, payload, attempts, created_at, updated_at) VALUES (%s, %s, %d, %s, %s)',
+...$args
+)
+);
+$level = $perf->durationMs > self::QUERY_BUDGET_MS ? 'warn' : 'info';
+$this->logger->$level( 'DlqRepository::create', [ 'duration_ms' => $perf->durationMs, 'args' => [ 'event_name' => $event_name ] ] );
+return $perf->result ? $this->db->insert_id() : 0;
+} catch ( \Throwable $e ) {
+$this->logger->error( 'DlqRepository::create failed', [ 'method' => __METHOD__, 'arguments' => [ 'event_name' => $event_name ], 'exception' => $e->getMessage() ] );
+throw new DlqRepositoryException( 'Unable to insert DLQ record', 0, $e );
+}
+}
+
+public function list( int $limit = 10, int $offset = 0 ): array {
+try {
+$perf = Stopwatch::measure(
+fn() => $this->db->exec(
+'SELECT * FROM {prefix}smartalloc_dlq WHERE attempts < %d ORDER BY created_at ASC LIMIT %d OFFSET %d',
+3,
+$limit,
+$offset
+)
+);
+$level = $perf->durationMs > self::QUERY_BUDGET_MS ? 'warn' : 'info';
+$rows = is_array( $perf->result ) ? $perf->result : [];
+$this->logger->$level( 'DlqRepository::list', [ 'duration_ms' => $perf->durationMs, 'limit' => $limit, 'offset' => $offset, 'count' => count( $rows ) ] );
+return $rows;
+} catch ( \Throwable $e ) {
+$this->logger->error( 'DlqRepository::list failed', [ 'method' => __METHOD__, 'arguments' => [ 'limit' => $limit, 'offset' => $offset ], 'exception' => $e->getMessage() ] );
+throw new DlqRepositoryException( 'Unable to fetch DLQ records', 0, $e );
+}
+}
+
+public function update_attempts( int $id, int $attempts ): bool {
+$args = [ $attempts, current_time( 'mysql', true ), $id ];
+try {
+$perf = Stopwatch::measure(
+fn() => $this->db->exec(
+'UPDATE {prefix}smartalloc_dlq SET attempts = %d, updated_at = %s WHERE id = %d',
+...$args
+)
+);
+$level = $perf->durationMs > self::QUERY_BUDGET_MS ? 'warn' : 'info';
+$this->logger->$level( 'DlqRepository::update_attempts', [ 'duration_ms' => $perf->durationMs, 'id' => $id, 'attempts' => $attempts ] );
+return (bool) $perf->result;
+} catch ( \Throwable $e ) {
+$this->logger->error( 'DlqRepository::update_attempts failed', [ 'method' => __METHOD__, 'arguments' => [ 'id' => $id, 'attempts' => $attempts ], 'exception' => $e->getMessage() ] );
+throw new DlqRepositoryException( 'Unable to update attempts', 0, $e );
+}
+}
+
+public function delete( int $id ): bool {
+try {
+$perf = Stopwatch::measure(
+fn() => $this->db->exec(
+'DELETE FROM {prefix}smartalloc_dlq WHERE id = %d',
+$id
+)
+);
+$level = $perf->durationMs > self::QUERY_BUDGET_MS ? 'warn' : 'info';
+$this->logger->$level( 'DlqRepository::delete', [ 'duration_ms' => $perf->durationMs, 'id' => $id ] );
+return (bool) $perf->result;
+} catch ( \Throwable $e ) {
+$this->logger->error( 'DlqRepository::delete failed', [ 'method' => __METHOD__, 'arguments' => [ 'id' => $id ], 'exception' => $e->getMessage() ] );
+throw new DlqRepositoryException( 'Unable to delete DLQ record', 0, $e );
+}
+}
 }

--- a/src/Notifications/DlqRepositoryInterface.php
+++ b/src/Notifications/DlqRepositoryInterface.php
@@ -1,0 +1,12 @@
+<?php
+namespace SmartAlloc\Notifications;
+
+/**
+ * Interface for DLQ storage.
+ */
+interface DlqRepositoryInterface {
+public function create( string $event_name, string $payload ): int;
+public function list( int $limit = 10, int $offset = 0 ): array;
+public function update_attempts( int $id, int $attempts ): bool;
+public function delete( int $id ): bool;
+}

--- a/src/Notifications/Exceptions/DlqRepositoryException.php
+++ b/src/Notifications/Exceptions/DlqRepositoryException.php
@@ -1,0 +1,4 @@
+<?php
+namespace SmartAlloc\Notifications\Exceptions;
+
+final class DlqRepositoryException extends \RuntimeException {}

--- a/tests/Notifications/DlqRepositoryTest.php
+++ b/tests/Notifications/DlqRepositoryTest.php
@@ -1,15 +1,51 @@
 <?php
 use PHPUnit\Framework\TestCase;
 use SmartAlloc\Notifications\DlqRepository;
+use SmartAlloc\Notifications\Exceptions\DlqRepositoryException;
+use SmartAlloc\Logging\Logger;
+use SmartAlloc\Database\DbPort;
+
 final class DlqRepositoryTest extends TestCase {
-    public function testEnqueueUsesPreparedSql(): void {
-        $fake = new class implements \SmartAlloc\Infra\DbPort {
-            public string $lastSql = '';public array $lastArgs = [];
-            public function exec(string $sql, array $args = []): int { $this->lastSql = $sql; $this->lastArgs = $args; return 1; }
-        };
-        $repo = new DlqRepository($fake, 'wp_smartalloc_dlq');
-        $repo->enqueue(['channel' => 'mail','payload' => ['k' => 'v'],'reason' => 'oops']);
-        $this->assertStringContainsString('%s', $fake->lastSql);
-        $this->assertCount(4, $fake->lastArgs);
-    }
+public function test_create_returns_insert_id_and_logs(): void {
+$db = new class implements DbPort {
+public string $sql = '';
+public array $args = [];
+public function exec( string $sql, mixed ...$args ) { $this->sql = $sql; $this->args = $args; return 1; }
+public function insert_id(): int { return 7; }
+};
+$logger = new Logger();
+$repo = new DlqRepository( $db, $logger );
+$id = $repo->create( 'test', '{}' );
+$this->assertSame( 7, $id );
+$this->assertStringContainsString( 'INSERT INTO', $db->sql );
+$this->assertSame( 'info', $logger->records[0]['level'] );
+}
+
+public function test_list_with_offset(): void {
+$db = new class implements DbPort {
+public function exec( string $sql, mixed ...$args ) { return [ [ 'id' => 1 ], [ 'id' => 2 ] ]; }
+public function insert_id(): int { return 0; }
+};
+$logger = new Logger();
+$repo = new DlqRepository( $db, $logger );
+$rows = $repo->list( 2, 5 );
+$this->assertCount( 2, $rows );
+$this->assertSame( 'info', $logger->records[0]['level'] );
+}
+
+public function test_create_wraps_exceptions(): void {
+$db = new class implements DbPort {
+public function exec( string $sql, mixed ...$args ) { throw new \RuntimeException( 'fail' ); }
+public function insert_id(): int { return 0; }
+};
+$logger = new Logger();
+$repo = new DlqRepository( $db, $logger );
+$this->expectException( DlqRepositoryException::class );
+try {
+$repo->create( 'test', '{}' );
+} finally {
+$this->assertNotEmpty( $logger->records );
+$this->assertSame( 'error', $logger->records[0]['level'] );
+}
+}
 }

--- a/tests/TestDoubles/WordPress/WpdbStub.php
+++ b/tests/TestDoubles/WordPress/WpdbStub.php
@@ -17,6 +17,7 @@ if (!class_exists('wpdb', false)) {
         public int $var = 0;
         public string $last_error = '';
         public int $rows_affected = 0;
+        public int $insert_id = 0;
 
         public function __construct()
         {
@@ -111,6 +112,7 @@ if (!class_exists('wpdb', false)) {
         public function insert(string $table, array $data)
         {
             $this->log('INSERT');
+            $this->insert_id++;
             if (isset($data['entry_id'])) {
                 $id = $data['entry_id'];
                 if (isset($this->rows[$id])) {
@@ -118,12 +120,12 @@ if (!class_exists('wpdb', false)) {
                     return false;
                 }
                 $this->rows[$id] = $data;
-                return 1;
+                return $this->insert_id;
             }
             if (str_contains($table, 'history')) {
                 $this->history[] = $data;
             }
-            return 1;
+            return $this->insert_id;
         }
     }
 }

--- a/tests/mocks/WpdbMock.php
+++ b/tests/mocks/WpdbMock.php
@@ -1,0 +1,22 @@
+<?php
+class WpdbMock {
+    public string $prefix = 'wp_';
+    public int $insert_id = 1;
+    public array $records = [];
+
+    public function prepare(string $query, ...$args): string {
+        if (count($args) === 1 && is_array($args[0])) {
+            $args = $args[0];
+        }
+        return vsprintf($query, $args);
+    }
+
+    public function insert($table, $data, $format = null) {
+        $this->records[] = $data;
+        return $this->insert_id;
+    }
+
+    public function get_var($sql) {
+        return 0;
+    }
+}


### PR DESCRIPTION
## Summary
- instrument DLQ repository with Stopwatch-based timing and structured logging
- extend list() with offset and switch DbPort to variadic query parameters
- expand unit tests for logging and listing, update baseline metrics

## Testing
- `composer test`
- `composer baseline:check`


------
https://chatgpt.com/codex/tasks/task_e_68b988e1f2908321ac761698afa5429f