### PR TITLE
Add auto PR workflow for codex-pass events

### DIFF
--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -1,0 +1,82 @@
+name: Auto PR
+
+on:
+  repository_dispatch:
+    types: [codex-pass]
+
+jobs:
+  auto-pr:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Extract dispatch payload
+        id: payload
+        run: |
+          echo "base=${{ github.event.client_payload.base }}" >> "$GITHUB_OUTPUT"
+          echo "head=${{ github.event.client_payload.pr_branch }}" >> "$GITHUB_OUTPUT"
+          echo "title=${{ github.event.client_payload.pr_title }}" >> "$GITHUB_OUTPUT"
+          echo "body=${{ github.event.client_payload.pr_body }}" >> "$GITHUB_OUTPUT"
+          echo "auto_merge=${{ github.event.client_payload.auto_merge }}" >> "$GITHUB_OUTPUT"
+          echo "commit_ref=${{ github.event.client_payload.commit_ref }}" >> "$GITHUB_OUTPUT"
+
+      - name: Prepare branch
+        id: branch
+        env:
+          HEAD: ${{ steps.payload.outputs.head }}
+          COMMIT_REF: ${{ steps.payload.outputs.commit_ref }}
+        run: |
+          if [ -n "$HEAD" ]; then
+            echo "pr_branch=$HEAD" >> "$GITHUB_OUTPUT"
+          else
+            BRANCH="release/$COMMIT_REF"
+            git checkout -b "$BRANCH" "$COMMIT_REF"
+            git push origin "$BRANCH"
+            echo "pr_branch=$BRANCH" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create pull request
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BASE: ${{ steps.payload.outputs.base }}
+          TITLE: ${{ steps.payload.outputs.title }}
+          BODY: ${{ steps.payload.outputs.body }}
+          HEAD: ${{ steps.branch.outputs.pr_branch }}
+        run: |
+          pr_url=$(gh pr create --base "$BASE" --head "$HEAD" --title "$TITLE" --body "$BODY")
+          pr_number=$(gh pr view "$pr_url" --json number -q .number)
+          echo "url=$pr_url" >> "$GITHUB_OUTPUT"
+          echo "number=$pr_number" >> "$GITHUB_OUTPUT"
+
+      - name: Auto merge
+        if: steps.payload.outputs.auto_merge == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        run: gh pr merge "$PR_NUMBER" --merge --delete-branch --admin
+
+      - name: Notify WordPress
+        env:
+          WEBHOOK_URL: ${{ secrets.SMARTALLOC_WEBHOOK_URL }}
+          WEBHOOK_TOKEN: ${{ secrets.SMARTALLOC_WEBHOOK_TOKEN }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          PR_URL: ${{ steps.pr.outputs.url }}
+          PAYLOAD: ${{ toJson(github.event.client_payload) }}
+        run: |
+          jq -n \
+            --arg pr_number "$PR_NUMBER" \
+            --arg pr_url "$PR_URL" \
+            --argjson payload "$PAYLOAD" \
+            '{pr_number:$pr_number, pr_url:$pr_url, payload:$payload}' \
+            | curl -s -X POST "$WEBHOOK_URL" \
+                -H "Authorization: Bearer $WEBHOOK_TOKEN" \
+                -H "Content-Type: application/json" \
+                -d @-

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -23,7 +23,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-10T15:56:29Z
+Last Updated (UTC): 2025-09-10T15:56:31Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -23,7 +23,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-10T15:56:27Z
+Last Updated (UTC): 2025-09-10T15:56:29Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -23,7 +23,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-10T02:37:20Z
+Last Updated (UTC): 2025-09-10T15:56:27Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-10T15:56:27Z",
+  "last_update_utc": "2025-09-10T15:56:29Z",
   "repo": {
     "default_branch": "codex/implement-e2e-automation-for-auto-pr",
-    "last_commit": "0aa37da643fe2fbafc7c7cbaf053e707b0571c3a",
-    "commits_total": 1198,
+    "last_commit": "9928449ad0817fe38d705930f5242bbc67b535d5",
+    "commits_total": 1199,
     "files_tracked": 851
   },
   "quality_gate": {

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-10T15:56:29Z",
+  "last_update_utc": "2025-09-10T15:56:32Z",
   "repo": {
     "default_branch": "codex/implement-e2e-automation-for-auto-pr",
-    "last_commit": "9928449ad0817fe38d705930f5242bbc67b535d5",
-    "commits_total": 1199,
+    "last_commit": "c56ef2a4449d10bebae2ef3603b51f6eb0bac7d4",
+    "commits_total": 1200,
     "files_tracked": 851
   },
   "quality_gate": {

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,10 +1,10 @@
 {
-  "last_update_utc": "2025-09-10T02:37:20Z",
+  "last_update_utc": "2025-09-10T15:56:27Z",
   "repo": {
-    "default_branch": "main",
-    "last_commit": "e174a7f8f665317a6855a88c2055ca4246713268",
-    "commits_total": 1196,
-    "files_tracked": 850
+    "default_branch": "codex/implement-e2e-automation-for-auto-pr",
+    "last_commit": "0aa37da643fe2fbafc7c7cbaf053e707b0571c3a",
+    "commits_total": 1198,
+    "files_tracked": 851
   },
   "quality_gate": {
     "weighted_threshold": 0.85,


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to create and optionally merge pull requests when Codex dispatch passes
- report PR details to WordPress context pool webhook

## Testing
- `composer run quality:selective`
- `php baseline-check --current-phase=FOUNDATION`
- `./scripts/patch-guard-check.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c19ceae2d48321b163e4a0e455f9d5