### PR TITLE
feat(notification): handle rate-limit dlq metrics

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -19,7 +19,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-04T18:27:27Z
+Last Updated (UTC): 2025-09-04T18:27:29Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -19,7 +19,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-04T18:27:29Z
+Last Updated (UTC): 2025-09-04T18:27:31Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -19,7 +19,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-04T15:24:18Z
+Last Updated (UTC): 2025-09-04T18:27:27Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-04T18:27:27Z",
+  "last_update_utc": "2025-09-04T18:27:29Z",
   "repo": {
     "default_branch": "codex/enhance-notificationservice-throttling",
-    "last_commit": "0cbc479686c7d5f6f2e2443b9286224aee75da92",
-    "commits_total": 940,
+    "last_commit": "8f156aaed83f2e2c396ac28f2c23aa11c9dfafb7",
+    "commits_total": 941,
     "files_tracked": 731
   },
   "quality_gate": {

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-04T15:24:18Z",
+  "last_update_utc": "2025-09-04T18:27:27Z",
   "repo": {
-    "default_branch": "main",
-    "last_commit": "bd9236089626e9eb3e4025c747fcdcbd99c4faa2",
-    "commits_total": 938,
+    "default_branch": "codex/enhance-notificationservice-throttling",
+    "last_commit": "0cbc479686c7d5f6f2e2443b9286224aee75da92",
+    "commits_total": 940,
     "files_tracked": 731
   },
   "quality_gate": {

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-04T18:27:29Z",
+  "last_update_utc": "2025-09-04T18:27:31Z",
   "repo": {
     "default_branch": "codex/enhance-notificationservice-throttling",
-    "last_commit": "8f156aaed83f2e2c396ac28f2c23aa11c9dfafb7",
-    "commits_total": 941,
+    "last_commit": "fd90afd23589149254c061cf1f6f4c297817e708",
+    "commits_total": 942,
     "files_tracked": 731
   },
   "quality_gate": {


### PR DESCRIPTION
## Summary
- track throttling metrics and send sanitized payloads to DLQ on global rate limit
- cover rate limit DLQ behaviour with unit and integration tests

## Testing
- `./vendor/bin/phpcs src/Services/NotificationService.php tests/Unit/Services/NotificationServiceTest.php tests/Integration/Services/NotificationServiceIntegrationTest.php`
- `./vendor/bin/phpunit --testsuite Unit --filter NotificationServiceTest`
- `./vendor/bin/phpunit --testsuite Integration --filter NotificationServiceIntegrationTest`
- `php baseline-check --current-phase=foundation`
- `php baseline-compare --feature=notification`
- `php gap-analysis --target=rate-limit`

------
https://chatgpt.com/codex/tasks/task_e_68b9af63ba84832187392b5cc797731c