### PR TITLE
ci: merge selector artifacts and honor auto-merge flag

### DIFF
--- a/.github/workflows/mrg-evaluate.yml
+++ b/.github/workflows/mrg-evaluate.yml
@@ -71,7 +71,10 @@ jobs:
     needs: [eval]
     steps:
       - uses: actions/download-artifact@v4
-        with: { path: build/selector }
+        with:
+          path: build/selector
+          pattern: selector-*
+          merge-multiple: true
       - name: Pick winner by gates + weighted_percent
         id: pick
         run: |
@@ -90,7 +93,7 @@ jobs:
           git push origin "$BR" || true
           gh pr create --base "${{ github.event.client_payload.base || 'main' }}" --head "$BR" --title "$T" --body "$B"
       - name: Auto-merge (optional)
-        if: ${{ github.event.client_payload.auto_merge || true }}
+        if: ${{ github.event.client_payload.auto_merge }}
         env: { GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} }
         run: |
           NUM=$(gh pr view --json number --jq .number)

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -23,7 +23,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-10T18:01:26Z
+Last Updated (UTC): 2025-09-10T18:01:28Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -23,7 +23,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-10T18:01:25Z
+Last Updated (UTC): 2025-09-10T18:01:26Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -23,7 +23,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-10T17:20:16Z
+Last Updated (UTC): 2025-09-10T18:01:25Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-10T18:01:25Z",
+  "last_update_utc": "2025-09-10T18:01:26Z",
   "repo": {
     "default_branch": "codex/fix-mrg-evaluate.yml-line-79",
-    "last_commit": "35dbadbff54cacc31f0f06108e8f6ec550388ca2",
-    "commits_total": 1208,
+    "last_commit": "856492ce1720bca701ff76be047aaa56682fa8d0",
+    "commits_total": 1209,
     "files_tracked": 855
   },
   "quality_gate": {

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-10T17:20:16Z",
+  "last_update_utc": "2025-09-10T18:01:25Z",
   "repo": {
-    "default_branch": "codex/integrate-appendix-d-into-ci-pipeline-068bz0",
-    "last_commit": "51d8b2f73b1f2c4ba83075e8ab77d752a7d636a6",
-    "commits_total": 1206,
+    "default_branch": "codex/fix-mrg-evaluate.yml-line-79",
+    "last_commit": "35dbadbff54cacc31f0f06108e8f6ec550388ca2",
+    "commits_total": 1208,
     "files_tracked": 855
   },
   "quality_gate": {

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-10T18:01:26Z",
+  "last_update_utc": "2025-09-10T18:01:29Z",
   "repo": {
     "default_branch": "codex/fix-mrg-evaluate.yml-line-79",
-    "last_commit": "856492ce1720bca701ff76be047aaa56682fa8d0",
-    "commits_total": 1209,
+    "last_commit": "eafb1c49f9a5c92b132169e78366cc6fa846825d",
+    "commits_total": 1210,
     "files_tracked": 855
   },
   "quality_gate": {


### PR DESCRIPTION
## Summary
- merge selector artifacts into a single directory for evaluation
- respect `auto_merge` flag in MRG workflow

## Testing
- `composer run quality:selective`
- `php baseline-check --current-phase=FOUNDATION`
- `./scripts/patch-guard-check.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c1bc2eaf58832182c8e4402b0077c5