### PR TITLE
fix: resolve post-merge issues for option C

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -23,7 +23,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-08T08:28:59Z
+Last Updated (UTC): 2025-09-08T08:29:03Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -23,7 +23,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-08T08:29:03Z
+Last Updated (UTC): 2025-09-08T08:29:06Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -23,7 +23,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-08T08:11:57Z
+Last Updated (UTC): 2025-09-08T08:28:59Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,10 +1,10 @@
 {
-  "last_update_utc": "2025-09-08T08:11:57Z",
+  "last_update_utc": "2025-09-08T08:28:59Z",
   "repo": {
-    "default_branch": "main",
-    "last_commit": "c8ec5eceffeefb9270ef44c436d62380a300e92c",
-    "commits_total": 1101,
-    "files_tracked": 785
+    "default_branch": "codex/fix-wp-cli-plugin-check-issues",
+    "last_commit": "ae6e501eaec7fccec79006289f0eb5cab95c4823",
+    "commits_total": 1103,
+    "files_tracked": 793
   },
   "quality_gate": {
     "weighted_threshold": 0.85,

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-08T08:28:59Z",
+  "last_update_utc": "2025-09-08T08:29:04Z",
   "repo": {
     "default_branch": "codex/fix-wp-cli-plugin-check-issues",
-    "last_commit": "ae6e501eaec7fccec79006289f0eb5cab95c4823",
-    "commits_total": 1103,
+    "last_commit": "db60d9f633707f2650039d2dc77f617dd4eb929f",
+    "commits_total": 1104,
     "files_tracked": 793
   },
   "quality_gate": {

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-08T08:29:04Z",
+  "last_update_utc": "2025-09-08T08:29:06Z",
   "repo": {
     "default_branch": "codex/fix-wp-cli-plugin-check-issues",
-    "last_commit": "db60d9f633707f2650039d2dc77f617dd4eb929f",
-    "commits_total": 1104,
+    "last_commit": "2f1c19d1b29c3ae5144be2cb1d1abeed54d6d596",
+    "commits_total": 1105,
     "files_tracked": 793
   },
   "quality_gate": {

--- a/includes/Core/Cache.php
+++ b/includes/Core/Cache.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SmartAlloc\Core;
+
+/**
+ * Simple caching utilities
+ */
+class Cache
+{
+    public static function get(string $key): mixed
+    {
+        return get_transient('smartalloc_' . $key);
+    }
+
+    public static function set(string $key, mixed $value, int $expiration = 3600): bool
+    {
+        return set_transient('smartalloc_' . $key, $value, $expiration);
+    }
+
+    public static function delete(string $key): bool
+    {
+        return delete_transient('smartalloc_' . $key);
+    }
+}

--- a/includes/Core/Plugin.php
+++ b/includes/Core/Plugin.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SmartAlloc\Core;
+
+/**
+ * Main Plugin Class
+ */
+class Plugin
+{
+    private static ?self $instance = null;
+
+    public static function getInstance(): self
+    {
+        if (self::$instance === null) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
+
+    private function __construct()
+    {
+        $this->init();
+    }
+
+    private function init(): void
+    {
+        add_action('init', array( $this, 'loadTextDomain' ));
+    }
+
+    public function loadTextDomain(): void
+    {
+        load_plugin_textdomain(
+            'smartalloc',
+            false,
+            dirname(plugin_basename(__DIR__ . '/../smart-alloc.php')) . '/languages'
+        );
+    }
+}

--- a/includes/Core/Security.php
+++ b/includes/Core/Security.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SmartAlloc\Core;
+
+/**
+ * Security utilities
+ */
+class Security
+{
+    public static function verifyCaps(string $capability = 'manage_options'): bool
+    {
+        return current_user_can($capability);
+    }
+
+    public static function verifyNonce(string $nonce, string $action): bool
+    {
+        return wp_verify_nonce($nonce, $action) !== false;
+    }
+
+    public static function sanitizeInput(string $input): string
+    {
+        return sanitize_text_field($input);
+    }
+
+    public static function escapeOutput(string $output): string
+    {
+        return esc_html($output);
+    }
+}

--- a/includes/Core/Validator.php
+++ b/includes/Core/Validator.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SmartAlloc\Core;
+
+/**
+ * Input validation utilities
+ */
+class Validator
+{
+    public static function validateEmail(string $email): bool
+    {
+        return is_email($email) !== false;
+    }
+
+    public static function validateUrl(string $url): bool
+    {
+        return filter_var($url, FILTER_VALIDATE_URL) !== false;
+    }
+
+    public static function validateInt(mixed $value, int $min = 0, int $max = PHP_INT_MAX): bool
+    {
+        $int = filter_var($value, FILTER_VALIDATE_INT);
+        return $int !== false && $int >= $min && $int <= $max;
+    }
+}

--- a/includes/autoload.php
+++ b/includes/autoload.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+// PSR-4 Autoloader for SmartAlloc
+spl_autoload_register(
+    function ($class) {
+        $prefix   = 'SmartAlloc\\';
+        $base_dir = __DIR__ . '/';
+
+        $len = strlen($prefix);
+        if (strncmp($prefix, $class, $len) !== 0) {
+            return;
+        }
+
+        $relative_class = substr($class, $len);
+        $file           = $base_dir . str_replace('\\', '/', $relative_class) . '.php';
+
+        if (file_exists($file)) {
+            require $file;
+        }
+    }
+);

--- a/scripts/fix-quality-issues.sh
+++ b/scripts/fix-quality-issues.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+vendor/bin/phpcbf --standard=WordPress-Extra includes/ || true

--- a/scripts/fix-wp-cli-plugin-check.sh
+++ b/scripts/fix-wp-cli-plugin-check.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+command -v wp >/dev/null || {
+  curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar;
+  chmod +x wp-cli.phar;
+  mv wp-cli.phar /usr/local/bin/wp || mv wp-cli.phar ./wp;
+}
+mkdir -p /tmp/wp-test && cd /tmp/wp-test
+wp core download --allow-root --quiet
+wp config create --dbname=test --dbuser=test --dbpass=test --allow-root --skip-check
+cd - >/dev/null
+WP_CLI_PACKAGES_DIR=/tmp/wp-test wp plugin check ./ --allow-root --format=json || {
+  wp package install wp-cli/plugin-check-command --allow-root;
+  wp plugin check ./ --allow-root --format=json;
+}

--- a/scripts/selective-quality-gates.php
+++ b/scripts/selective-quality-gates.php
@@ -43,8 +43,10 @@ if ($mode === 'analyze' || $mode === 'all') {
     echo "Running PHPStan on staged files...\n";
     $tmpConfig = tempnam(sys_get_temp_dir(), 'phpstan') . '.neon';
     file_put_contents($tmpConfig, "parameters:\n    bootstrapFiles: []\n");
-    $cfgArg = escapeshellarg($tmpConfig);
-    passthru("vendor/bin/phpstan analyze --level=5 -c $cfgArg $files", $stanCode);
+    $cfgArg   = escapeshellarg($tmpConfig);
+    $autoload = escapeshellarg(__DIR__ . '/../vendor/php-stubs/wordpress-stubs/wordpress-stubs.php');
+    $cmd      = "vendor/bin/phpstan analyze --level=5 --memory-limit=512M --autoload-file=$autoload -c $cfgArg $files";
+    passthru($cmd, $stanCode);
     unlink($tmpConfig);
     $exit = max($exit, $stanCode);
 }

--- a/scripts/verify-fixes.sh
+++ b/scripts/verify-fixes.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+vendor/bin/phpcs --standard=WordPress-Extra includes/ admin/ smart-alloc.php
+vendor/bin/phpstan analyze --no-progress
+WP_CLI_PACKAGES_DIR=/tmp/wp-test wp plugin check ./ --allow-root --format=table
+vendor/bin/phpunit --group smoke --no-coverage
+php baseline-check --current-phase=FOUNDATION
+php baseline-compare --feature=post-merge-fixes
+php gap-analysis --target=baseline


### PR DESCRIPTION
## Summary
- Fix WP-CLI plugin check bootstrap script
- Introduce basic plugin skeleton and autoloader under `includes/`
- Add security, validation, and caching helpers
- Wire PHPStan to WordPress stubs for selective quality gates

## Testing
- `composer run quality:selective`
- `php baseline-check --current-phase=FOUNDATION`
- `vendor/bin/phpunit --group smoke --no-coverage`
- `php baseline-compare --feature=post-merge-fixes`
- `php gap-analysis --target=baseline`
- `WP_CLI_PACKAGES_DIR=/tmp/wp-test php -d memory_limit=512M /usr/local/bin/wp plugin check ./ --allow-root --path=/tmp/wp-test --format=table` *(fails: Error establishing a database connection)*
- `./scripts/patch-guard-check.sh`


------
https://chatgpt.com/codex/tasks/task_e_68be9006f94883218b90210b9a6c608e