### PR TITLE
fix(circuit-breaker): restore legacy API

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -23,7 +23,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-05T08:34:18Z
+Last Updated (UTC): 2025-09-05T08:34:20Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -23,7 +23,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-05T08:34:16Z
+Last Updated (UTC): 2025-09-05T08:34:18Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -23,7 +23,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-05T08:26:07Z
+Last Updated (UTC): 2025-09-05T08:34:16Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-05T08:34:16Z",
+  "last_update_utc": "2025-09-05T08:34:18Z",
   "repo": {
     "default_branch": "codex/fix-comments-in-circuitbreaker.php",
-    "last_commit": "6190962895caacfa6761b94227e637b614f9041d",
-    "commits_total": 994,
+    "last_commit": "2fe1e1675339a1053b550b507c3a8a50edf387ea",
+    "commits_total": 995,
     "files_tracked": 741
   },
   "quality_gate": {

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-05T08:26:07Z",
+  "last_update_utc": "2025-09-05T08:34:16Z",
   "repo": {
-    "default_branch": "main",
-    "last_commit": "b8acc2ee558adfaa5d62fba2c59e805546b34789",
-    "commits_total": 992,
+    "default_branch": "codex/fix-comments-in-circuitbreaker.php",
+    "last_commit": "6190962895caacfa6761b94227e637b614f9041d",
+    "commits_total": 994,
     "files_tracked": 741
   },
   "quality_gate": {

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-05T08:34:18Z",
+  "last_update_utc": "2025-09-05T08:34:20Z",
   "repo": {
     "default_branch": "codex/fix-comments-in-circuitbreaker.php",
-    "last_commit": "2fe1e1675339a1053b550b507c3a8a50edf387ea",
-    "commits_total": 995,
+    "last_commit": "1cdf0aefe1cdecab7dcbadb44898b3afe1f5d355",
+    "commits_total": 996,
     "files_tracked": 741
   },
   "quality_gate": {

--- a/tests/Unit/Services/CircuitBreakerTest.php
+++ b/tests/Unit/Services/CircuitBreakerTest.php
@@ -55,5 +55,27 @@ namespace SmartAlloc\Tests\Unit\Services {
             $this->assertSame('closed', $status->state);
             $this->assertSame(0, $status->failCount);
         }
+
+        public function testLegacyApiDelegatesToNewMethods(): void
+        {
+            $cb = new CircuitBreaker('test');
+
+            for ($i = 0; $i < 10; $i++) {
+                $cb->failure('test', new \Exception('fail'));
+            }
+
+            try {
+                $cb->guard('test');
+                $this->fail('Expected exception not thrown');
+            } catch (\RuntimeException $e) {
+                $this->assertStringContainsString('Circuit breaker open', $e->getMessage());
+            }
+
+            $cb->success('test');
+
+            $status = $cb->getStatus();
+            $this->assertSame('closed', $status->state);
+            $this->assertSame(0, $status->failCount);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- restore legacy guard/success/failure wrappers around new circuit breaker logic
- add unit test covering legacy API delegation

## Testing
- `php baseline-check --current-phase=foundation`
- `php baseline-compare --feature=circuit-breaker`
- `php gap-analysis --target=foundation`
- `vendor/bin/phpcs src/Services/CircuitBreaker.php tests/Unit/Services/CircuitBreakerTest.php`
- `vendor/bin/phpunit tests/Unit/Services/CircuitBreakerTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68ba9eb396708321a6c426231557e8c2