### PR TITLE
feat(dlq): add structured error logging to replay

### DIFF
--- a/tests/TestDoubles/ArrayLogger.php
+++ b/tests/TestDoubles/ArrayLogger.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+namespace SmartAlloc\Tests\TestDoubles;
+
+use Psr\Log\LoggerInterface;
+use Psr\Log\LoggerTrait;
+
+final class ArrayLogger implements LoggerInterface
+{
+    use LoggerTrait;
+
+    /** @var array<int,array{level:string,message:string,context:array<string,mixed>}> */
+    public array $records = [];
+
+    public function log($level, $message, array $context = []): void
+    {
+        $this->records[] = [
+            'level' => strtoupper((string) $level),
+            'message' => $message,
+            'context' => $context,
+        ];
+    }
+}

--- a/tests/TestDoubles/FailingDlq.php
+++ b/tests/TestDoubles/FailingDlq.php
@@ -1,0 +1,74 @@
+<?php
+declare(strict_types=1);
+
+namespace SmartAlloc\Tests\TestDoubles;
+
+use SmartAlloc\Infrastructure\Contracts\DlqRepository;
+use DateTimeImmutable;
+use RuntimeException;
+
+final class FailingDlq implements DlqRepository
+{
+    /** @var array<int,array{topic:string,payload:array,ts:DateTimeImmutable}> */
+    public array $entries = [];
+
+    public function insert(string $topic, array $payload, DateTimeImmutable $createdAtUtc): bool
+    {
+        $this->entries[] = ['topic' => $topic, 'payload' => $payload, 'ts' => $createdAtUtc];
+        return true;
+    }
+
+    public function has(string $topic): bool
+    {
+        foreach ($this->entries as $e) {
+            if ($e['topic'] === $topic) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public function last(string $topic): ?array
+    {
+        foreach (array_reverse($this->entries) as $e) {
+            if ($e['topic'] === $topic) {
+                return $e['payload'];
+            }
+        }
+        return null;
+    }
+
+    /** @return array<int,array<string,mixed>> */
+    public function listRecent(int $limit): array
+    {
+        $out = [];
+        foreach (array_slice(array_reverse($this->entries), 0, $limit) as $i => $e) {
+            $out[] = [
+                'id'         => $i + 1,
+                'event_name' => $e['topic'],
+                'payload'    => $e['payload'],
+                'attempts'   => $e['payload']['attempts'] ?? 0,
+                'error_text' => $e['payload']['error_text'] ?? null,
+                'created_at' => $e['ts']->format('Y-m-d H:i:s'),
+            ];
+        }
+        return $out;
+    }
+
+    /** @return array<string,mixed>|null */
+    public function get(int $id): ?array
+    {
+        $items = $this->listRecent(PHP_INT_MAX);
+        return $items[$id - 1] ?? null;
+    }
+
+    public function delete(int $id): bool
+    {
+        throw new RuntimeException('delete failed');
+    }
+
+    public function count(): int
+    {
+        return count($this->entries);
+    }
+}

--- a/tests/unit/Services/DlqServiceReplayLoggingTest.php
+++ b/tests/unit/Services/DlqServiceReplayLoggingTest.php
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types=1);
+
+use SmartAlloc\Tests\BaseTestCase;
+use SmartAlloc\Services\DlqService;
+use SmartAlloc\Tests\TestDoubles\FailingDlq;
+use SmartAlloc\Tests\TestDoubles\ArrayLogger;
+
+if (!function_exists('wp_json_encode')) {
+    function wp_json_encode($data, $options = 0) {
+        return json_encode($data, $options);
+    }
+}
+
+final class DlqServiceReplayLoggingTest extends BaseTestCase
+{
+    public function test_doReplay_logs_error_with_structured_logger(): void
+    {
+        $repo = new FailingDlq();
+        $repo->insert('test', [], new \DateTimeImmutable('now', new \DateTimeZone('UTC')));
+
+        $logger = new ArrayLogger();
+
+        $svc = new DlqService($repo, $logger);
+        $svc->replay(1);
+
+        $this->assertCount(1, $logger->records);
+        $record = $logger->records[0];
+        $this->assertSame('ERROR', $record['level']);
+        $this->assertSame('DlqService::doReplay failed for row', $record['message']);
+        $this->assertSame(1, $record['context']['row_id']);
+        $this->assertSame('delete failed', $record['context']['exception']);
+    }
+
+    public function test_doReplay_uses_error_log_fallback(): void
+    {
+        $repo = new FailingDlq();
+        $repo->insert('t', [], new \DateTimeImmutable('now', new \DateTimeZone('UTC')));
+
+        $tmp = tempnam(sys_get_temp_dir(), 'dlq');
+        $prev = ini_set('error_log', $tmp);
+        try {
+            $svc = new DlqService($repo);
+            $svc->replay(1);
+            $content = file_get_contents($tmp) ?: '';
+            $this->assertStringContainsString('DlqService::doReplay: Row ID 1 - delete failed', $content);
+        } finally {
+            ini_set('error_log', (string) $prev);
+            @unlink($tmp);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add optional PSR-3 logger injection to DlqService and log replay failures with row context
- introduce ArrayLogger and FailingDlq test doubles
- cover structured and fallback logging with dedicated unit tests

## Testing
- `php baseline-check --current-phase=foundation`
- `php baseline-compare --feature="DlqService Error Logging Enhancement"`
- `php gap-analysis --target="DlqService Error Logging"`
- `vendor/bin/phpunit tests/unit/Services/DlqServiceReplayLoggingTest.php`

------
https://chatgpt.com/codex/tasks/task_e_68b99455fd6883219a233b083f3d2151