### PR TITLE
Refactor CircuitBreaker service with PSR-12 compliance

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -23,7 +23,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-08T10:49:11Z
+Last Updated (UTC): 2025-09-08T10:49:18Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -23,7 +23,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-08T09:22:34Z
+Last Updated (UTC): 2025-09-08T10:49:11Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-08T10:49:11Z",
+  "last_update_utc": "2025-09-08T10:49:18Z",
   "repo": {
     "default_branch": "codex/fix-comments-in-circuitbreakerinterface",
-    "last_commit": "85ee7628b4b7f975473582fbc4ed3fd6818471da",
-    "commits_total": 1128,
+    "last_commit": "7a183fc25d8fbb89b35869982d19cfeeea97d033",
+    "commits_total": 1129,
     "files_tracked": 801
   },
   "quality_gate": {

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-08T09:22:34Z",
+  "last_update_utc": "2025-09-08T10:49:11Z",
   "repo": {
-    "default_branch": "codex/fix-circuitbreaker-psr-12-compliance",
-    "last_commit": "b2ebd796fe44c5d68a5138b69d5c8e9800c3d7af",
-    "commits_total": 1126,
+    "default_branch": "codex/fix-comments-in-circuitbreakerinterface",
+    "last_commit": "85ee7628b4b7f975473582fbc4ed3fd6818471da",
+    "commits_total": 1128,
     "files_tracked": 801
   },
   "quality_gate": {

--- a/src/Interfaces/CircuitBreakerInterface.php
+++ b/src/Interfaces/CircuitBreakerInterface.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 namespace SmartAlloc\Interfaces;
 
 use SmartAlloc\Exceptions\CircuitBreakerException;
+use SmartAlloc\Services\CircuitBreakerStatus;
+use Throwable;
 
 /**
  * Circuit Breaker Interface
@@ -53,9 +55,58 @@ interface CircuitBreakerInterface
     public function getState(): string;
 
     /**
-     * Reset circuit breaker to closed state
+     * Reset circuit breaker to closed state.
+     */
+    public function reset(): void;
+
+    /**
+     * Retrieve detailed circuit breaker status
+     *
+     * @return CircuitBreakerStatus Status value object.
+     */
+    public function getStatus(): CircuitBreakerStatus;
+
+    /**
+     * Record a failure with optional error message
+     *
+     * @param string $error Error message.
      *
      * @return void
      */
-    public function reset(): void;
+    public function recordFailure(string $error): void;
+
+    /**
+     * Record a successful operation
+     *
+     * @return void
+     */
+    public function recordSuccess(): void;
+
+    /**
+     * Guard an operation and throw when circuit is open
+     *
+     * @param string $context Context identifier for the operation.
+     *
+     * @return void
+     */
+    public function guard(string $context): void;
+
+    /**
+     * Mark an operation as successful
+     *
+     * @param string $context Context identifier for the operation.
+     *
+     * @return void
+     */
+    public function success(string $context): void;
+
+    /**
+     * Mark an operation as failed
+     *
+     * @param string    $context   Context identifier for the operation.
+     * @param Throwable $exception Exception that occurred.
+     *
+     * @return void
+     */
+    public function failure(string $context, Throwable $exception): void;
 }


### PR DESCRIPTION
## Summary
- expose legacy CircuitBreaker methods in interface
- allow string-key constructor and wrap legacy API calls
- clarify reset method comment in interface

## Testing
- `composer run quality:selective`
- `php baseline-check --current-phase=FOUNDATION`
- `./scripts/patch-guard-check.sh`


------
https://chatgpt.com/codex/tasks/task_e_68beb27ce9848321842ec1047ea87bbc