### PR TITLE
feat(health): add circuit breaker health reporter

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -23,7 +23,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-05T08:52:10Z
+Last Updated (UTC): 2025-09-05T09:04:00Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -23,7 +23,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-05T09:04:00Z
+Last Updated (UTC): 2025-09-05T09:04:06Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,10 +1,10 @@
 {
-  "last_update_utc": "2025-09-05T08:52:11Z",
+  "last_update_utc": "2025-09-05T09:04:00Z",
   "repo": {
-    "default_branch": "main",
-    "last_commit": "039c990b691e8f2b6939f9db7172c82da2b67895",
-    "commits_total": 1003,
-    "files_tracked": 743
+    "default_branch": "codex/create-healthreporter-class-with-ajax-support",
+    "last_commit": "d9159290658f91592f4b93c5239cc96f041eaf09",
+    "commits_total": 1005,
+    "files_tracked": 745
   },
   "quality_gate": {
     "weighted_threshold": 0.85,

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-05T09:04:00Z",
+  "last_update_utc": "2025-09-05T09:04:07Z",
   "repo": {
     "default_branch": "codex/create-healthreporter-class-with-ajax-support",
-    "last_commit": "d9159290658f91592f4b93c5239cc96f041eaf09",
-    "commits_total": 1005,
+    "last_commit": "f21987c10cd826d6e20be91bc30ba44d3517a2fe",
+    "commits_total": 1006,
     "files_tracked": 745
   },
   "quality_gate": {

--- a/smart-alloc.php
+++ b/smart-alloc.php
@@ -221,3 +221,7 @@ add_action('wp_ajax_smartalloc_manual_candidates', ['SmartAlloc\\Admin\\Actions\
 (new \SmartAlloc\Admin\OverrideUIController())->boot();
 
 add_action('gform_after_submission_150', [\SmartAlloc\Infra\GF\SabtSubmissionHandler::class, 'handle'], 10, 2);
+
+add_action('init', function () {
+    (new \SmartAlloc\Health\HealthReporter())->register_hooks();
+});

--- a/src/Health/HealthReporter.php
+++ b/src/Health/HealthReporter.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SmartAlloc\Health;
+
+use SmartAlloc\Services\CircuitBreaker;
+use SmartAlloc\Services\CircuitBreakerStatus;
+
+/**
+ * Reports circuit breaker health via AJAX endpoints.
+ */
+final class HealthReporter
+{
+    private const NONCE_ACTION = 'smartalloc_health_check';
+    private const AJAX_ACTION  = 'smartalloc_health';
+
+    public function register_hooks(): void
+    {
+        add_action('wp_ajax_' . self::AJAX_ACTION, [$this, 'ajax_health_check']);
+        add_action('wp_ajax_nopriv_' . self::AJAX_ACTION, [$this, 'ajax_health_check']);
+    }
+
+    public function ajax_health_check(): void
+    {
+        $nonce = sanitize_key($_POST['nonce'] ?? '');
+        if (!wp_verify_nonce($nonce, self::NONCE_ACTION)) {
+            wp_send_json_error(
+                [
+                    'message'   => 'Invalid security token',
+                    'timestamp' => gmdate('c'),
+                ],
+                403
+            );
+            return;
+        }
+
+        $circuit_key = sanitize_text_field($_POST['circuit_key'] ?? 'default');
+        $health_data = $this->get_circuit_breaker_health($circuit_key);
+
+        wp_send_json_success($health_data);
+    }
+
+    /**
+     * Retrieve health information for a circuit breaker.
+     *
+     * @param string $circuit_key Circuit identifier.
+     *
+     * @return array<string,mixed>
+     */
+    public function get_circuit_breaker_health(string $circuit_key = 'default'): array
+    {
+        try {
+            $circuit_breaker = new CircuitBreaker($circuit_key);
+            $status          = $circuit_breaker->getStatus();
+
+            return [
+                'component'   => 'circuit_breaker',
+                'circuit_key' => $circuit_key,
+                'status'      => $this->determine_health_status($status),
+                'details'     => $this->format_status_details($status),
+                'timestamp'   => gmdate('c'),
+            ];
+        } catch (\Throwable $e) {
+            return [
+                'component'   => 'circuit_breaker',
+                'circuit_key' => $circuit_key,
+                'status'      => 'degraded',
+                'details'     => [
+                    'error'   => 'Health check failed',
+                    'message' => substr($e->getMessage(), 0, 100),
+                ],
+                'timestamp'   => gmdate('c'),
+            ];
+        }
+    }
+
+    private function determine_health_status(CircuitBreakerStatus $status): string
+    {
+        if ($status->isOpen()) {
+            return 'degraded';
+        }
+
+        if ($status->isHalfOpen()) {
+            return 'degraded';
+        }
+
+        if ($status->failCount >= ($status->threshold * 0.8)) {
+            return 'degraded';
+        }
+
+        return 'healthy';
+    }
+
+    /**
+     * Format details section of health response.
+     *
+     * @return array<string,mixed>
+     */
+    private function format_status_details(CircuitBreakerStatus $status): array
+    {
+        $details = [
+            'state'        => $status->state,
+            'fail_count'   => $status->failCount,
+            'threshold'    => $status->threshold,
+            'failure_rate' => $status->threshold > 0 ? round(($status->failCount / $status->threshold) * 100, 2) : 0,
+        ];
+
+        if ($status->cooldownUntil !== null) {
+            $details['cooldown_until']    = gmdate('c', $status->cooldownUntil);
+            $details['cooldown_remaining'] = max(0, $status->cooldownUntil - (int) wp_date('U'));
+        }
+
+        if ($status->lastError !== null) {
+            $details['last_error'] = $status->lastError;
+        }
+
+        return $details;
+    }
+
+    public static function get_nonce(): string
+    {
+        return wp_create_nonce(self::NONCE_ACTION);
+    }
+
+    public static function get_ajax_url(): string
+    {
+        return admin_url('admin-ajax.php');
+    }
+}

--- a/tests/Unit/Health/HealthReporterTest.php
+++ b/tests/Unit/Health/HealthReporterTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SmartAlloc\Tests\Unit\Health;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use SmartAlloc\Health\HealthReporter;
+use SmartAlloc\Tests\BaseTestCase;
+
+final class HealthReporterTest extends BaseTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Monkey\setUp();
+        $GLOBALS['t'] = [];
+
+        Functions\when('SmartAlloc\\Health\\wp_create_nonce')->alias(fn(string $action): string => 'nonce');
+        Functions\when('SmartAlloc\\Health\\admin_url')->alias(fn(string $path = ''): string => 'https://example.com/' . ltrim($path, '/'));
+        Functions\when('SmartAlloc\\Services\\apply_filters')->alias(fn(string $hook, $value, ...$args) => $value);
+        Functions\when('SmartAlloc\\Services\\get_transient')->alias(fn(string $key) => $GLOBALS['t'][$key] ?? false);
+        Functions\when('SmartAlloc\\Services\\set_transient')->alias(function (string $key, $value, int $ttl): bool { $GLOBALS['t'][$key] = $value; return true; });
+        Functions\when('SmartAlloc\\Services\\wp_date')->alias(fn($format) => time());
+    }
+
+    protected function tearDown(): void
+    {
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    public function testHealthyStatusForClosedCircuit(): void
+    {
+        $reporter = new HealthReporter();
+        $health   = $reporter->get_circuit_breaker_health('test');
+
+        $this->assertEquals('circuit_breaker', $health['component']);
+        $this->assertEquals('healthy', $health['status']);
+        $this->assertArrayHasKey('details', $health);
+        $this->assertArrayHasKey('timestamp', $health);
+    }
+
+    public function testResponseFormatValidation(): void
+    {
+        $reporter = new HealthReporter();
+        $health   = $reporter->get_circuit_breaker_health('test');
+
+        $this->assertArrayHasKey('component', $health);
+        $this->assertArrayHasKey('status', $health);
+        $this->assertArrayHasKey('details', $health);
+        $this->assertArrayHasKey('timestamp', $health);
+        $this->assertMatchesRegularExpression('/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}$/', $health['timestamp']);
+    }
+
+    public function testStaticHelperMethods(): void
+    {
+        $nonce    = HealthReporter::get_nonce();
+        $ajax_url = HealthReporter::get_ajax_url();
+
+        $this->assertIsString($nonce);
+        $this->assertStringContainsString('admin-ajax.php', $ajax_url);
+    }
+}


### PR DESCRIPTION
## Summary
- add `HealthReporter` for circuit breaker status via secure AJAX
- register health reporter hooks on init
- cover health reporter with unit tests

## Testing
- `vendor/bin/phpcs --standard=phpcs.xml src/Health/HealthReporter.php tests/Unit/Health/HealthReporterTest.php`
- `vendor/bin/phpunit tests/Unit/Health/HealthReporterTest.php`
- `./baseline-check --current-phase=foundation`
- `./baseline-compare --feature=HealthReporter`
- `./gap-analysis --target=HealthReporter`


------
https://chatgpt.com/codex/tasks/task_e_68baa54133948321a756d151b234b6d8