### PR TITLE
feat(dlq): add stopwatch instrumentation and typed replay exception

### DIFF
--- a/patchwork.json
+++ b/patchwork.json
@@ -1,3 +1,3 @@
 {
-    "redefinable-internals": ["header", "time", "filter_input"]
+    "redefinable-internals": ["header", "time", "filter_input", "error_log"]
 }

--- a/src/Services/DlqService.php
+++ b/src/Services/DlqService.php
@@ -8,13 +8,18 @@ use SmartAlloc\Infrastructure\Contracts\DlqRepository;
 use SmartAlloc\Infrastructure\WpDb\WpDlqRepository;
 use DateTimeImmutable;
 use DateTimeZone;
+use Psr\Log\LoggerInterface;
+use SmartAlloc\Perf\Stopwatch;
+use SmartAlloc\Services\Exceptions\ReplayException;
 
 /**
  * Dead letter queue storage service.
  */
 final class DlqService
 {
-    public function __construct(private ?DlqRepository $repo = null)
+    private const REPLAY_BUDGET_MS = 150.0;
+
+    public function __construct(private ?DlqRepository $repo = null, private ?LoggerInterface $logger = null)
     {
         $this->repo ??= WpDlqRepository::createDefault();
     }
@@ -87,15 +92,49 @@ final class DlqService
                 '_attempt'   => 1,
             ];
             try {
-                \do_action('smartalloc_notify', $payload);
-                $this->delete((int) $row['id']);
+                $perf = Stopwatch::measure(function () use ($payload, $row): void {
+                    try {
+                        \do_action('smartalloc_notify', $payload);
+                        $this->delete((int) $row['id']);
+                    } catch (\Throwable $e) {
+                        throw new ReplayException($e->getMessage(), 0, $e); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
+                    }
+                });
+                if ($this->logger) {
+                    $level = $perf->durationMs > self::REPLAY_BUDGET_MS ? 'warning' : 'info';
+                    $this->logger->$level('DlqService::doReplay row processed', [
+                        'method'      => __METHOD__,
+                        'row_id'      => $row['id'] ?? 'unknown',
+                        'duration_ms' => $perf->durationMs,
+                    ]);
+                }
                 $ok++;
-            } catch (\Throwable $e) {
+            } catch (ReplayException $e) {
+                $this->logReplayError($e, $row['id'] ?? 'unknown');
                 $fail++;
             }
         }
         $depth = $this->count();
         return ['ok' => $ok, 'fail' => $fail, 'depth' => $depth];
+    }
+
+    private function logReplayError(\Throwable $e, int|string $rowId): void
+    {
+        if ($this->logger) {
+            $this->logger->error('DlqService::doReplay failed for row', [
+                'method'    => __METHOD__,
+                'row_id'    => $rowId,
+                'exception' => $e->getMessage(),
+                'trace'     => $e->getTraceAsString(),
+                'file'      => $e->getFile(),
+                'line'      => $e->getLine(),
+            ]);
+            return;
+        }
+        // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+        error_log(
+            'DlqService::doReplay: Row ID ' . $rowId . ' - ' . $e->getMessage()
+        );
     }
 
     private function count(): int

--- a/src/Services/Exceptions/ReplayException.php
+++ b/src/Services/Exceptions/ReplayException.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+
+namespace SmartAlloc\Services\Exceptions;
+
+final class ReplayException extends \RuntimeException
+{
+}
+

--- a/tests/unit/Services/DlqServiceTest.php
+++ b/tests/unit/Services/DlqServiceTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 use SmartAlloc\Tests\BaseTestCase;
 use SmartAlloc\Services\DlqService;
 use SmartAlloc\Tests\TestDoubles\SpyDlq;
+use SmartAlloc\Infrastructure\Contracts\DlqRepository;
+use Psr\Log\LoggerInterface;
 
 final class DlqServiceTest extends BaseTestCase
 {
@@ -27,6 +29,58 @@ final class DlqServiceTest extends BaseTestCase
         $this->assertSame('Evt', $item['event_name']);
         $svc->delete($id);
         $this->assertCount(0, $svc->listRecent());
+    }
+
+    public function testDoReplayLogsErrorWithStructuredLogger(): void
+    {
+        $repo = new class implements DlqRepository {
+            public array $rows = [];
+            public function insert(string $topic, array $payload, \DateTimeImmutable $createdAtUtc): bool { $this->rows[] = ['id' => count($this->rows) + 1, 'event_name' => $topic, 'payload' => $payload]; return true; }
+            public function listRecent(int $limit): array { return $this->rows; }
+            public function get(int $id): ?array { return null; }
+            public function delete(int $id): bool { throw new \RuntimeException('Test error'); }
+            public function count(): int { return count($this->rows); }
+        };
+        $repo->insert('Evt', ['payload' => 'x'], new \DateTimeImmutable());
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())->method('error')->with(
+            'DlqService::doReplay failed for row',
+            $this->callback(function ($context) {
+                return ($context['row_id'] ?? null) === 1 && isset($context['exception']);
+            })
+        );
+
+        $svc = new DlqService($repo, $logger);
+        $svc->replay(1);
+    }
+
+    public function testDoReplayUsesErrorLogFallback(): void
+    {
+        $repo = new class implements DlqRepository {
+            public array $rows = [];
+            public function insert(string $topic, array $payload, \DateTimeImmutable $createdAtUtc): bool { $this->rows[] = ['id' => count($this->rows) + 1, 'event_name' => $topic, 'payload' => $payload]; return true; }
+            public function listRecent(int $limit): array { return $this->rows; }
+            public function get(int $id): ?array { return null; }
+            public function delete(int $id): bool { throw new \RuntimeException('Fallback error'); }
+            public function count(): int { return count($this->rows); }
+        };
+        $repo->insert('Evt', ['payload' => 'x'], new \DateTimeImmutable());
+
+        $svc = new DlqService($repo);
+
+        $captured = '';
+        $h = \Patchwork\replace('error_log', function ($msg) use (&$captured) { $captured = $msg; return true; });
+        $svc->replay(1);
+        \Patchwork\restore($h);
+        $this->assertStringContainsString('DlqService::doReplay: Row ID 1 - Fallback error', $captured);
+    }
+
+    public function testBackwardCompatibilityWithoutLogger(): void
+    {
+        $repo = new SpyDlq();
+        $svc = new DlqService($repo);
+        $this->assertInstanceOf(DlqService::class, $svc);
     }
 }
 


### PR DESCRIPTION
## Summary
- measure DLQ replay processing with Stopwatch and log durations
- introduce ReplayException and handle it with structured logging

## Testing
- `vendor/bin/phpcs src/Services/DlqService.php src/Services/Exceptions/ReplayException.php tests/unit/Services/DlqServiceTest.php`
- `vendor/bin/phpunit tests/unit/Services/DlqServiceTest.php`
- `php baseline-check --current-phase=foundation`
- `php baseline-compare --feature=DlqServiceErrorLogging`
- `php gap-analysis --target=foundation`


------
https://chatgpt.com/codex/tasks/task_e_68b99455fd6883219a233b083f3d2151