### PR TITLE
feat(dlq): add replay exception and iteration stopwatch

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -19,7 +19,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-04T15:00:33Z
+Last Updated (UTC): 2025-09-04T15:00:37Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -19,7 +19,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-04T14:08:33Z
+Last Updated (UTC): 2025-09-04T15:00:30Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -19,7 +19,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-04T15:00:30Z
+Last Updated (UTC): 2025-09-04T15:00:33Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,10 +1,10 @@
 {
-  "last_update_utc": "2025-09-04T14:08:33Z",
+  "last_update_utc": "2025-09-04T15:00:31Z",
   "repo": {
-    "default_branch": "main",
-    "last_commit": "6ad0fe1f8945db0b4d5187d2ea87f5c3a3dfef8f",
-    "commits_total": 921,
-    "files_tracked": 728
+    "default_branch": "codex/implement-replayexception-and-stopwatch-measure",
+    "last_commit": "6cf50a9d7e89a7a8254be43a0855572022e57e44",
+    "commits_total": 923,
+    "files_tracked": 729
   },
   "quality_gate": {
     "weighted_threshold": 0.85,

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-04T15:00:31Z",
+  "last_update_utc": "2025-09-04T15:00:34Z",
   "repo": {
     "default_branch": "codex/implement-replayexception-and-stopwatch-measure",
-    "last_commit": "6cf50a9d7e89a7a8254be43a0855572022e57e44",
-    "commits_total": 923,
+    "last_commit": "c81c4cb90334c0e8f0f030d49f50523b5aced7bf",
+    "commits_total": 924,
     "files_tracked": 729
   },
   "quality_gate": {

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-04T15:00:34Z",
+  "last_update_utc": "2025-09-04T15:00:37Z",
   "repo": {
     "default_branch": "codex/implement-replayexception-and-stopwatch-measure",
-    "last_commit": "c81c4cb90334c0e8f0f030d49f50523b5aced7bf",
-    "commits_total": 924,
+    "last_commit": "d4884d6e9bac8aa9d18b0f18b7a459c7de738f28",
+    "commits_total": 925,
     "files_tracked": 729
   },
   "quality_gate": {

--- a/src/Exception/ReplayException.php
+++ b/src/Exception/ReplayException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SmartAlloc\Exception;
+
+final class ReplayException extends \Exception
+{
+}


### PR DESCRIPTION
## Summary
- handle replay errors via dedicated ReplayException
- instrument DlqService replay iterations with Stopwatch and 150ms budget
- warn when replay iteration exceeds budget

## Testing
- `composer lint:php`
- `vendor/bin/phpcs src/Services/DlqService.php src/Exception/ReplayException.php tests/unit/Services/DlqServiceTest.php`
- `composer test`
- `./baseline-check --current-phase=foundation`
- `./baseline-compare --feature=DlqServiceErrorLogging`
- `./gap-analysis`


------
https://chatgpt.com/codex/tasks/task_e_68b9a7cf48508321a71447cf0702c514