### PR TITLE
refactor(circuit-breaker): apply PSR-12 formatting (PHPCS=0)

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -23,7 +23,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-05T09:46:49Z
+Last Updated (UTC): 2025-09-05T09:46:54Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -23,7 +23,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-05T09:46:54Z
+Last Updated (UTC): 2025-09-05T09:46:56Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -23,7 +23,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-05T09:28:51Z
+Last Updated (UTC): 2025-09-05T09:46:49Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-05T09:46:49Z",
+  "last_update_utc": "2025-09-05T09:46:54Z",
   "repo": {
     "default_branch": "codex/prepare-psr-12-specification-for-circuitbreaker",
-    "last_commit": "88f85787502c97a312c8ff5ba8f9210f6909fb95",
-    "commits_total": 1020,
+    "last_commit": "18104b69d2962136fae5cc209c76f6997a39134f",
+    "commits_total": 1021,
     "files_tracked": 747
   },
   "quality_gate": {

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-05T09:46:54Z",
+  "last_update_utc": "2025-09-05T09:46:56Z",
   "repo": {
     "default_branch": "codex/prepare-psr-12-specification-for-circuitbreaker",
-    "last_commit": "18104b69d2962136fae5cc209c76f6997a39134f",
-    "commits_total": 1021,
+    "last_commit": "1ff97e145dd278dce23285766bb98a337acb3730",
+    "commits_total": 1022,
     "files_tracked": 747
   },
   "quality_gate": {

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-05T09:28:52Z",
+  "last_update_utc": "2025-09-05T09:46:49Z",
   "repo": {
-    "default_branch": "main",
-    "last_commit": "07e8d6168f498b002151fa5d933fe6c75124b1b5",
-    "commits_total": 1018,
+    "default_branch": "codex/prepare-psr-12-specification-for-circuitbreaker",
+    "last_commit": "88f85787502c97a312c8ff5ba8f9210f6909fb95",
+    "commits_total": 1020,
     "files_tracked": 747
   },
   "quality_gate": {

--- a/src/Services/CircuitBreaker.php
+++ b/src/Services/CircuitBreaker.php
@@ -6,23 +6,67 @@ namespace SmartAlloc\Services;
 
 use SmartAlloc\Services\Exceptions\CircuitOpenException;
 
+/**
+ * Circuit Breaker implementation with transient-based state storage.
+ *
+ * Provides fault tolerance by monitoring failure rates and temporarily
+ * blocking operations when thresholds are exceeded.
+ */
 final class CircuitBreaker
 {
+    /**
+     * Default failure threshold before circuit opens.
+     */
     private const DEFAULT_THRESHOLD = 5;
-    private const DEFAULT_COOLDOWN = 300; // 5 minutes
+
+    /**
+     * Default cooldown period in seconds (5 minutes).
+     */
+    private const DEFAULT_COOLDOWN = 300;
+
+    /**
+     * Base transient key for circuit breaker state.
+     */
     private const TRANSIENT_KEY = 'smartalloc_circuit_breaker';
 
+    /**
+     * Failure threshold for this circuit.
+     */
     private int $threshold;
+
+    /**
+     * Cooldown period in seconds.
+     */
     private int $cooldown;
+
+    /**
+     * Unique transient key for this circuit instance.
+     */
     private string $transientKey;
 
+    /**
+     * Initialize circuit breaker with configurable parameters.
+     */
     public function __construct(string $key = 'default')
     {
-        $this->threshold = (int) apply_filters('smartalloc_cb_threshold', self::DEFAULT_THRESHOLD, $key);
-        $this->cooldown = (int) apply_filters('smartalloc_cb_cooldown', self::DEFAULT_COOLDOWN, $key);
+        $this->threshold = (int) apply_filters(
+            'smartalloc_cb_threshold',
+            self::DEFAULT_THRESHOLD,
+            $key
+        );
+
+        $this->cooldown = (int) apply_filters(
+            'smartalloc_cb_cooldown',
+            self::DEFAULT_COOLDOWN,
+            $key
+        );
+
         $this->transientKey = self::TRANSIENT_KEY . '_' . $key;
     }
 
+    /**
+     * Get current circuit breaker status with auto-recovery.
+     */
     public function getStatus(): CircuitBreakerStatus
     {
         $data = $this->retrieveOrInitializeTransient();
@@ -38,57 +82,89 @@ final class CircuitBreaker
         );
     }
 
+    /**
+     * Record a failure and update circuit state.
+     *
+     * @throws CircuitOpenException When failure threshold is exceeded.
+     */
     public function recordFailure(string $error): void
     {
         $status = $this->getStatus();
         $newFailCount = $status->failCount + 1;
 
         $newState = $newFailCount >= $this->threshold ? 'open' : 'closed';
-        $cooldownUntil = $newState === 'open' ? wp_date('U') + $this->cooldown : null;
+        $cooldownUntil = $newState === 'open'
+            ? wp_date('U') + $this->cooldown
+            : null;
 
-        $this->saveState($newState, $newFailCount, $cooldownUntil, $error);
+        $this->saveState(
+            $newState,
+            $newFailCount,
+            $cooldownUntil,
+            $error
+        );
 
         if ($newState === 'open') {
-            // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
             throw new CircuitOpenException(
-                $this->transientKey, // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
-                $newFailCount, // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
+                $this->transientKey,
+                $newFailCount,
                 (int) $cooldownUntil,
                 'Circuit breaker opened due to failure threshold exceeded'
             );
         }
     }
 
+    /**
+     * Record a successful operation and reset circuit state.
+     */
     public function recordSuccess(): void
     {
         $this->saveState('closed', 0, null, null);
     }
 
+    /**
+     * Guard against circuit breaker open state.
+     *
+     * @throws \RuntimeException When circuit is open.
+     */
     public function guard(string $context): void
     {
         $status = $this->getStatus();
 
         if (
             $status->state === 'open' &&
-            ($status->cooldownUntil === null || $status->cooldownUntil > (int) wp_date('U'))
+            (
+                $status->cooldownUntil === null ||
+                $status->cooldownUntil > (int) wp_date('U')
+            )
         ) {
-            // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
-            throw new \RuntimeException('Circuit breaker open for ' . $context);
+            throw new \RuntimeException(
+                'Circuit breaker open for ' . $context
+            );
         }
     }
 
+    /**
+     * Handle successful operation completion.
+     */
     public function success(string $context): void
     {
         unset($context);
         $this->recordSuccess();
     }
 
+    /**
+     * Handle operation failure.
+     */
     public function failure(string $context, \Throwable $exception): void
     {
         unset($context);
         $this->recordFailure($exception->getMessage());
     }
 
+    /**
+     * Save circuit breaker state to transient storage.
+     */
     private function saveState(
         string $state,
         int $failCount,
@@ -102,9 +178,16 @@ final class CircuitBreaker
             'last_error' => $lastError,
         ];
 
-        set_transient($this->transientKey, $data, $this->cooldown + 60);
+        set_transient(
+            $this->transientKey,
+            $data,
+            $this->cooldown + 60
+        );
     }
 
+    /**
+     * Retrieve existing transient data or initialize default state.
+     */
     private function retrieveOrInitializeTransient(): array
     {
         $data = get_transient($this->transientKey);
@@ -121,6 +204,9 @@ final class CircuitBreaker
         return $data;
     }
 
+    /**
+     * Auto-recover circuit from open to half-open if cooldown expired.
+     */
     private function autoRecoverIfExpired(array $data): array
     {
         if (
@@ -143,6 +229,9 @@ final class CircuitBreaker
         return $data;
     }
 
+    /**
+     * Sanitize and truncate error message to prevent storage bloat.
+     */
     private function sanitizeErrorMessage(array $data): array
     {
         if ($data['last_error'] !== null) {

--- a/src/Services/CircuitBreakerStatus.php
+++ b/src/Services/CircuitBreakerStatus.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace SmartAlloc\Services;
 
+/**
+ * Data transfer object representing circuit breaker status.
+ */
 final class CircuitBreakerStatus
 {
     private const ALLOWED_STATES = ['open', 'closed', 'half-open'];
@@ -14,6 +17,9 @@ final class CircuitBreakerStatus
     public readonly ?int $cooldownUntil;
     public readonly ?string $lastError;
 
+    /**
+     * @throws \InvalidArgumentException When state is invalid.
+     */
     public function __construct(
         string $state,
         int $failCount,
@@ -22,7 +28,7 @@ final class CircuitBreakerStatus
         ?string $lastError = null
     ) {
         if (!in_array($state, self::ALLOWED_STATES, true)) {
-            throw new \InvalidArgumentException(sprintf('Invalid state: %s', $state)); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
+            throw new \InvalidArgumentException(sprintf('Invalid state: %s', $state));
         }
 
         $this->state = $state;

--- a/src/Services/Exceptions/CircuitOpenException.php
+++ b/src/Services/Exceptions/CircuitOpenException.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace SmartAlloc\Services\Exceptions;
 
+/**
+ * Exception thrown when a circuit breaker is open.
+ */
 final class CircuitOpenException extends \RuntimeException
 {
     private string $circuitKey;


### PR DESCRIPTION
## Summary
- format CircuitBreaker classes to PSR-12 with explicit docblocks

## Testing
- `vendor/bin/phpcs --standard=PSR12 -v src/Services/CircuitBreaker.php src/Services/CircuitBreakerStatus.php src/Services/Exceptions/CircuitOpenException.php`
- `vendor/bin/phpcs --standard=WordPress -v src/Services/CircuitBreaker.php src/Services/CircuitBreakerStatus.php src/Services/Exceptions/CircuitOpenException.php` *(fails: Tabs must be used to indent lines)*
- `vendor/bin/phpstan analyse src/Services/CircuitBreaker.php src/Services/CircuitBreakerStatus.php src/Services/Exceptions/CircuitOpenException.php --level=8` *(fails: Function wp_date not found, etc.)*
- `vendor/bin/phpunit tests/Services/CircuitBreakerTest.php` *(fails: Undefined constant "WP_TESTS_DOMAIN")*
- `php baseline-check --current-phase=foundation`
- `php baseline-compare --feature=circuit-breaker`
- `php gap-analysis --target=psr12-formatting`


------
https://chatgpt.com/codex/tasks/task_e_68baae90b2908321b195a9aa83f9d99e