### PR TITLE
ci: add Patch Guard enforcement workflow

### DIFF
--- a/.github/workflows/patch-guard.yml
+++ b/.github/workflows/patch-guard.yml
@@ -1,0 +1,76 @@
+name: Patch Guard (branch-type caps)
+
+on:
+  pull_request:
+    branches: [ main, develop ]
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (full history for diff)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Compute stats (files & LoC, with exclusions)
+        id: stats
+        shell: bash
+        run: |
+          set -euo pipefail
+          BASE="${{ github.event.pull_request.base.sha }}"
+          HEAD="${{ github.event.pull_request.head.sha }}"
+          BRANCH="${{ github.head_ref || github.ref_name }}"
+          FILTER='^(vendor/|node_modules/|dist/|build/|assets/dist/|languages/.*\.(mo|po)$|.*\.min\.(js|css)$|.*\.bundle\.js$)'
+          FILES=$(git diff --name-only "$BASE..$HEAD" | grep -Ev "$FILTER" | wc -l | tr -d ' ')
+          LOC=$(git diff --numstat "$BASE..$HEAD" | grep -Ev "$FILTER" | awk '{add+=$1; del+=$2} END {print (add+del)}')
+          echo "files=$FILES" >> "$GITHUB_OUTPUT"
+          echo "loc=$LOC" >> "$GITHUB_OUTPUT"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+
+      - name: Enforce branch-type caps
+        id: enforce
+        shell: bash
+        run: |
+          set -euo pipefail
+          FILES="${{ steps.stats.outputs.files }}"
+          LOC="${{ steps.stats.outputs.loc }}"
+          BRANCH="${{ steps.stats.outputs.branch }}"
+
+          max_files=10; max_loc=300
+          case "$BRANCH" in
+            hotfix/*)        max_files=5;  max_loc=150 ;;
+            bugfix/*)        max_files=8;  max_loc=200 ;;
+            feature/*)       max_files=20; max_loc=600 ;;
+            refactor/*)      max_files=15; max_loc=500 ;;
+            perf/*)          max_files=12; max_loc=350 ;;
+            security/*)      max_files=8;  max_loc=200 ;;
+            docs/*)          max_files=30; max_loc=800 ;;
+            tests/*|test/*)  max_files=25; max_loc=700 ;;
+            i18n/*)          max_files=50; max_loc=1000 ;;
+            migration/*)     max_files=15; max_loc=400 ;;
+            compatibility/*) max_files=10; max_loc=300 ;;
+          esac
+
+          echo "Caps → files:${max_files} loc:${max_loc}"
+          echo "PR   → files:${FILES} loc:${LOC}"
+
+          echo "## Patch Guard Result" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Branch: \`$BRANCH\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Files changed: **$FILES** / cap **$max_files**" >> "$GITHUB_STEP_SUMMARY"
+          echo "- LoC (added+deleted): **$LOC** / cap **$max_loc**" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Policy: \`PATCH_GUARD_STANDARDS_WordPress_2025-09-07.md\`" >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$FILES" -le "$max_files" ] && [ "$LOC" -le "$max_loc" ]; then
+            echo "status=pass" >> "$GITHUB_OUTPUT"
+            exit 0
+          else
+            echo "::error title=Patch Guard violation::files=$FILES (cap=$max_files), loc=$LOC (cap=$max_loc), branch=$BRANCH"
+            echo "status=fail" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -23,7 +23,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-07T19:11:18Z
+Last Updated (UTC): 2025-09-07T19:11:23Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -23,7 +23,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-07T18:49:25Z
+Last Updated (UTC): 2025-09-07T19:11:16Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -23,7 +23,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-07T19:11:16Z
+Last Updated (UTC): 2025-09-07T19:11:18Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,10 +1,10 @@
 {
-  "last_update_utc": "2025-09-07T18:49:25Z",
+  "last_update_utc": "2025-09-07T19:11:16Z",
   "repo": {
-    "default_branch": "main",
-    "last_commit": "0a7401f27b8b44d128f57b9351b454140166e543",
-    "commits_total": 1073,
-    "files_tracked": 770
+    "default_branch": "codex/create-patch-guard-github-action",
+    "last_commit": "51791e076924e2322a2c236f5082f5858eb620c5",
+    "commits_total": 1075,
+    "files_tracked": 772
   },
   "quality_gate": {
     "weighted_threshold": 0.85,

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-07T19:11:18Z",
+  "last_update_utc": "2025-09-07T19:11:23Z",
   "repo": {
     "default_branch": "codex/create-patch-guard-github-action",
-    "last_commit": "bf19f19fac7108c0c1ce439a88885073c481c8c4",
-    "commits_total": 1076,
+    "last_commit": "a312a2c563832c8ba072964d44b923b803d09487",
+    "commits_total": 1077,
     "files_tracked": 772
   },
   "quality_gate": {

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-07T19:11:16Z",
+  "last_update_utc": "2025-09-07T19:11:18Z",
   "repo": {
     "default_branch": "codex/create-patch-guard-github-action",
-    "last_commit": "51791e076924e2322a2c236f5082f5858eb620c5",
-    "commits_total": 1075,
+    "last_commit": "bf19f19fac7108c0c1ce439a88885073c481c8c4",
+    "commits_total": 1076,
     "files_tracked": 772
   },
   "quality_gate": {

--- a/scripts/patch-guard-check.sh
+++ b/scripts/patch-guard-check.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Local checker (same logic as CI) — run before opening PR
+
+set -euo pipefail
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+BASE=$(git merge-base origin/develop HEAD 2>/dev/null || git rev-parse HEAD~1)
+
+FILTER='^(vendor/|node_modules/|dist/|build/|assets/dist/|languages/.*\.(mo|po)$|.*\.min\.(js|css)$|.*\.bundle\.js$)'
+FILES=$(git diff --name-only "$BASE...HEAD" | grep -Ev "$FILTER" | wc -l | tr -d ' ')
+LOC=$(git diff --numstat "$BASE...HEAD" | grep -Ev "$FILTER" | awk '{add+=$1; del+=$2} END {print (add+del)}')
+
+max_files=10; max_loc=300
+case "$BRANCH" in
+  hotfix/*)        max_files=5;  max_loc=150 ;;
+  bugfix/*)        max_files=8;  max_loc=200 ;;
+  feature/*)       max_files=20; max_loc=600 ;;
+  refactor/*)      max_files=15; max_loc=500 ;;
+  perf/*)          max_files=12; max_loc=350 ;;
+  security/*)      max_files=8;  max_loc=200 ;;
+  docs/*)          max_files=30; max_loc=800 ;;
+  tests/*|test/*)  max_files=25; max_loc=700 ;;
+  i18n/*)          max_files=50; max_loc=1000 ;;
+  migration/*)     max_files=15; max_loc=400 ;;
+  compatibility/*) max_files=10; max_loc=300 ;;
+
+esac
+
+echo "Branch: $BRANCH"
+echo "Files:  $FILES / cap $max_files"
+echo "LoC:    $LOC / cap $max_loc"
+
+if [ "$FILES" -le "$max_files" ] && [ "$LOC" -le "$max_loc" ]; then
+  echo "✅ Patch Guard check passed"
+  exit 0
+else
+  echo "❌ Patch Guard violation"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- add Patch Guard CI workflow enforcing branch-type file/LoC caps
- provide matching local `patch-guard-check.sh` script

## Testing
- `scripts/patch-guard-check.sh`

------
https://chatgpt.com/codex/tasks/task_e_68bdd6cabcdc8321a229f9a6518658f4