### PR TITLE
chore: add toolchain smoke test

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,10 +19,10 @@
     "maennchen/zipstream-php": ">=3.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.6",
+    "phpunit/phpunit": "^10.5",
     "yoast/phpunit-polyfills": "^2.0",
     "brain/monkey": "^2.6",
-    "mockery/mockery": "^1.4",
+    "mockery/mockery": "^1.6",
     "wp-coding-standards/wpcs": "^3.0",
     "automattic/vipwpcs": "^3.0",
     "phpcompatibility/php-compatibility": "^9.3",
@@ -41,7 +41,7 @@
   },
   "autoload": {
     "psr-4": {
-      "SmartAlloc\\": "src/"
+      "SmartAlloc\\": ["src/", "includes/"]
     },
     "files": ["src/Support/SafetyKit.php", "src/Infra/DbAbstraction.php"]
   },

--- a/tests/Smoke/ToolchainTest.php
+++ b/tests/Smoke/ToolchainTest.php
@@ -1,0 +1,63 @@
+<?php
+declare(strict_types=1);
+
+namespace SmartAlloc\Tests\Smoke;
+
+use PHPUnit\Framework\TestCase;
+
+final class ToolchainTest extends TestCase
+{
+    public function test_composer_autoloader_exists(): void
+    {
+        $this->assertTrue(class_exists(\Composer\Autoload\ClassLoader::class));
+    }
+
+    public function test_phpunit_version_is_10(): void
+    {
+        $this->assertStringStartsWith('10.', \PHPUnit\Runner\Version::id());
+    }
+
+    public function test_mockery_is_available(): void
+    {
+        $this->assertTrue(class_exists('Mockery'));
+    }
+
+    public function test_brain_monkey_is_available(): void
+    {
+        $this->assertTrue(class_exists('Brain\\Monkey\\Container'));
+    }
+
+    public function test_smartalloc_namespace_autoloads(): void
+    {
+        $dir = dirname(__DIR__, 2) . '/includes';
+        if (! is_dir($dir)) {
+            mkdir($dir, 0777, true);
+        }
+        $file = $dir . '/TestAutoload.php';
+        file_put_contents($file, '<?php namespace SmartAlloc; class TestAutoload {}');
+        $this->assertTrue(class_exists('SmartAlloc\\TestAutoload'));
+        unlink($file);
+        @rmdir($dir);
+    }
+
+    public function test_php_version_requirement(): void
+    {
+        $this->assertTrue(version_compare(PHP_VERSION, '8.1.0', '>='));
+    }
+
+    public function test_phpcs_is_available(): void
+    {
+        $phpcs = dirname(__DIR__, 2) . '/vendor/bin/phpcs';
+        $this->assertFileExists($phpcs);
+        exec($phpcs . ' -i', $out);
+        $this->assertStringContainsString('WordPress', implode(' ', $out));
+    }
+
+    public function test_configuration_files_exist(): void
+    {
+        $root = dirname(__DIR__, 2);
+        $this->assertFileExists($root . '/composer.json');
+        $this->assertFileExists($root . '/phpunit.xml.dist');
+        $this->assertFileExists($root . '/vendor/autoload.php');
+    }
+}


### PR DESCRIPTION
## Summary
- upgrade PHPUnit and Mockery dev dependencies and extend autoloader to includes
- add smoke test verifying toolchain and autoloading

## Testing
- `vendor/bin/phpunit tests/Smoke/ToolchainTest.php`
- `vendor/bin/phpcs -i`
- `php scripts/coverage-import.php`
- `php scripts/artifact-schema-validate.php`
- `php scripts/ga-enforcer.php --profile=rc --junit`
- `php baseline-check --current-phase=foundation`
- `php baseline-compare --feature=bootstrap`
- `php gap-analysis --target=bootstrap`


------
https://chatgpt.com/codex/tasks/task_e_68bdd0ff89308321927a6c4c30b06163