### PR TITLE
feat(circuit-breaker): use wp_date for utc timestamps

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -23,7 +23,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-05T09:59:22Z
+Last Updated (UTC): 2025-09-05T09:59:24Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -23,7 +23,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-05T09:48:07Z
+Last Updated (UTC): 2025-09-05T09:59:22Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -23,7 +23,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-05T09:59:24Z
+Last Updated (UTC): 2025-09-05T09:59:26Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-05T09:59:24Z",
+  "last_update_utc": "2025-09-05T09:59:26Z",
   "repo": {
     "default_branch": "codex/replace-time-with-wp_date-for-utc-consistency",
-    "last_commit": "b0e4851efdba682e7ff02b6b6051a30d3f081870",
-    "commits_total": 1027,
+    "last_commit": "85a244ade6938ac13611e6f0ad7c934c09ade26f",
+    "commits_total": 1028,
     "files_tracked": 747
   },
   "quality_gate": {

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-05T09:48:08Z",
+  "last_update_utc": "2025-09-05T09:59:22Z",
   "repo": {
-    "default_branch": "main",
-    "last_commit": "cd82077bd853b7d93f84e7759eb67610f96fbe63",
-    "commits_total": 1024,
+    "default_branch": "codex/replace-time-with-wp_date-for-utc-consistency",
+    "last_commit": "c825b0d2ef2751faa584256fdcb4596e49a1b6da",
+    "commits_total": 1026,
     "files_tracked": 747
   },
   "quality_gate": {

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-05T09:59:22Z",
+  "last_update_utc": "2025-09-05T09:59:24Z",
   "repo": {
     "default_branch": "codex/replace-time-with-wp_date-for-utc-consistency",
-    "last_commit": "c825b0d2ef2751faa584256fdcb4596e49a1b6da",
-    "commits_total": 1026,
+    "last_commit": "b0e4851efdba682e7ff02b6b6051a30d3f081870",
+    "commits_total": 1027,
     "files_tracked": 747
   },
   "quality_gate": {


### PR DESCRIPTION
## Summary
- ensure CircuitBreaker uses wp_date('U') with time() fallback
- add timezone-aware tests for UTC consistency

## Testing
- `./vendor/bin/phpcs src/Services/CircuitBreaker.php tests/Services/CircuitBreakerTest.php`
- `./vendor/bin/phpunit tests/Services/CircuitBreakerTest.php` *(fails: Undefined constant "WP_TESTS_DOMAIN")*

------
https://chatgpt.com/codex/tasks/task_e_68bab29c46648321ac8decfdc75c02df