### PR TITLE
feat: add temporary DB setup for WP plugin checks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,12 +42,21 @@
   },
   "autoload": {
     "psr-4": {
-      "SmartAlloc\\": ["src/", "includes/"]
+      "SmartAlloc\\": [
+        "src/",
+        "includes/"
+      ]
     },
-    "files": ["src/Support/SafetyKit.php", "src/Infra/DbAbstraction.php"]
+    "files": [
+      "src/Support/SafetyKit.php",
+      "src/Infra/DbAbstraction.php"
+    ]
   },
   "scripts": {
-    "score:5d": ["@phpcbf", "bash scripts/update_state.sh"],
+    "score:5d": [
+      "@phpcbf",
+      "bash scripts/update_state.sh"
+    ],
     "state": "php scripts/generate_features_md.php && php scripts/ai_context_sync.php && bash scripts/update_state.sh",
     "cs": "vendor/bin/phpcs -q --standard=phpcs.xml",
     "lint:php": "php -l $(git ls-files '*.php')",
@@ -90,7 +99,8 @@
     "test:performance": "phpunit --group=performance || true",
     "security:relaxed": "php scripts/security-relaxed-check.php",
     "maintainability:relaxed": "php scripts/maintainability-check.php",
-    "quality:selective": "php scripts/selective-quality-gates.php"
+    "quality:selective": "php scripts/selective-quality-gates.php",
+    "plugin:check": "bash scripts/run-plugin-check.sh"
   },
   "scripts-descriptions": {
     "baseline:check": "Run baseline compliance check for current phase",

--- a/scripts/run-plugin-check.sh
+++ b/scripts/run-plugin-check.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Run WordPress Plugin Check using a temporary database
+
+set -euo pipefail
+
+PLUGIN_DIR="${1:-$(pwd)}"
+PLUGIN_DIR="$(cd "$PLUGIN_DIR" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Setup database and WordPress configuration
+source "$SCRIPT_DIR/setup-wp-test-db.sh"
+
+cleanup() {
+  echo "Cleaning up temporary environment"
+  mysql -h"$DB_HOST" -u"$DB_USER" ${DB_PASS:+-p$DB_PASS} -e "DROP DATABASE IF EXISTS \`$WP_TEST_DB_NAME\`;" >/dev/null 2>&1 || true
+  rm -rf "$WP_TEST_DIR"
+}
+trap cleanup EXIT
+
+# Install WordPress core
+wp core install --allow-root --path="$WP_TEST_DIR" \
+  --url="http://localhost" --title="Test Site" \
+  --admin_user=admin --admin_password=password --admin_email=test@example.com \
+  --skip-email >/dev/null
+
+# Run plugin check
+echo "Running plugin check for: $PLUGIN_DIR"
+WP_CLI_PACKAGES_DIR="$WP_CLI_PACKAGES_DIR" php -d memory_limit=512M "$(command -v wp)" plugin check "$PLUGIN_DIR" --allow-root --path="$WP_TEST_DIR" --format=table

--- a/scripts/setup-wp-test-db.sh
+++ b/scripts/setup-wp-test-db.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Setup WP Test Database for Plugin Check
+# Creates a temporary database and prepares a WordPress environment
+
+set -euo pipefail
+
+# Ensure MySQL client is available
+if ! command -v mysql >/dev/null 2>&1; then
+  echo "MySQL client not found. Please install MySQL or MariaDB client." >&2
+  exit 1
+fi
+
+# Determine environment (local vs CI/Docker)
+if [ -n "${CI:-}" ] || [ -f /.dockerenv ]; then
+  DB_USER="${DB_USER:-root}"
+  DB_PASS="${DB_PASS:-root}"
+  DB_HOST="${DB_HOST:-127.0.0.1}"
+else
+  DB_USER="${DB_USER:-root}"
+  DB_PASS="${DB_PASS:-}"
+  DB_HOST="${DB_HOST:-localhost}"
+fi
+
+# Create a unique temporary database
+DB_NAME="wp_test_$(date +%s)_$RANDOM"
+mysql -h"$DB_HOST" -u"$DB_USER" ${DB_PASS:+-p$DB_PASS} -e "CREATE DATABASE IF NOT EXISTS \`$DB_NAME\`;" || {
+  echo "Unable to create database. Check MySQL credentials." >&2
+  exit 1
+}
+
+# Prepare temporary WordPress directory
+WP_TEST_DIR=$(mktemp -d /tmp/wp-test-XXXX)
+export WP_TEST_DIR
+
+# Install WP-CLI if missing
+if ! command -v wp >/dev/null 2>&1; then
+  "$(dirname "$0")/install-wp-cli.sh"
+fi
+
+# Setup packages directory and install plugin-check package
+WP_CLI_PACKAGES_DIR=${WP_CLI_PACKAGES_DIR:-/tmp/wp-cli-packages}
+export WP_CLI_PACKAGES_DIR
+mkdir -p "$WP_CLI_PACKAGES_DIR"
+if ! wp package list --allow-root | grep -q "plugin-check-command"; then
+  wp package install wp-cli/plugin-check-command --allow-root >/dev/null
+fi
+
+# Download WordPress core and create configuration
+wp core download --allow-root --path="$WP_TEST_DIR" >/dev/null
+wp config create --allow-root --path="$WP_TEST_DIR" --dbname="$DB_NAME" --dbuser="$DB_USER" --dbpass="$DB_PASS" --dbhost="$DB_HOST" --skip-check >/dev/null
+
+# Export database variables for caller
+export WP_TEST_DB_NAME="$DB_NAME"
+export DB_HOST DB_USER DB_PASS
+
+echo "WordPress test environment ready at $WP_TEST_DIR"
+echo "Database: $DB_NAME"


### PR DESCRIPTION
## Summary
- add script to provision temporary database and WP test env
- run plugin check against isolated WordPress install
- expose new `composer plugin:check` command

## Testing
- `composer run quality:selective`
- `php baseline-check --current-phase=FOUNDATION`
- `./scripts/patch-guard-check.sh`
- `composer run plugin:check` *(fails: MySQL client not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be942ec39c8321b869e54f25e2a9a0