### PR TITLE
Codex/fix comments in circuitbreaker.php ayg7e0

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -23,7 +23,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-08T11:03:12Z
+Last Updated (UTC): 2025-09-08T11:03:17Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -23,7 +23,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-08T12:24:46Z
+Last Updated (UTC): 2025-09-08T12:24:48Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -23,7 +23,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-08T12:24:44Z
+Last Updated (UTC): 2025-09-08T12:24:46Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -23,7 +23,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-08T10:43:40Z
+Last Updated (UTC): 2025-09-08T11:03:12Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -23,7 +23,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-08T11:03:17Z
+Last Updated (UTC): 2025-09-08T12:24:44Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-08T12:24:44Z",
+  "last_update_utc": "2025-09-08T12:24:46Z",
   "repo": {
     "default_branch": "codex/fix-comments-in-circuitbreaker.php-ayg7e0",
-    "last_commit": "024d975a46697dcd590e1174c72f14d11fadbd10",
-    "commits_total": 1139,
+    "last_commit": "deb354371e6e7c87c238e16b7c4e838457d519b8",
+    "commits_total": 1140,
     "files_tracked": 807
   },
   "quality_gate": {

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,10 +1,10 @@
 {
-  "last_update_utc": "2025-09-08T10:43:40Z",
+  "last_update_utc": "2025-09-08T11:03:12Z",
   "repo": {
-    "default_branch": "main",
-    "last_commit": "6174ad7693b39afbfa236b57b817c37d2946152f",
-    "commits_total": 1134,
-    "files_tracked": 805
+    "default_branch": "codex/implement-circuitbreaker-callback-exception-handling-kcjr2m",
+    "last_commit": "fdddd10b8a5f69de4287f5a841e1cc32ab147a1a",
+    "commits_total": 1136,
+    "files_tracked": 807
   },
   "quality_gate": {
     "weighted_threshold": 0.85,

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-08T11:03:12Z",
+  "last_update_utc": "2025-09-08T11:03:17Z",
   "repo": {
     "default_branch": "codex/implement-circuitbreaker-callback-exception-handling-kcjr2m",
-    "last_commit": "fdddd10b8a5f69de4287f5a841e1cc32ab147a1a",
-    "commits_total": 1136,
+    "last_commit": "986d82c3d4d272ee19d7953a1ede338ae837b521",
+    "commits_total": 1137,
     "files_tracked": 807
   },
   "quality_gate": {

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-08T11:03:17Z",
+  "last_update_utc": "2025-09-08T12:24:44Z",
   "repo": {
-    "default_branch": "codex/implement-circuitbreaker-callback-exception-handling-kcjr2m",
-    "last_commit": "986d82c3d4d272ee19d7953a1ede338ae837b521",
-    "commits_total": 1137,
+    "default_branch": "codex/fix-comments-in-circuitbreaker.php-ayg7e0",
+    "last_commit": "024d975a46697dcd590e1174c72f14d11fadbd10",
+    "commits_total": 1139,
     "files_tracked": 807
   },
   "quality_gate": {

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-08T12:24:46Z",
+  "last_update_utc": "2025-09-08T12:24:48Z",
   "repo": {
     "default_branch": "codex/fix-comments-in-circuitbreaker.php-ayg7e0",
-    "last_commit": "deb354371e6e7c87c238e16b7c4e838457d519b8",
-    "commits_total": 1140,
+    "last_commit": "c932a8c25be9fd4fab73c354a4e1d940aad1ee9c",
+    "commits_total": 1141,
     "files_tracked": 807
   },
   "quality_gate": {

--- a/src/Exceptions/CircuitBreakerCallbackException.php
+++ b/src/Exceptions/CircuitBreakerCallbackException.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SmartAlloc\Exceptions;
+
+use Exception;
+use Throwable;
+
+final class CircuitBreakerCallbackException extends Exception
+{
+    private ?Throwable $originalException;
+    private string $callbackType;
+    private string $circuitName;
+
+    public function __construct(
+        string $message = 'Circuit breaker callback failed',
+        string $callbackType = 'unknown',
+        string $circuitName = 'default',
+        ?Throwable $originalException = null,
+        int $code = 0,
+        ?Throwable $previous = null
+    ) {
+        $this->callbackType = $callbackType;
+        $this->circuitName = $circuitName;
+        $this->originalException = $originalException;
+        parent::__construct($message, $code, $previous);
+    }
+
+    public function getOriginalException(): ?Throwable
+    {
+        return $this->originalException;
+    }
+
+    public function getCallbackType(): string
+    {
+        return $this->callbackType;
+    }
+
+    public function getCircuitName(): string
+    {
+        return $this->circuitName;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function getContext(): array
+    {
+        return [
+            'callback_type' => $this->callbackType,
+            'circuit_name'  => $this->circuitName,
+            'original_exception' => $this->originalException ? [
+                'type'    => $this->originalException::class,
+                'message' => $this->originalException->getMessage(),
+                'code'    => $this->originalException->getCode(),
+                'file'    => $this->originalException->getFile(),
+                'line'    => $this->originalException->getLine(),
+            ] : null,
+        ];
+    }
+}

--- a/tests/Unit/Services/CircuitBreakerCallbackExceptionTest.php
+++ b/tests/Unit/Services/CircuitBreakerCallbackExceptionTest.php
@@ -1,0 +1,37 @@
+<?php
+// phpcs:ignoreFile
+
+declare(strict_types=1);
+
+namespace SmartAlloc\Tests\Unit\Services;
+
+use PHPUnit\Framework\TestCase;
+use SmartAlloc\Services\CircuitBreaker;
+use SmartAlloc\Exceptions\CircuitBreakerCallbackException;
+use Psr\Log\AbstractLogger;
+
+class TestLogger extends AbstractLogger{
+    public array $records=[];
+    public function log($l,$m,array $c=[]):void{$this->records[]=compact('l','m','c');}
+    public function hasError(string $m):bool{foreach($this->records as $r){if($r['l']==='error'&&$r['m']===$m)return true;}return false;}
+}
+
+final class CircuitBreakerCallbackExceptionTest extends TestCase{
+    private TestLogger $logger;
+    protected function setUp():void{$this->logger=new TestLogger();$GLOBALS['_wp_transients']=[];}
+
+    public function test_callback_exception_thrown_and_logged():void{
+        $cb=new CircuitBreaker('t',$this->logger,5,function(){throw new \RuntimeException('cb');});
+        \set_transient('smartalloc_circuit_breaker_t',['state'=>'open','fail_count'=>1,'cooldown_until'=>time()-1,'last_error'=>'x'],3600);
+        $this->expectException(CircuitBreakerCallbackException::class);
+        try{$cb->execute(fn()=> 'ok');}catch(CircuitBreakerCallbackException $e){$m=$cb->getFailureMetadata();$this->assertSame('callback',$m[0]['failure_type']);$this->assertTrue($this->logger->hasError('Circuit breaker callback failed'));throw $e;}}
+
+    public function test_callback_exception_context():void{
+        $orig=new \InvalidArgumentException('bad',4);
+        $e=new CircuitBreakerCallbackException('m','t','c',$orig,0,$orig);
+        $ctx=$e->getContext();
+        $this->assertEquals('t',$ctx['callback_type']);
+        $this->assertEquals('c',$ctx['circuit_name']);
+        $this->assertEquals('InvalidArgumentException',$ctx['original_exception']['type']);
+    }
+}

--- a/tests/Unit/Services/CircuitBreakerCallbackExceptionTest.php
+++ b/tests/Unit/Services/CircuitBreakerCallbackExceptionTest.php
@@ -24,7 +24,7 @@ final class CircuitBreakerCallbackExceptionTest extends TestCase{
         $cb=new CircuitBreaker('t',$this->logger,5,function(){throw new \RuntimeException('cb');});
         \set_transient('smartalloc_circuit_breaker_t',['state'=>'open','fail_count'=>1,'cooldown_until'=>time()-1,'last_error'=>'x'],3600);
         $this->expectException(CircuitBreakerCallbackException::class);
-        try{$cb->execute(fn()=> 'ok');}catch(CircuitBreakerCallbackException $e){$m=$cb->getFailureMetadata();$this->assertSame('callback',$m[0]['failure_type']);$this->assertTrue($this->logger->hasError('Circuit breaker callback failed'));throw $e;}}
+        try{$cb->execute(fn()=> 'ok');}catch(CircuitBreakerCallbackException $e){$m=$cb->getFailureMetadata();$st=$cb->getStatus();$this->assertSame('callback',$m[0]['failure_type']);$this->assertTrue($this->logger->hasError('Circuit breaker callback failed'));$this->assertSame('open',$st->state);$this->assertGreaterThan(time(),$st->cooldownUntil);$this->assertSame(5,$st->failCount);throw $e;}}
 
     public function test_callback_exception_context():void{
         $orig=new \InvalidArgumentException('bad',4);


### PR DESCRIPTION
## Summary
<!-- What changed? Why? -->

## QA Checklist (advisory)
- [ ] Ran `composer qa:advisory`
- [ ] If i18n touched, ran `php scripts/pot-refresh.php`
- [ ] REST routes enforce cap + nonce/signature
- [ ] No unprepared `$wpdb` queries
- [ ] Linked rehearsal summary/JUnit and attached artifacts

## Artifacts
- `artifacts/ga/GA_REHEARSAL.txt`
- `artifacts/ga/GA_REHEARSAL.junit.xml`
