### PR TITLE
افزودن SchemaChecker و آزمون‌های واحد

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -23,7 +23,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-09T18:34:21Z
+Last Updated (UTC): 2025-09-09T18:34:26Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -23,7 +23,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-09T17:59:15Z
+Last Updated (UTC): 2025-09-09T18:34:21Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -23,7 +23,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-09T18:34:26Z
+Last Updated (UTC): 2025-09-09T18:34:30Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-09T18:34:22Z",
+  "last_update_utc": "2025-09-09T18:34:26Z",
   "repo": {
     "default_branch": "codex/update-global_state.json-for-p6.a-plan-001",
-    "last_commit": "ca5f86b3f1071a2c540620185575108932ec6c72",
-    "commits_total": 1182,
+    "last_commit": "04cc397266d1046e7725d6d88b5c863cfdefc3a1",
+    "commits_total": 1183,
     "files_tracked": 847
   },
   "quality_gate": {

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-09T18:34:26Z",
+  "last_update_utc": "2025-09-09T18:34:31Z",
   "repo": {
     "default_branch": "codex/update-global_state.json-for-p6.a-plan-001",
-    "last_commit": "04cc397266d1046e7725d6d88b5c863cfdefc3a1",
-    "commits_total": 1183,
+    "last_commit": "43e3683736c87b7fd38fac5d38a27b810ecf6616",
+    "commits_total": 1184,
     "files_tracked": 847
   },
   "quality_gate": {

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,10 +1,10 @@
 {
-  "last_update_utc": "2025-09-09T17:59:15Z",
+  "last_update_utc": "2025-09-09T18:34:22Z",
   "repo": {
-    "default_branch": "main",
-    "last_commit": "a2fb097b4be4707b085eb0b2c62b11efaa97f49f",
-    "commits_total": 1180,
-    "files_tracked": 846
+    "default_branch": "codex/update-global_state.json-for-p6.a-plan-001",
+    "last_commit": "ca5f86b3f1071a2c540620185575108932ec6c72",
+    "commits_total": 1182,
+    "files_tracked": 847
   },
   "quality_gate": {
     "weighted_threshold": 0.85,

--- a/src/Infra/GF/SchemaChecker.php
+++ b/src/Infra/GF/SchemaChecker.php
@@ -4,10 +4,132 @@ declare(strict_types=1);
 
 namespace SmartAlloc\Infra\GF;
 
-final class SchemaChecker
+use GFAPI;
+
+class SchemaChecker
 {
-    public static function check(int $formId): array
+    private array $schemaSpec;
+
+    public function __construct()
     {
-        return ['status' => 'compatible', 'reasons' => []];
+        $this->loadSchemaSpec();
+    }
+
+    private function loadSchemaSpec(): void
+    {
+        $specPath = wp_upload_dir()['basedir'] . '/smartalloc/artifacts/SCHEMA_SPEC.json';
+
+        if (!file_exists($specPath)) {
+            throw new \RuntimeException(__('Schema specification file not found', 'smartalloc'));
+        }
+
+        $content = file_get_contents($specPath);
+        $this->schemaSpec = json_decode($content, true);
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            throw new \RuntimeException(__('Invalid schema specification JSON', 'smartalloc'));
+        }
+    }
+
+    public function checkForm(int $formId): array
+    {
+        if ($formId !== 150) {
+            throw new \InvalidArgumentException(__('Only form ID 150 is supported', 'smartalloc'));
+        }
+
+        $form = GFAPI::get_form($formId);
+        if (!$form || !is_array($form)) {
+            throw new \RuntimeException(sprintf(__('Form %d not found or invalid', 'smartalloc'), $formId));
+        }
+
+        return $this->validateFormStructure($form);
+    }
+
+    private function validateFormStructure(array $form): array
+    {
+        $result = [
+            'status' => 'compatible',
+            'score' => 0,
+            'issues' => [],
+            'timestamp' => current_time('mysql', true)
+        ];
+
+        $maxScore = 0;
+        $currentScore = 0;
+
+        foreach ($this->schemaSpec['fields'] as $fieldSpec) {
+            $fieldId = (int) $fieldSpec['id'];
+            $maxScore += $fieldSpec['scoring']['complete_points'];
+
+            $formField = $this->findFormField($form, $fieldId);
+
+            if (!$formField) {
+                $result['issues'][] = [
+                    'fieldId' => $fieldId,
+                    'kind' => 'missing',
+                    'details' => sprintf(__('Required field %d is missing', 'smartalloc'), $fieldId)
+                ];
+                continue;
+            }
+
+            if (!$this->validateFieldType($formField, $fieldSpec)) {
+                $result['issues'][] = [
+                    'fieldId' => $fieldId,
+                    'kind' => 'wrong_type',
+                    'details' => sprintf(
+                        __('Field %d type mismatch: expected %s, got %s', 'smartalloc'),
+                        $fieldId,
+                        $fieldSpec['type'],
+                        $formField['type']
+                    )
+                ];
+                continue;
+            }
+
+            if ($fieldSpec['required'] && empty($formField['isRequired'])) {
+                $result['issues'][] = [
+                    'fieldId' => $fieldId,
+                    'kind' => 'not_required',
+                    'details' => sprintf(__('Field %d should be marked as required', 'smartalloc'), $fieldId)
+                ];
+                continue;
+            }
+
+            $currentScore += $fieldSpec['scoring']['complete_points'];
+        }
+
+        $result['score'] = $maxScore > 0 ? (int) round(($currentScore / $maxScore) * 100) : 0;
+
+        if (!empty($result['issues'])) {
+            $result['status'] = count($result['issues']) >= 2 ? 'critical' : 'warning';
+        }
+
+        return $result;
+    }
+
+    private function findFormField(array $form, int $fieldId): ?array
+    {
+        foreach ($form['fields'] ?? [] as $field) {
+            if ((int) $field['id'] === $fieldId) {
+                return $field;
+            }
+        }
+
+        return null;
+    }
+
+    private function validateFieldType(array $formField, array $fieldSpec): bool
+    {
+        $typeMap = [
+            'text' => ['text', 'name'],
+            'email' => ['email'],
+            'phone' => ['phone'],
+            'select' => ['select'],
+            'textarea' => ['textarea'],
+            'checkbox' => ['checkbox']
+        ];
+
+        $allowedTypes = $typeMap[$fieldSpec['type']] ?? [$fieldSpec['type']];
+        return in_array($formField['type'], $allowedTypes, true);
     }
 }

--- a/tests/Unit/SchemaCheckerTest.php
+++ b/tests/Unit/SchemaCheckerTest.php
@@ -1,0 +1,165 @@
+<?php
+// phpcs:ignoreFile
+
+declare(strict_types=1);
+
+namespace {
+    if (!class_exists('GFAPI')) {
+        class GFAPI
+        {
+            /** @var mixed */
+            public static $form;
+
+            public static function set_form($form): void
+            {
+                self::$form = $form;
+            }
+
+            public static function get_form(int $id)
+            {
+                return self::$form;
+            }
+        }
+    }
+}
+
+namespace SmartAlloc\Tests\Unit {
+
+use PHPUnit\Framework\TestCase;
+use SmartAlloc\Infra\GF\SchemaChecker;
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use GFAPI;
+
+class SchemaCheckerTest extends TestCase
+{
+    private SchemaChecker $checker;
+    private string $dir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Monkey\setUp();
+        $this->dir = sys_get_temp_dir() . '/smartalloc_' . uniqid();
+        mkdir($this->dir . '/smartalloc/artifacts', 0755, true);
+        Functions\when('wp_upload_dir')->justReturn(['basedir' => $this->dir]);
+        Functions\when('__')->returnArg();
+        $this->createSpec();
+        $this->checker = new SchemaChecker();
+    }
+
+    protected function tearDown(): void
+    {
+        Monkey\tearDown();
+        array_map('unlink', glob($this->dir . '/smartalloc/artifacts/*'));
+        rmdir($this->dir . '/smartalloc/artifacts');
+        rmdir($this->dir . '/smartalloc');
+        rmdir($this->dir);
+        parent::tearDown();
+    }
+
+    private function createSpec(): void
+    {
+        $spec = [
+            'form_id' => 150,
+            'fields' => [
+                ['id' => 39, 'type' => 'text', 'required' => true, 'scoring' => ['complete_points' => 25]],
+                ['id' => 20, 'type' => 'email', 'required' => true, 'scoring' => ['complete_points' => 25]],
+                ['id' => 92, 'type' => 'phone', 'required' => true, 'scoring' => ['complete_points' => 25]],
+                ['id' => 75, 'type' => 'checkbox', 'required' => true, 'scoring' => ['complete_points' => 25]],
+            ],
+        ];
+        file_put_contents($this->dir . '/smartalloc/artifacts/SCHEMA_SPEC.json', json_encode($spec));
+    }
+
+    /** @test */
+    public function it_validates_complete_correct_form(): void
+    {
+        GFAPI::set_form([
+            'id' => 150,
+            'fields' => [
+                ['id' => 39, 'type' => 'text', 'isRequired' => true],
+                ['id' => 20, 'type' => 'email', 'isRequired' => true],
+                ['id' => 92, 'type' => 'phone', 'isRequired' => true],
+                ['id' => 75, 'type' => 'checkbox', 'isRequired' => true],
+            ],
+        ]);
+        $r = $this->checker->checkForm(150);
+        $this->assertEquals('compatible', $r['status']);
+        $this->assertEquals(100, $r['score']);
+        $this->assertEmpty($r['issues']);
+    }
+
+    /**
+     * @test
+     * @dataProvider invalidForms
+     */
+    public function it_detects_schema_issues(array $form, string $status, int $score, array $kinds): void
+    {
+        GFAPI::set_form($form);
+        $r = $this->checker->checkForm(150);
+        $this->assertEquals($status, $r['status']);
+        $this->assertEquals($score, $r['score']);
+        $this->assertCount(count($kinds), $r['issues']);
+        foreach ($kinds as $kind) {
+            $this->assertContains($kind, array_column($r['issues'], 'kind'));
+        }
+    }
+
+    public static function invalidForms(): array
+    {
+        return [
+            'missing_fields' => [
+                ['id' => 150, 'fields' => [
+                    ['id' => 39, 'type' => 'text', 'isRequired' => true],
+                    ['id' => 20, 'type' => 'email', 'isRequired' => true],
+                ]],
+                'critical', 50, ['missing', 'missing'],
+            ],
+            'wrong_types' => [
+                ['id' => 150, 'fields' => [
+                    ['id' => 39, 'type' => 'text', 'isRequired' => true],
+                    ['id' => 20, 'type' => 'text', 'isRequired' => true],
+                    ['id' => 92, 'type' => 'text', 'isRequired' => true],
+                    ['id' => 75, 'type' => 'checkbox', 'isRequired' => true],
+                ]],
+                'critical', 50, ['wrong_type', 'wrong_type'],
+            ],
+            'not_required' => [
+                ['id' => 150, 'fields' => [
+                    ['id' => 39, 'type' => 'text', 'isRequired' => true],
+                    ['id' => 20, 'type' => 'email', 'isRequired' => false],
+                    ['id' => 92, 'type' => 'phone', 'isRequired' => true],
+                    ['id' => 75, 'type' => 'checkbox', 'isRequired' => true],
+                ]],
+                'warning', 75, ['not_required'],
+            ],
+        ];
+    }
+
+    /** @test */
+    public function it_throws_exception_for_unsupported_form_id(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->checker->checkForm(999);
+    }
+
+    /** @test */
+    public function it_throws_exception_when_form_not_found(): void
+    {
+        GFAPI::set_form(false);
+        $this->expectException(\RuntimeException::class);
+        $this->checker->checkForm(150);
+    }
+
+    /** @test */
+    public function it_handles_empty_form_fields(): void
+    {
+        GFAPI::set_form(['id' => 150, 'fields' => []]);
+        $r = $this->checker->checkForm(150);
+        $this->assertEquals('critical', $r['status']);
+        $this->assertEquals(0, $r['score']);
+        $this->assertCount(4, $r['issues']);
+    }
+}
+}


### PR DESCRIPTION
## خلاصه
- پیاده‌سازی کلاس `SchemaChecker` برای اعتبارسنجی ساختار فرم ۱۵۰ و امتیازدهی به فیلدها
- افزودن تست‌های واحد با سناریوهای نقص فیلد، نوع اشتباه و فیلد غیرالزامی با Data Provider
- رعایت دروازه‌های کیفی و گذر از Patch Guard

## آزمایش‌ها
- `composer run quality:selective`
- `php baseline-check --current-phase=FOUNDATION`
- `vendor/bin/phpunit --filter SchemaCheckerTest`
- `./scripts/patch-guard-check.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c0419187c483218d8b4bee8f485f25