### PR TITLE
feat(dlq): add structured error logging to replay

### DIFF
--- a/src/Services/DlqService.php
+++ b/src/Services/DlqService.php
@@ -8,13 +8,15 @@ use SmartAlloc\Infrastructure\Contracts\DlqRepository;
 use SmartAlloc\Infrastructure\WpDb\WpDlqRepository;
 use DateTimeImmutable;
 use DateTimeZone;
+use Psr\Log\LoggerInterface;
+use Throwable;
 
 /**
  * Dead letter queue storage service.
  */
 final class DlqService
 {
-    public function __construct(private ?DlqRepository $repo = null)
+    public function __construct(private ?DlqRepository $repo = null, private ?LoggerInterface $logger = null)
     {
         $this->repo ??= WpDlqRepository::createDefault();
     }
@@ -90,12 +92,36 @@ final class DlqService
                 \do_action('smartalloc_notify', $payload);
                 $this->delete((int) $row['id']);
                 $ok++;
-            } catch (\Throwable $e) {
+            } catch (Throwable $e) {
+                $this->logReplayError($e, $row['id'] ?? 'unknown');
                 $fail++;
+                continue;
             }
         }
         $depth = $this->count();
         return ['ok' => $ok, 'fail' => $fail, 'depth' => $depth];
+    }
+
+    /**
+     * Log replay error with context.
+     *
+     * @param Throwable $e     The caught exception
+     * @param mixed     $rowId The problematic row identifier
+     */
+    private function logReplayError(Throwable $e, $rowId): void
+    {
+        if ($this->logger) {
+            $this->logger->error('DlqService::doReplay failed for row', [
+                'method'    => __METHOD__,
+                'row_id'    => $rowId,
+                'exception' => $e->getMessage(),
+                'trace'     => $e->getTraceAsString(),
+                'file'      => $e->getFile(),
+                'line'      => $e->getLine(),
+            ]);
+        } else {
+            error_log('DlqService::doReplay: Row ID ' . $rowId . ' - ' . $e->getMessage()); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+        }
     }
 
     private function count(): int

--- a/tests/unit/Services/DlqServiceTest.php
+++ b/tests/unit/Services/DlqServiceTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 use SmartAlloc\Tests\BaseTestCase;
 use SmartAlloc\Services\DlqService;
 use SmartAlloc\Tests\TestDoubles\SpyDlq;
+use Psr\Log\LoggerInterface;
+use SmartAlloc\Infrastructure\Contracts\DlqRepository;
 
 final class DlqServiceTest extends BaseTestCase
 {
@@ -28,5 +30,95 @@ final class DlqServiceTest extends BaseTestCase
         $svc->delete($id);
         $this->assertCount(0, $svc->listRecent());
     }
+
+    public function testReplayLogsErrorWithStructuredLogger(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())
+            ->method('error')
+            ->with(
+                'DlqService::doReplay failed for row',
+                $this->callback(static fn($context) => isset($context['method'], $context['row_id'], $context['exception']))
+            );
+
+        $repo = new class implements DlqRepository {
+            public array $rows = [];
+            public function insert(string $topic, array $payload, \DateTimeImmutable $createdAtUtc): bool
+            {
+                $this->rows[] = ['id' => count($this->rows) + 1, 'event_name' => $topic, 'payload' => $payload];
+                return true;
+            }
+            public function listRecent(int $limit): array
+            {
+                return array_slice($this->rows, 0, $limit);
+            }
+            public function get(int $id): ?array
+            {
+                foreach ($this->rows as $row) {
+                    if ($row['id'] === $id) {
+                        return $row;
+                    }
+                }
+                return null;
+            }
+            public function delete(int $id): bool
+            {
+                throw new \Exception('Test error');
+            }
+            public function count(): int
+            {
+                return count($this->rows);
+            }
+        };
+
+        $svc = new DlqService($repo, $logger);
+        $svc->push(['event_name' => 'Evt', 'payload' => []]);
+        $svc->replay(1);
+    }
+
+    public function testReplayUsesErrorLogFallback(): void
+    {
+        $repo = new class implements DlqRepository {
+            public array $rows = [];
+            public function insert(string $topic, array $payload, \DateTimeImmutable $createdAtUtc): bool
+            {
+                $this->rows[] = ['id' => count($this->rows) + 1, 'event_name' => $topic, 'payload' => $payload];
+                return true;
+            }
+            public function listRecent(int $limit): array
+            {
+                return array_slice($this->rows, 0, $limit);
+            }
+            public function get(int $id): ?array
+            {
+                foreach ($this->rows as $row) {
+                    if ($row['id'] === $id) {
+                        return $row;
+                    }
+                }
+                return null;
+            }
+            public function delete(int $id): bool
+            {
+                throw new \Exception('Fallback error');
+            }
+            public function count(): int
+            {
+                return count($this->rows);
+            }
+        };
+
+        $svc = new DlqService($repo);
+        $svc->push(['event_name' => 'Evt', 'payload' => []]);
+
+        $tmpLog = tempnam(sys_get_temp_dir(), 'dlq');
+        $orig   = ini_get('error_log');
+        ini_set('error_log', $tmpLog);
+        $svc->replay(1);
+        ini_set('error_log', (string) $orig);
+        $this->assertStringContainsString('Row ID 1 - Fallback error', (string) file_get_contents($tmpLog));
+        @unlink($tmpLog);
+    }
+
 }
 


### PR DESCRIPTION
## Summary
- inject optional PSR-3 logger into `DlqService` for structured error reporting with fallback to `error_log`
- cover DLQ replay logging paths with unit tests

## Testing
- `./baseline-check --current-phase=foundation`
- `./baseline-compare --feature=DlqServiceErrorLogging`
- `./gap-analysis --target=foundation`
- `vendor/bin/phpcs src/Services/DlqService.php tests/unit/Services/DlqServiceTest.php`
- `vendor/bin/phpunit tests/unit/Services/DlqServiceTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68b99455fd6883219a233b083f3d2151