### PR TITLE
refactor(metrics): inject DbPort for metrics service

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -19,7 +19,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-04T15:23:58Z
+Last Updated (UTC): 2025-09-04T15:24:01Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -19,7 +19,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-04T15:10:47Z
+Last Updated (UTC): 2025-09-04T15:23:58Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-04T15:23:58Z",
+  "last_update_utc": "2025-09-04T15:24:01Z",
   "repo": {
     "default_branch": "codex/refactor-metrics-service-for-dependency-injection",
-    "last_commit": "e59667f60d46ec1a56770962d3432edcf09a4cf7",
-    "commits_total": 935,
+    "last_commit": "85ad97b8b385f29b44105a53390518e0a8cd4b8b",
+    "commits_total": 936,
     "files_tracked": 731
   },
   "quality_gate": {

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,10 +1,10 @@
 {
-  "last_update_utc": "2025-09-04T15:10:48Z",
+  "last_update_utc": "2025-09-04T15:23:58Z",
   "repo": {
-    "default_branch": "main",
-    "last_commit": "ae08b881618b9814a67a044595c10a4a8309c509",
-    "commits_total": 933,
-    "files_tracked": 729
+    "default_branch": "codex/refactor-metrics-service-for-dependency-injection",
+    "last_commit": "e59667f60d46ec1a56770962d3432edcf09a4cf7",
+    "commits_total": 935,
+    "files_tracked": 731
   },
   "quality_gate": {
     "weighted_threshold": 0.85,

--- a/src/Services/Metrics.php
+++ b/src/Services/Metrics.php
@@ -4,47 +4,79 @@ declare(strict_types=1);
 
 namespace SmartAlloc\Services;
 
-use SmartAlloc\Infrastructure\Contracts\DbProxy;
-use SmartAlloc\Infrastructure\WpDb\WpdbAdapter;
+use Psr\Log\LoggerInterface;
+use SmartAlloc\Database\DbPort;
 use Throwable;
+use function wp_json_encode;
 
 /**
- * Metrics collection service
+ * Metrics collection service.
  */
 class Metrics
 {
-    private DbProxy $db;
+    private DbPort $db;
+
     private string $table;
 
-    public function __construct(?DbProxy $db = null, ?string $table = null)
+    private ?LoggerInterface $logger;
+
+    public function __construct(DbPort $dbPort, string $tableName, ?LoggerInterface $logger = null)
     {
-        $this->db = $db ?? WpdbAdapter::fromGlobals();
-        $this->table = $table ?? $this->db->getPrefix() . 'salloc_metrics';
+        $this->db     = $dbPort;
+        $this->table  = $tableName;
+        $this->logger = $logger;
     }
 
-    public static function createDefault(): self
+    private function log_error(string $method, Throwable $e): void
     {
-        return new self(WpdbAdapter::fromGlobals());
-    }
+        $context = [
+            'method'    => $method,
+            'table'     => $this->table,
+            'exception' => $e->getMessage(),
+        ];
 
-    /**
-     * Increment a counter metric
-     */
-    public function inc(string $key, float $value = 1.0, array $labels = []): void
-    {
-        try {
-            $this->db->insert($this->table, [
-                'metric_key' => $key,
-                'labels' => \wp_json_encode($labels),
-                'value' => $value,
-            ]);
-        } catch (Throwable $e) {
-            error_log('Metrics::inc: ' . $e->getMessage()); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+        if ($this->logger) {
+            $this->logger->error('Metrics database operation failed', $context);
+        } else {
+            // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+            error_log(
+                sprintf(
+                    'Metrics::%s failed for table %s: %s',
+                    $method,
+                    $this->table,
+                    $e->getMessage()
+                )
+            );
         }
     }
 
     /**
-     * Record a duration metric
+     * Increment a counter metric.
+     *
+     * @param string $key    Metric key.
+     * @param float  $value  Increment amount.
+     * @param array  $labels Metric labels.
+     */
+    public function inc(string $key, float $value = 1.0, array $labels = []): void
+    {
+        try {
+            $this->db->exec(
+                "INSERT INTO {prefix}{$this->table} (metric_key, labels, value) VALUES (%s, %s, %f)",
+                $key,
+                wp_json_encode($labels),
+                $value
+            );
+        } catch (Throwable $e) {
+            $this->log_error(__METHOD__, $e);
+        }
+    }
+
+    /**
+     * Record a duration metric.
+     *
+     * @param string $key          Metric key.
+     * @param int    $milliseconds Duration in milliseconds.
+     * @param array  $labels       Metric labels.
      */
     public function observe(string $key, int $milliseconds, array $labels = []): void
     {
@@ -52,52 +84,69 @@ class Metrics
     }
 
     /**
-     * Get metrics for a specific key
+     * Get metrics for a specific key.
+     *
+     * @param string $key   Metric key.
+     * @param int    $limit Maximum rows to return.
+     * @return array<int,array<string,mixed>>
      */
     public function get(string $key, int $limit = 100): array
     {
         try {
-            $sql = "SELECT metric_key, labels, value, ts FROM {$this->table} WHERE metric_key = %s ORDER BY ts DESC LIMIT %d";
-            $results = $this->db->getResults($sql, [$key, $limit]);
+            $rows = $this->db->exec(
+                "SELECT metric_key, labels, value, ts FROM {prefix}{$this->table} WHERE metric_key = %s ORDER BY ts DESC LIMIT %d",
+                $key,
+                $limit
+            );
         } catch (Throwable $e) {
-            error_log('Metrics::get: ' . $e->getMessage()); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+            $this->log_error(__METHOD__, $e);
             return [];
         }
 
-        foreach ($results as &$result) {
-            $result['labels'] = json_decode($result['labels'] ?: '[]', true);
+        $rows = is_array($rows) ? $rows : [];
+        foreach ($rows as &$row) {
+            $row['labels'] = json_decode($row['labels'] ?: '[]', true);
         }
 
-        return $results;
+        return $rows;
     }
 
     /**
-     * Get aggregated metrics
+     * Get aggregated metrics.
+     *
+     * @param string $key         Metric key.
+     * @param string $aggregation Aggregation type.
+     * @param int    $hours       Hours to look back.
+     * @return array<int,array<string,mixed>>
      */
     public function getAggregated(string $key, string $aggregation = 'sum', int $hours = 24): array
     {
-        $sqlAgg = match ($aggregation) {
-            'sum' => 'SUM(value)',
-            'avg' => 'AVG(value)',
+        $sql_agg = match ($aggregation) {
+            'sum'   => 'SUM(value)',
+            'avg'   => 'AVG(value)',
             'count' => 'COUNT(*)',
-            'min' => 'MIN(value)',
-            'max' => 'MAX(value)',
+            'min'   => 'MIN(value)',
+            'max'   => 'MAX(value)',
             default => 'SUM(value)',
         };
 
         try {
-            $sql = "SELECT {$sqlAgg} as value, labels FROM {$this->table} WHERE metric_key = %s AND ts >= DATE_SUB(NOW(), INTERVAL %d HOUR) GROUP BY labels ORDER BY value DESC";
-            $results = $this->db->getResults($sql, [$key, $hours]);
+            $rows = $this->db->exec(
+                "SELECT {$sql_agg} as value, labels FROM {prefix}{$this->table} WHERE metric_key = %s AND ts >= DATE_SUB(NOW(), INTERVAL %d HOUR) GROUP BY labels ORDER BY value DESC",
+                $key,
+                $hours
+            );
         } catch (Throwable $e) {
-            error_log('Metrics::getAggregated: ' . $e->getMessage()); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+            $this->log_error(__METHOD__, $e);
             return [];
         }
 
-        foreach ($results as &$result) {
-            $result['labels'] = json_decode($result['labels'] ?: '[]', true);
+        $rows = is_array($rows) ? $rows : [];
+        foreach ($rows as &$row) {
+            $row['labels'] = json_decode($row['labels'] ?: '[]', true);
         }
 
-        return $results;
+        return $rows;
     }
 }
 

--- a/tests/integration/Services/MetricsIntegrationTest.php
+++ b/tests/integration/Services/MetricsIntegrationTest.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use SmartAlloc\Database\DbPort;
+use SmartAlloc\Services\Metrics;
+
+if (!function_exists('wp_json_encode')) {
+    function wp_json_encode($data) {
+        return json_encode($data);
+    }
+}
+
+final class MetricsIntegrationTest extends TestCase
+{
+    public function test_error_log_fallback_when_no_logger(): void
+    {
+        $db = new class implements DbPort {
+            public function exec(string $sql, mixed ...$args)
+            {
+                throw new RuntimeException('fail');
+            }
+            public function insert_id(): int { return 0; }
+        };
+
+        ini_set('error_log', 'php://output');
+        ob_start();
+        $metrics = new Metrics($db, 'salloc_metrics');
+        $metrics->inc('views');
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('Metrics::', (string) $output);
+    }
+}
+

--- a/tests/unit/Services/MetricsTest.php
+++ b/tests/unit/Services/MetricsTest.php
@@ -1,0 +1,122 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use Psr\Log\AbstractLogger;
+use SmartAlloc\Database\DbPort;
+use SmartAlloc\Services\Metrics;
+
+if (!function_exists('wp_json_encode')) {
+    function wp_json_encode($data) {
+        return json_encode($data);
+    }
+}
+
+final class MetricsTest extends TestCase
+{
+    public function test_constructor_injection_and_inc_uses_db_port(): void
+    {
+        $db = new class implements DbPort {
+            public string $sql = '';
+            public array $args = [];
+            public function exec(string $sql, mixed ...$args)
+            {
+                $this->sql  = $sql;
+                $this->args = $args;
+                return 1;
+            }
+            public function insert_id(): int { return 0; }
+        };
+
+        $logger = new class extends AbstractLogger {
+            /** @var array<int,array<string,mixed>> */
+            public array $records = [];
+            public function log($level, $message, array $context = []): void
+            {
+                $this->records[] = compact('level', 'message', 'context');
+            }
+        };
+
+        $metrics = new Metrics($db, 'salloc_metrics', $logger);
+        $metrics->inc('views');
+
+        $this->assertStringContainsString('salloc_metrics', $db->sql);
+        $this->assertEmpty($logger->records);
+    }
+
+    public function test_inc_logs_errors_and_continues(): void
+    {
+        $db = new class implements DbPort {
+            public function exec(string $sql, mixed ...$args)
+            {
+                throw new RuntimeException('fail');
+            }
+            public function insert_id(): int { return 0; }
+        };
+
+        $logger = new class extends AbstractLogger {
+            /** @var array<int,array<string,mixed>> */
+            public array $records = [];
+            public function log($level, $message, array $context = []): void
+            {
+                $this->records[] = compact('level', 'message', 'context');
+            }
+        };
+
+        $metrics = new Metrics($db, 'salloc_metrics', $logger);
+        $metrics->inc('views');
+
+        $this->assertSame('error', $logger->records[0]['level']);
+        $this->assertSame('Metrics database operation failed', $logger->records[0]['message']);
+    }
+
+    public function test_get_returns_safe_default_on_failure(): void
+    {
+        $db = new class implements DbPort {
+            public function exec(string $sql, mixed ...$args)
+            {
+                throw new RuntimeException('fail');
+            }
+            public function insert_id(): int { return 0; }
+        };
+
+        $logger = new class extends AbstractLogger {
+            /** @var array<int,array<string,mixed>> */
+            public array $records = [];
+            public function log($level, $message, array $context = []): void
+            {
+                $this->records[] = compact('level', 'message', 'context');
+            }
+        };
+
+        $metrics = new Metrics($db, 'salloc_metrics', $logger);
+        $result  = $metrics->get('views');
+
+        $this->assertSame([], $result);
+        $this->assertSame('error', $logger->records[0]['level']);
+    }
+
+    public function test_get_decodes_labels(): void
+    {
+        $db = new class implements DbPort {
+            public function exec(string $sql, mixed ...$args)
+            {
+                return [
+                    [
+                        'metric_key' => 'views',
+                        'labels'     => '{"foo":1}',
+                        'value'      => 2,
+                        'ts'         => '2024-01-01 00:00:00',
+                    ],
+                ];
+            }
+            public function insert_id(): int { return 0; }
+        };
+
+        $metrics = new Metrics($db, 'salloc_metrics');
+        $rows    = $metrics->get('views');
+
+        $this->assertSame(['foo' => 1], $rows[0]['labels']);
+    }
+}
+


### PR DESCRIPTION
## Summary
- refactor Metrics service to depend on injected DbPort and optional PSR-3 logger
- add structured error handling with safe defaults and error_log fallback
- cover Metrics service with unit and integration tests

## Testing
- `php baseline-check --current-phase=foundation`
- `php baseline-compare --feature=metrics-service`
- `php gap-analysis --target=metrics-service`
- `vendor/bin/phpcs src/Services/Metrics.php tests/unit/Services/MetricsTest.php tests/integration/Services/MetricsIntegrationTest.php`
- `vendor/bin/phpunit tests/unit/Services/MetricsTest.php tests/integration/Services/MetricsIntegrationTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68b9ac8a6d9883219fb1933b524d7bde