### PR TITLE
ci: honor auto_merge flag and merge selector artifacts

### DIFF
--- a/.github/workflows/mrg-evaluate.yml
+++ b/.github/workflows/mrg-evaluate.yml
@@ -71,7 +71,9 @@ jobs:
     needs: [eval]
     steps:
       - uses: actions/download-artifact@v4
-        with: { path: build/selector }
+        with:
+          path: build/selector
+          merge: true
       - name: Pick winner by gates + weighted_percent
         id: pick
         run: |
@@ -90,7 +92,7 @@ jobs:
           git push origin "$BR" || true
           gh pr create --base "${{ github.event.client_payload.base || 'main' }}" --head "$BR" --title "$T" --body "$B"
       - name: Auto-merge (optional)
-        if: ${{ github.event.client_payload.auto_merge || true }}
+        if: ${{ github.event.client_payload.auto_merge == true }}
         env: { GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} }
         run: |
           NUM=$(gh pr view --json number --jq .number)


### PR DESCRIPTION
## Summary
- ensure selector downloads merge variant artifacts
- respect `auto_merge` flag before merging MRG winner

## Testing
- `composer run quality:selective`
- `php baseline-check --current-phase=FOUNDATION`
- `./scripts/patch-guard-check.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c1bc4506848321af33f4e7fb59f07e