### PR TITLE
feat: add circuit breaker failure metadata

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -23,7 +23,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-08T09:14:22Z
+Last Updated (UTC): 2025-09-08T10:43:14Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -23,7 +23,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-08T10:43:14Z
+Last Updated (UTC): 2025-09-08T10:43:17Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-08T10:43:14Z",
+  "last_update_utc": "2025-09-08T10:43:17Z",
   "repo": {
     "default_branch": "codex/enhance-circuitbreaker-failure-metadata",
-    "last_commit": "d047b1706ff175814926b8c549660764b163fcfc",
-    "commits_total": 1131,
+    "last_commit": "16bbb0b46aad756e0b54a2551cefaa1bcf5e12ba",
+    "commits_total": 1132,
     "files_tracked": 805
   },
   "quality_gate": {

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,10 +1,10 @@
 {
-  "last_update_utc": "2025-09-08T09:14:22Z",
+  "last_update_utc": "2025-09-08T10:43:14Z",
   "repo": {
-    "default_branch": "main",
-    "last_commit": "e22ae079a2d946ff6743b3266c68e641d2b468f3",
-    "commits_total": 1129,
-    "files_tracked": 803
+    "default_branch": "codex/enhance-circuitbreaker-failure-metadata",
+    "last_commit": "d047b1706ff175814926b8c549660764b163fcfc",
+    "commits_total": 1131,
+    "files_tracked": 805
   },
   "quality_gate": {
     "weighted_threshold": 0.85,

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
   "require": {
     "php": ">=8.1",
     "phpoffice/phpspreadsheet": "~1.29.0",
-    "maennchen/zipstream-php": "^2.2.1"
+    "maennchen/zipstream-php": "^2.2.1",
+    "psr/log": "^3.0"
   },
   "conflict": {
     "maennchen/zipstream-php": ">=3.0"

--- a/tests/Integration/Services/CircuitBreakerWordPressIntegrationTest.php
+++ b/tests/Integration/Services/CircuitBreakerWordPressIntegrationTest.php
@@ -1,0 +1,17 @@
+<?php
+// phpcs:ignoreFile
+declare(strict_types=1);
+
+namespace SmartAlloc\Tests\Integration\Services;
+
+use PHPUnit\Framework\TestCase;
+use SmartAlloc\Services\CircuitBreaker;
+
+final class CircuitBreakerWordPressIntegrationTest extends TestCase {
+    public function testTransientPersistence(): void {
+        $cb = new CircuitBreaker('wp');
+        $cb->failure('op', new \RuntimeException('err'));
+        $summary = get_transient('smartalloc_circuit_summary_wp');
+        $this->assertEquals(1, $summary['total_failures']);
+    }
+}

--- a/tests/Unit/Services/CircuitBreakerFailureMetadataTest.php
+++ b/tests/Unit/Services/CircuitBreakerFailureMetadataTest.php
@@ -1,0 +1,62 @@
+<?php
+// phpcs:ignoreFile
+declare(strict_types=1);
+
+namespace SmartAlloc\Tests\Unit\Services;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Log\AbstractLogger;
+use SmartAlloc\Services\CircuitBreaker;
+
+class ArrayLogger extends AbstractLogger {
+	public array $records = array();
+	public function log( $level, $message, array $context = array() ): void {
+		$this->records[] = compact( 'level', 'message', 'context' );
+	}
+	public function hasWarning( string $message ): bool {
+		foreach ( $this->records as $r ) {
+			if ( $r['level'] === 'warning' && $r['message'] === $message ) {
+				return true;
+			}
+		}
+		return false;
+	}
+	public function hasError( string $message ): bool {
+		foreach ( $this->records as $r ) {
+			if ( $r['level'] === 'error' && $r['message'] === $message ) {
+				return true;
+			}
+		}
+		return false;
+	}
+}
+
+final class CircuitBreakerFailureMetadataTest extends TestCase {
+	private CircuitBreaker $cb;
+	private ArrayLogger $logger;
+
+	protected function setUp(): void {
+		$this->logger = new ArrayLogger();
+		$this->cb     = new CircuitBreaker( 'test', $this->logger, 5 );
+	}
+
+	public function testFailureRecordsMetadataAndLogging(): void {
+		$e = new \RuntimeException( 'fail', 123 );
+		$this->cb->failure( 'op', $e );
+		$m = $this->cb->getFailureMetadata();
+		$this->assertCount( 1, $m );
+		$this->assertSame( 'op', $m[0]['operation_name'] );
+		$this->assertTrue( $this->logger->hasWarning( 'Circuit breaker failure recorded' ) );
+	}
+
+        public function testMetadataSizeLimit(): void {
+                $cb = new CircuitBreaker( 'limit', $this->logger, 2 );
+                for ( $i = 0; $i < 4; $i++ ) {
+                        $cb->failure( 'o' . $i, new \RuntimeException( (string) $i ) );
+                }
+		$m = $cb->getFailureMetadata();
+		$this->assertCount( 2, $m );
+		$this->assertSame( '3', $m[1]['exception_message'] );
+	}
+
+}


### PR DESCRIPTION
## Summary
- track failure metadata and log via PSR-3 logger
- persist failure info in WordPress transients
- test metadata recording and transient summary

## Testing
- `composer run quality:selective`
- `php baseline-check --current-phase=FOUNDATION`
- `vendor/bin/phpunit tests/Unit/Services/CircuitBreakerFailureMetadataTest.php`
- `vendor/bin/phpunit tests/Integration/Services/CircuitBreakerWordPressIntegrationTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68bea014e37083218694f0a715940360