### PR TITLE
افزودن محافظ تکرار برای ارسال‌های Gravity Forms

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -23,7 +23,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-09T14:27:43Z
+Last Updated (UTC): 2025-09-09T14:45:16Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -23,7 +23,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-09T14:45:16Z
+Last Updated (UTC): 2025-09-09T14:45:24Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-09T14:27:43Z",
+  "last_update_utc": "2025-09-09T14:45:16Z",
   "repo": {
-    "default_branch": "codex/assess-impact-of-idempotencyguard-introduction",
-    "last_commit": "e6ca578d6c160b8f55776dda63a5e8df13ecdf51",
-    "commits_total": 1172,
+    "default_branch": "codex/update-bootstrap-and-align-gravityforms-instantiation",
+    "last_commit": "e6fa3f8b8314938dbb76485e44d9462f4c5a251f",
+    "commits_total": 1174,
     "files_tracked": 825
   },
   "quality_gate": {

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-09T14:45:16Z",
+  "last_update_utc": "2025-09-09T14:45:24Z",
   "repo": {
     "default_branch": "codex/update-bootstrap-and-align-gravityforms-instantiation",
-    "last_commit": "e6fa3f8b8314938dbb76485e44d9462f4c5a251f",
-    "commits_total": 1174,
+    "last_commit": "fd746e6eaae814ebca41bd0dee30a5f40a852124",
+    "commits_total": 1175,
     "files_tracked": 825
   },
   "quality_gate": {

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -88,7 +88,7 @@ final class Bootstrap
 
         // Create upload directory
         $upload = wp_upload_dir();
-        $upload_dir = trailingslashit($upload['basedir']) . SMARTALLOC_UPLOAD_DIR; // @phpstan-ignore-line
+        $upload_dir = trailingslashit($upload['basedir']) . SMARTALLOC_UPLOAD_DIR;
         wp_mkdir_p($upload_dir);
 
         // Set default options
@@ -225,7 +225,7 @@ final class Bootstrap
         $as->register();
 
         // Gravity Forms integration
-        (new GravityForms($c, $c->get(EventBus::class), $c->get(LoggerInterface::class)))->register();
+        (new GravityForms($c->get(LoggerInterface::class)))->register();
     }
 
     /**

--- a/tests/Infra/GF/HookBootstrapTest.php
+++ b/tests/Infra/GF/HookBootstrapTest.php
@@ -6,6 +6,7 @@ namespace SmartAlloc\Tests\Infra\GF;
 
 use Brain\Monkey;
 use Brain\Monkey\Functions;
+use Mockery;
 use SmartAlloc\Infra\GF\HookBootstrap;
 use SmartAlloc\Tests\BaseTestCase;
 
@@ -15,14 +16,6 @@ final class HookBootstrapTest extends BaseTestCase
     {
         parent::setUp();
         Monkey\setUp();
-        global $wpdb;
-        $wpdb = new class {
-            public string $prefix = 'wp_';
-            public function prepare($sql, ...$args) {
-                return vsprintf(str_replace('%s', '%s', $sql), $args);
-            }
-            public function get_results($sql, $output = OBJECT) { return [['form_id' => 150]]; }
-        };
     }
 
     protected function tearDown(): void
@@ -31,9 +24,11 @@ final class HookBootstrapTest extends BaseTestCase
         parent::tearDown();
     }
 
-    public function test_registers_hooks_for_enabled_forms(): void
+    public function testRegistersHooksForEnabledForms(): void
     {
-        Functions\expect('add_action')->once()->with('gform_after_submission_150', [\SmartAlloc\Infra\GF\SabtSubmissionHandler::class, 'handle'], 10, 2);
-        HookBootstrap::registerEnabledForms();
+        Functions\expect('add_action')
+            ->once()
+            ->with('gform_after_submission_150', Mockery::type('callable'), 10, 2);
+        (new HookBootstrap())->register();
     }
 }

--- a/tests/Infra/HookBootstrapTest.php
+++ b/tests/Infra/HookBootstrapTest.php
@@ -8,27 +8,27 @@ use SmartAlloc\Tests\BaseTestCase;
 use SmartAlloc\Infra\GF\HookBootstrap;
 use Brain\Monkey;
 use Brain\Monkey\Functions;
+use Mockery;
 
-final class HookBootstrapTest extends BaseTestCase {
-    protected function setUp(): void {
+final class HookBootstrapTest extends BaseTestCase
+{
+    protected function setUp(): void
+    {
         parent::setUp();
         Monkey\setUp();
-        global $wpdb;
-        $wpdb = new class {
-            public string $prefix = 'wp_';
-            public function get_results($sql, $output = ARRAY_A) { return [['form_id'=>150]]; }
-        };
     }
 
-    protected function tearDown(): void {
+    protected function tearDown(): void
+    {
         Monkey\tearDown();
         parent::tearDown();
     }
 
-    public function test_registers_gf_hooks_for_enabled_forms(): void {
+    public function testRegistersGfHooksForEnabledForms(): void
+    {
         Functions\expect('add_action')
             ->once()
-            ->with('gform_after_submission_150', [\SmartAlloc\Infra\GF\SabtSubmissionHandler::class, 'handle'], 10, 2);
-        HookBootstrap::registerEnabledForms();
+            ->with('gform_after_submission_150', Mockery::type('callable'), 10, 2);
+        (new HookBootstrap())->register();
     }
 }


### PR DESCRIPTION
## Summary
- switch Gravity Forms hook bootstrapper to instance-based `register()`
- construct GravityForms integration with updated logger-only signature
- update HookBootstrap tests for instance-based registration

## Testing
- `composer run quality:selective`
- `php baseline-check --current-phase=FOUNDATION`
- `vendor/bin/phpunit --filter IdempotencyGuardTest`
- `vendor/bin/phpunit --configuration phpunit-integration.xml --filter AfterSubmissionSinglePathTest`
- `XDEBUG_MODE=coverage vendor/bin/phpunit --configuration phpunit-integration.xml --filter AfterSubmissionSinglePathTest --coverage-text` *(warning: No code coverage driver available)*
- `rg "add_action" src | rg "gform_after_submission" | rg -v "gform_after_submission_150" | wc -l`
- `vendor/bin/phpunit tests/Infra/GF/HookBootstrapTest.php tests/Infra/HookBootstrapTest.php` *(errors: Patchwork defined too early)*
- `./scripts/patch-guard-check.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c03a3ac700832185f6ecd3a891d357