### PR TITLE
Define SMARTALLOC_CAP in test bootstrap

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -23,7 +23,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-10T15:56:48Z
+Last Updated (UTC): 2025-09-10T17:00:50Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -23,7 +23,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-10T17:00:50Z
+Last Updated (UTC): 2025-09-10T17:00:53Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-10T15:56:48Z",
+  "last_update_utc": "2025-09-10T17:00:50Z",
   "repo": {
-    "default_branch": "main",
-    "last_commit": "bd5f0614344226b0c871f089542763c95b353bcd",
-    "commits_total": 1202,
+    "default_branch": "codex/edit-tests/bootstrap.php-for-initialization",
+    "last_commit": "04ceec8f60a56010c9cdaad49a9255afd4cc8d80",
+    "commits_total": 1204,
     "files_tracked": 851
   },
   "quality_gate": {

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-10T17:00:50Z",
+  "last_update_utc": "2025-09-10T17:00:53Z",
   "repo": {
     "default_branch": "codex/edit-tests/bootstrap.php-for-initialization",
-    "last_commit": "04ceec8f60a56010c9cdaad49a9255afd4cc8d80",
-    "commits_total": 1204,
+    "last_commit": "34432d40bebef3cc7ea1bb2442d10f84699c8516",
+    "commits_total": 1205,
     "files_tracked": 851
   },
   "quality_gate": {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 namespace {
+define('SMARTALLOC_CAP', 'manage_smartalloc');
 foreach(['WP_TESTS_DOMAIN'=>'example.org','WP_TESTS_EMAIL'=>'admin@example.org','WP_TESTS_TITLE'=>'Test Blog','ABSPATH'=>'/tmp/wordpress/','WP_DEBUG'=>true,'WP_CONTENT_DIR'=>'/tmp/wordpress/wp-content','WP_PLUGIN_DIR'=>'/tmp/wordpress/wp-content/plugins','WPINC'=>'wp-includes','DB_NAME'=>'wordpress_test','DB_USER'=>'root','DB_PASSWORD'=>'','DB_HOST'=>'localhost','DB_CHARSET'=>'utf8','DB_COLLATE'=>''] as $k=>$v) if(!defined($k)) define($k,$v);
 $table_prefix='wp_';
 require_once dirname(__DIR__).'/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- define SMARTALLOC_CAP for tests

## Testing
- `composer run quality:selective`
- `php baseline-check --current-phase=FOUNDATION`
- `./scripts/patch-guard-check.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c1a88114088321815a7e2e68a90e86