### PR TITLE
feat(services): add CircuitBreakerStatus class

### DIFF
--- a/src/Services/CircuitBreakerStatus.php
+++ b/src/Services/CircuitBreakerStatus.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SmartAlloc\Services;
+
+final class CircuitBreakerStatus
+{
+    private const ALLOWED_STATES = ['open', 'closed', 'half-open'];
+
+    public readonly string $state;
+    public readonly int $failCount;
+    public readonly int $threshold;
+    public readonly ?int $cooldownUntil;
+    public readonly ?string $lastError;
+
+    public function __construct(
+        string $state,
+        int $failCount,
+        int $threshold,
+        ?int $cooldownUntil = null,
+        ?string $lastError = null
+    ) {
+        if (!in_array($state, self::ALLOWED_STATES, true)) {
+            throw new \InvalidArgumentException(sprintf('Invalid state: %s', $state)); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
+        }
+
+        $this->state = $state;
+        $this->failCount = $failCount;
+        $this->threshold = $threshold;
+        $this->cooldownUntil = $cooldownUntil;
+        $this->lastError = $lastError !== null ? substr($lastError, 0, 100) : null;
+    }
+
+    public function isOpen(): bool
+    {
+        return $this->state === 'open';
+    }
+
+    public function isClosed(): bool
+    {
+        return $this->state === 'closed';
+    }
+
+    public function isHalfOpen(): bool
+    {
+        return $this->state === 'half-open';
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'state' => $this->state,
+            'fail_count' => $this->failCount,
+            'threshold' => $this->threshold,
+            'cooldown_until' => $this->cooldownUntil,
+            'last_error' => $this->lastError,
+        ];
+    }
+}

--- a/tests/Unit/CircuitBreakerStatusTest.php
+++ b/tests/Unit/CircuitBreakerStatusTest.php
@@ -1,0 +1,45 @@
+<?php
+// phpcs:ignoreFile
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use SmartAlloc\Services\CircuitBreakerStatus;
+
+final class CircuitBreakerStatusTest extends TestCase
+{
+    public function testValidState(): void
+    {
+        $status = new CircuitBreakerStatus('open', 0, 3);
+        $this->assertSame('open', $status->state);
+    }
+
+    public function testInvalidState(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        new CircuitBreakerStatus('invalid', 0, 3);
+    }
+
+    public function testLastErrorSanitization(): void
+    {
+        $longError = str_repeat('A', 150);
+        $status = new CircuitBreakerStatus('closed', 1, 3, null, $longError);
+        $this->assertSame(100, strlen($status->lastError));
+    }
+
+    public function testHelperMethods(): void
+    {
+        $open = new CircuitBreakerStatus('open', 0, 3);
+        $closed = new CircuitBreakerStatus('closed', 0, 3);
+        $half = new CircuitBreakerStatus('half-open', 0, 3);
+
+        $this->assertTrue($open->isOpen());
+        $this->assertFalse($open->isClosed());
+
+        $this->assertTrue($closed->isClosed());
+        $this->assertFalse($closed->isOpen());
+
+        $this->assertTrue($half->isHalfOpen());
+        $this->assertFalse($half->isClosed());
+    }
+}


### PR DESCRIPTION
## Summary
- add CircuitBreakerStatus value object with validation and helpers
- cover CircuitBreakerStatus with unit tests

## Testing
- `php baseline-check --current-phase=foundation`
- `php baseline-compare --feature=CircuitBreakerStatus`
- `php gap-analysis --target=CircuitBreakerStatus`
- `vendor/bin/phpcs src/Services/CircuitBreakerStatus.php tests/Unit/CircuitBreakerStatusTest.php`
- `vendor/bin/phpunit tests/Unit/CircuitBreakerStatusTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68ba987564d48321904716815d0531d9