### PR TITLE
اصلاح استانداردهای WPCS در هوک‌های GF

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -23,7 +23,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-10T02:53:16Z
+Last Updated (UTC): 2025-09-10T02:53:19Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -23,7 +23,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-10T02:53:13Z
+Last Updated (UTC): 2025-09-10T02:53:16Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -23,7 +23,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-10T02:39:01Z
+Last Updated (UTC): 2025-09-10T02:53:13Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-10T02:53:13Z",
+  "last_update_utc": "2025-09-10T02:53:17Z",
   "repo": {
     "default_branch": "codex/fix-comments-in-idempotencyguard.php",
-    "last_commit": "783a7eb027eb4e0e93aa091b690d664e28a6fa74",
-    "commits_total": 1197,
+    "last_commit": "a02f5a7f0d780d2cba5a846a2e17ffdd434861b9",
+    "commits_total": 1198,
     "files_tracked": 849
   },
   "quality_gate": {

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-10T02:53:17Z",
+  "last_update_utc": "2025-09-10T02:53:19Z",
   "repo": {
     "default_branch": "codex/fix-comments-in-idempotencyguard.php",
-    "last_commit": "a02f5a7f0d780d2cba5a846a2e17ffdd434861b9",
-    "commits_total": 1198,
+    "last_commit": "5aee215de5a352a042f5c2430a572cb741525979",
+    "commits_total": 1199,
     "files_tracked": 849
   },
   "quality_gate": {

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-10T02:39:02Z",
+  "last_update_utc": "2025-09-10T02:53:13Z",
   "repo": {
-    "default_branch": "codex/fix-phpcs-errors-and-add-docblocks",
-    "last_commit": "d20ba2dbe8229d4709a466dbb7acf8de8e139042",
-    "commits_total": 1195,
+    "default_branch": "codex/fix-comments-in-idempotencyguard.php",
+    "last_commit": "783a7eb027eb4e0e93aa091b690d664e28a6fa74",
+    "commits_total": 1197,
     "files_tracked": 849
   },
   "quality_gate": {

--- a/src/Infra/GF/IdempotencyGuard.php
+++ b/src/Infra/GF/IdempotencyGuard.php
@@ -63,4 +63,34 @@ final class IdempotencyGuard {
     public function mark_processed( int $form_id, int $entry_id ): void {
         $this->cache->l1Set( $this->key( $form_id, $entry_id ), 1, self::TTL );
     }
+
+    /**
+     * Check if the entry has already been processed.
+     *
+     * CamelCase wrapper for {@see has_processed()} to maintain backwards
+     * compatibility.
+     *
+     * @deprecated Use has_processed().
+     * @param int $form_id  Form ID.
+     * @param int $entry_id Entry ID.
+     * @return bool True if processed.
+     */
+    public function hasProcessed( int $form_id, int $entry_id ): bool {
+        return $this->has_processed( $form_id, $entry_id );
+    }
+
+    /**
+     * Mark the entry as processed.
+     *
+     * CamelCase wrapper for {@see mark_processed()} to maintain backwards
+     * compatibility.
+     *
+     * @deprecated Use mark_processed().
+     * @param int $form_id  Form ID.
+     * @param int $entry_id Entry ID.
+     * @return void
+     */
+    public function markProcessed( int $form_id, int $entry_id ): void {
+        $this->mark_processed( $form_id, $entry_id );
+    }
 }

--- a/tests/Integration/GF/AfterSubmissionSinglePathTest.php
+++ b/tests/Integration/GF/AfterSubmissionSinglePathTest.php
@@ -86,7 +86,7 @@ class AfterSubmissionSinglePathTest extends TestCase
 
         do_action('gform_after_submission_150', $entry, $form);
         $this->assertSame(1, $this->processCount);
-        $this->assertTrue($this->guard->hasProcessed(150, 123));
+        $this->assertTrue($this->guard->has_processed(150, 123));
 
         do_action('gform_after_submission_150', $entry, $form);
         $this->assertSame(1, $this->processCount);


### PR DESCRIPTION
## Summary
- add deprecated camelCase wrappers to IdempotencyGuard
- use new has_processed method in AfterSubmissionSinglePathTest

## Testing
- `composer run quality:selective`
- `php baseline-check --current-phase=FOUNDATION`
- `vendor/bin/phpunit --filter IdempotencyGuardTest`
- `vendor/bin/phpunit tests/Integration/GF/AfterSubmissionSinglePathTest.php`
- `./scripts/patch-guard-check.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c0e555320083218d1cd9d264152609