### PR TITLE
feat(dlq): log replay failures with context

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -19,7 +19,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-05T04:53:56Z
+Last Updated (UTC): 2025-09-05T05:04:29Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -19,7 +19,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-05T05:04:29Z
+Last Updated (UTC): 2025-09-05T05:04:36Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-05T04:53:56Z",
+  "last_update_utc": "2025-09-05T05:04:29Z",
   "repo": {
-    "default_branch": "main",
-    "last_commit": "5b4ac16436578d2c3e8a67f7b6603be75cd9d656",
-    "commits_total": 960,
+    "default_branch": "codex/enhance-dlq-replay-error-logging",
+    "last_commit": "13ca0746d0288688d31859b5bc27d8cffcab71fd",
+    "commits_total": 962,
     "files_tracked": 733
   },
   "quality_gate": {

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-05T05:04:29Z",
+  "last_update_utc": "2025-09-05T05:04:36Z",
   "repo": {
     "default_branch": "codex/enhance-dlq-replay-error-logging",
-    "last_commit": "13ca0746d0288688d31859b5bc27d8cffcab71fd",
-    "commits_total": 962,
+    "last_commit": "5ceb003cdb67fc01c10acf37f7873fd95b21ac14",
+    "commits_total": 963,
     "files_tracked": 733
   },
   "quality_gate": {


### PR DESCRIPTION
## Summary
- log DLQ replay failures with detailed context and error_log fallback
- cover replay failure and success logging scenarios in DlqService tests

## Testing
- `vendor/bin/phpcs src/Services/DlqService.php tests/unit/Services/DlqServiceTest.php`
- `vendor/bin/phpunit tests/unit/Services/DlqServiceTest.php`
- `vendor/bin/phpunit --filter=testReplayLogsErrorWithStructuredLogger tests/unit/Services/DlqServiceTest.php`
- `vendor/bin/phpunit --filter=testReplayUsesErrorLogFallback tests/unit/Services/DlqServiceTest.php`
- `vendor/bin/phpunit --filter=testSuccessfulReplayDoesNotLogError tests/unit/Services/DlqServiceTest.php`
- `php baseline-check --current-phase=foundation`
- `php baseline-compare --feature=dlq-replay-error-logging`
- `php gap-analysis --target=dlq-replay-error-logging`


------
https://chatgpt.com/codex/tasks/task_e_68ba6d7d7f148321b0c678a722bd34e8