### PR TITLE
chore: update composer autoload configuration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,14 +43,11 @@
   },
   "autoload": {
     "psr-4": {
-      "SmartAlloc\\": [
-        "src/",
-        "includes/"
-      ]
+      "SmartAlloc\\": "src/"
     },
     "files": [
-      "src/Support/SafetyKit.php",
-      "src/Infra/DbAbstraction.php"
+      "src/RuleEngine/Contracts.php",
+      "src/Rules/Exceptions.php"
     ]
   },
   "scripts": {
@@ -121,7 +118,10 @@
   "autoload-dev": {
     "psr-4": {
       "SmartAlloc\\Tests\\": "tests/"
-    }
+    },
+    "exclude-from-classmap": [
+      "tests/"
+    ]
   },
   "config": {
     "allow-plugins": {


### PR DESCRIPTION
## Summary
- simplify composer autoload to only use `src/`
- autoload rule engine contracts and rule exceptions files
- exclude tests from composer classmap

## Testing
- `composer run quality:selective`
- `php baseline-check --current-phase=FOUNDATION`
- `./scripts/patch-guard-check.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c666927af48321af620eca8e7d3155