### PR TITLE
chore(infra): add bootstrap script and toolchain smoke test

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -23,7 +23,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-07T18:28:15Z
+Last Updated (UTC): 2025-09-07T18:28:18Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -23,7 +23,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-07T12:23:21Z
+Last Updated (UTC): 2025-09-07T18:28:15Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -23,7 +23,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-07T18:28:18Z
+Last Updated (UTC): 2025-09-07T18:28:21Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-07T18:28:19Z",
+  "last_update_utc": "2025-09-07T18:28:21Z",
   "repo": {
     "default_branch": "codex/implement-bootstrap-script-for-environment-setup",
-    "last_commit": "635f454c91ed664a0238ab22e682275a46e3a97f",
-    "commits_total": 1064,
+    "last_commit": "52b3383f730b6d602d70e81953a8aa4ba0931076",
+    "commits_total": 1065,
     "files_tracked": 769
   },
   "quality_gate": {

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-07T18:28:15Z",
+  "last_update_utc": "2025-09-07T18:28:19Z",
   "repo": {
     "default_branch": "codex/implement-bootstrap-script-for-environment-setup",
-    "last_commit": "32b899cdd923748673526d2000777505994e1a71",
-    "commits_total": 1063,
+    "last_commit": "635f454c91ed664a0238ab22e682275a46e3a97f",
+    "commits_total": 1064,
     "files_tracked": 769
   },
   "quality_gate": {

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,10 +1,10 @@
 {
-  "last_update_utc": "2025-09-07T12:23:21Z",
+  "last_update_utc": "2025-09-07T18:28:15Z",
   "repo": {
-    "default_branch": "main",
-    "last_commit": "edcb82e31fd1c2ed98e7cb50dee172b95e44dc86",
-    "commits_total": 1061,
-    "files_tracked": 767
+    "default_branch": "codex/implement-bootstrap-script-for-environment-setup",
+    "last_commit": "32b899cdd923748673526d2000777505994e1a71",
+    "commits_total": 1063,
+    "files_tracked": 769
   },
   "quality_gate": {
     "weighted_threshold": 0.85,

--- a/bootstrap_infra.sh
+++ b/bootstrap_infra.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Ensure composer.json exists with minimal config if absent
+if [[ ! -f composer.json ]]; then
+  cat > composer.json <<'JSON'
+{
+  "name": "smartalloc/dev-bootstrap",
+  "require-dev": {
+    "phpunit/phpunit": "^10.5",
+    "squizlabs/php_codesniffer": "^3.9",
+    "wp-coding-standards/wpcs": "^3.0"
+  }
+}
+JSON
+fi
+
+# Install composer dependencies
+composer install --no-interaction --prefer-dist
+
+# Configure PHPCS to know about WPCS
+if vendor/bin/phpcs --config-show installed_paths | grep -q wpcs; then
+  echo "PHPCS installed_paths already configured"
+else
+  vendor/bin/phpcs --config-set installed_paths vendor/wp-coding-standards/wpcs
+fi
+
+# Setup pre-commit hook
+HOOK_FILE=".git/hooks/pre-commit"
+if [[ ! -f "$HOOK_FILE" ]]; then
+  cat > "$HOOK_FILE" <<'HOOK'
+#!/usr/bin/env bash
+set -e
+
+CHANGED=$(git diff --cached --name-only -- '*.php' '*.sh')
+if [[ -n "$CHANGED" ]]; then
+  vendor/bin/phpcs $CHANGED
+fi
+
+vendor/bin/phpunit tests/Smoke/ToolsSmokeTest.php --group smoke
+HOOK
+  chmod +x "$HOOK_FILE"
+fi
+
+echo "Infrastructure bootstrap complete"

--- a/tests/Smoke/ToolsSmokeTest.php
+++ b/tests/Smoke/ToolsSmokeTest.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+namespace SmartAlloc\Tests\Smoke;
+
+use PHPUnit\Framework\TestCase;
+
+final class ToolsSmokeTest extends TestCase
+{
+    /**
+     * @group smoke
+     */
+    public function test_toolchain_is_available(): void
+    {
+        $root = dirname(__DIR__, 2);
+        $this->assertTrue(class_exists(\Composer\Autoload\ClassLoader::class));
+        $this->assertFileExists($root . '/vendor/bin/phpcs');
+        $this->assertFileExists($root . '/vendor/bin/phpunit');
+    }
+}


### PR DESCRIPTION
## Summary
- add idempotent bootstrap_infra.sh to install dev dependencies and create pre-commit
- add ToolsSmokeTest to verify autoload and toolchain presence

## Testing
- `vendor/bin/phpcs --version`
- `vendor/bin/phpunit tests/Smoke/ToolsSmokeTest.php --group smoke`
- `php scripts/coverage-import.php`
- `php scripts/artifact-schema-validate.php`
- `php scripts/ga-enforcer.php --profile=rc --junit`
- `php baseline-check --current-phase=foundation`
- `php baseline-compare --feature=bootstrap-infra`
- `php gap-analysis --target=foundation`


------
https://chatgpt.com/codex/tasks/task_e_68bdcd3b10088321896265fd57d8c2b2