### PR TITLE
feat(circuit-breaker): sanitize failure messages

### DIFF
--- a/src/Services/CircuitBreaker.php
+++ b/src/Services/CircuitBreaker.php
@@ -166,7 +166,8 @@ final class CircuitBreaker
     public function failure(string $context, \Throwable $exception): void
     {
         unset($context);
-        $this->recordFailure($exception->getMessage());
+        $sanitized_message = $this->sanitizeMessage($exception->getMessage());
+        $this->recordFailure($sanitized_message);
     }
 
     /**
@@ -234,6 +235,14 @@ final class CircuitBreaker
         }
 
         return $data;
+    }
+
+    /**
+     * Sanitize and truncate message to prevent storage bloat.
+     */
+    private function sanitizeMessage(string $message): string
+    {
+        return substr($message, 0, 100);
     }
 
     /**


### PR DESCRIPTION
## Summary
- sanitize exception messages in `failure()` and truncate to 100 chars
- add regression tests for long, short, empty, and consistency scenarios

## Testing
- `./baseline-check --current-phase=foundation`
- `./baseline-compare --feature="Sanitize exception messages"`
- `./gap-analysis --target="Sanitize exception messages"`
- `./vendor/bin/phpcs src/Services/CircuitBreaker.php tests/Services/CircuitBreakerTest.php`
- `./vendor/bin/phpunit --filter test_failure_method_sanitizes_exception_messages tests/Services/CircuitBreakerTest.php` *(fails: Undefined constant "WP_TESTS_DOMAIN")*
- `./vendor/bin/phpunit --filter test_failure_method_preserves_short_messages tests/Services/CircuitBreakerTest.php` *(fails: Undefined constant "WP_TESTS_DOMAIN")*
- `./vendor/bin/phpunit --filter test_failure_method_handles_empty_messages tests/Services/CircuitBreakerTest.php` *(fails: Undefined constant "WP_TESTS_DOMAIN")*
- `./vendor/bin/phpunit --filter test_failure_and_record_failure_sanitization_consistency tests/Services/CircuitBreakerTest.php` *(fails: Undefined constant "WP_TESTS_DOMAIN")*


------
https://chatgpt.com/codex/tasks/task_e_68bab521290883219efe10c98b268c27