### PR TITLE
feat(circuit-breaker): add auto-recovery and custom exception

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -23,7 +23,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-05T08:50:52Z
+Last Updated (UTC): 2025-09-05T08:50:56Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -23,7 +23,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-05T08:35:29Z
+Last Updated (UTC): 2025-09-05T08:50:52Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-05T08:50:53Z",
+  "last_update_utc": "2025-09-05T08:50:56Z",
   "repo": {
     "default_branch": "codex/enhance-getstatus-with-auto-recovery",
-    "last_commit": "e322b65905d75a0f212060b84c91243f97668003",
-    "commits_total": 1000,
+    "last_commit": "8fec58ef2170e27152449088f8d113f9ed207cb4",
+    "commits_total": 1001,
     "files_tracked": 743
   },
   "quality_gate": {

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,10 +1,10 @@
 {
-  "last_update_utc": "2025-09-05T08:35:30Z",
+  "last_update_utc": "2025-09-05T08:50:53Z",
   "repo": {
-    "default_branch": "main",
-    "last_commit": "3ca9415b581d524f263d1e294742b26706cc5fae",
-    "commits_total": 998,
-    "files_tracked": 741
+    "default_branch": "codex/enhance-getstatus-with-auto-recovery",
+    "last_commit": "e322b65905d75a0f212060b84c91243f97668003",
+    "commits_total": 1000,
+    "files_tracked": 743
   },
   "quality_gate": {
     "weighted_threshold": 0.85,

--- a/src/Services/Exceptions/CircuitOpenException.php
+++ b/src/Services/Exceptions/CircuitOpenException.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SmartAlloc\Services\Exceptions;
+
+final class CircuitOpenException extends \RuntimeException
+{
+    private string $circuitKey;
+    private int $failureCount;
+    private int $cooldownUntil;
+
+    public function __construct(
+        string $circuitKey,
+        int $failureCount,
+        int $cooldownUntil,
+        string $message = 'Circuit breaker is open'
+    ) {
+        parent::__construct($message);
+        $this->circuitKey = $circuitKey;
+        $this->failureCount = $failureCount;
+        $this->cooldownUntil = $cooldownUntil;
+    }
+
+    public function getCircuitKey(): string
+    {
+        return $this->circuitKey;
+    }
+
+    public function getFailureCount(): int
+    {
+        return $this->failureCount;
+    }
+
+    public function getCooldownUntil(): int
+    {
+        return $this->cooldownUntil;
+    }
+}

--- a/tests/Unit/Services/CircuitBreakerEnhancedTest.php
+++ b/tests/Unit/Services/CircuitBreakerEnhancedTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SmartAlloc\Services {
+    function apply_filters($hook, $value, ...$args) {
+        return $value;
+    }
+    function get_transient($key) {
+        return $GLOBALS['t'][$key] ?? false;
+    }
+    function set_transient($key, $value, $ttl) {
+        $GLOBALS['t'][$key] = $value;
+        return true;
+    }
+    function wp_date($format) {
+        return time();
+    }
+}
+
+namespace SmartAlloc\Tests\Unit\Services {
+    use PHPUnit\Framework\TestCase;
+    use SmartAlloc\Services\CircuitBreaker;
+    use SmartAlloc\Services\Exceptions\CircuitOpenException;
+    use function SmartAlloc\Services\set_transient;
+
+    final class CircuitBreakerEnhancedTest extends TestCase
+    {
+        protected function setUp(): void
+        {
+            parent::setUp();
+            $GLOBALS['t'] = [];
+        }
+
+        public function testAutoRecoveryFromExpiredCooldown(): void
+        {
+            $cb = new CircuitBreaker('test');
+            $expiredTime = time() - 100;
+            set_transient('smartalloc_circuit_breaker_test', [
+                'state' => 'open',
+                'fail_count' => 5,
+                'cooldown_until' => $expiredTime,
+                'last_error' => 'Previous error',
+            ], 3600);
+
+            $status = $cb->getStatus();
+
+            $this->assertSame('half-open', $status->state);
+            $this->assertSame(0, $status->failCount);
+            $this->assertNull($status->cooldownUntil);
+        }
+
+        public function testErrorMessageSanitization(): void
+        {
+            $cb = new CircuitBreaker('test');
+            $longError = str_repeat('A', 150);
+            set_transient('smartalloc_circuit_breaker_test', [
+                'state' => 'closed',
+                'fail_count' => 1,
+                'cooldown_until' => null,
+                'last_error' => $longError,
+            ], 3600);
+
+            $status = $cb->getStatus();
+
+            $this->assertSame(100, strlen($status->lastError));
+            $this->assertSame(str_repeat('A', 100), $status->lastError);
+        }
+
+        public function testCircuitOpenExceptionThrown(): void
+        {
+            $cb = new CircuitBreaker('test');
+
+            $this->expectException(CircuitOpenException::class);
+            $this->expectExceptionMessage('Circuit breaker opened due to failure threshold exceeded');
+
+            for ($i = 0; $i < 5; $i++) {
+                $cb->recordFailure('Test error');
+            }
+        }
+
+        public function testTransientInitialization(): void
+        {
+            unset($GLOBALS['t']['smartalloc_circuit_breaker_test']);
+            $cb = new CircuitBreaker('test');
+
+            $status = $cb->getStatus();
+
+            $this->assertSame('closed', $status->state);
+            $this->assertSame(0, $status->failCount);
+            $this->assertNull($status->cooldownUntil);
+            $this->assertNull($status->lastError);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add CircuitOpenException to carry circuit metadata
- enhance CircuitBreaker with auto-recovery, message sanitization and exception
- add unit tests for CircuitBreaker auto-recovery and exception handling

## Testing
- `php baseline-check --current-phase=foundation`
- `php baseline-compare --feature="circuit-breaker"`
- `php gap-analysis --target="circuit-breaker"`
- `composer test` *(fails: Cannot redeclare class SmartAlloc\Tests\Unit\Services\SpyMetrics)*
- `vendor/bin/phpunit tests/Unit/Services/CircuitBreakerEnhancedTest.php`
- `vendor/bin/phpcs src/Services/CircuitBreaker.php src/Services/Exceptions/CircuitOpenException.php tests/Unit/Services/CircuitBreakerEnhancedTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68baa16454348321a19781bd0743e4be