### PR TITLE
Fix metrics tests and workflow env variables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,15 +68,15 @@ jobs:
       - name: Build and start
         run: |
           docker compose build --no-cache
-          docker compose up -d ${{ env.DB_SERVICE }}
+          docker compose up -d "$DB_SERVICE"
           sleep 8
-          docker compose up -d ${{ env.PHP_SERVICE }}
+          docker compose up -d "$PHP_SERVICE"
 
       - name: Wait for DB
         run: |
           for i in $(seq 1 120); do
-            docker compose exec -T ${{ env.DB_SERVICE }} sh -lc 'mysqladmin ping -u"$$MYSQL_USER" -p"$$MYSQL_PASSWORD" --silent' \
-            || docker compose exec -T ${{ env.DB_SERVICE }} sh -lc 'test -S /var/run/mysqld/mysqld.sock' \
+            docker compose exec -T "$DB_SERVICE" sh -lc 'mysqladmin ping -u"$$MYSQL_USER" -p"$$MYSQL_PASSWORD" --silent' \
+            || docker compose exec -T "$DB_SERVICE" sh -lc 'test -S /var/run/mysqld/mysqld.sock' \
             && exit 0 || true
             sleep 2
           done
@@ -84,19 +84,19 @@ jobs:
 
       - name: Composer install (retry, unlimited memory)
         run: |
-          docker compose run --rm ${{ env.PHP_SERVICE }} bash -lc 'export COMPOSER_MEMORY_LIMIT=-1; composer clear-cache || true; composer install -o || composer install -o'
+          docker compose run --rm "$PHP_SERVICE" bash -lc 'export COMPOSER_MEMORY_LIMIT=-1; composer clear-cache || true; composer install -o || composer install -o'
 
       - name: Project init
-        run: docker compose run --rm ${{ env.PHP_SERVICE }} bash -lc "./docker/init.sh"
+        run: docker compose run --rm "$PHP_SERVICE" bash -lc "./docker/init.sh"
 
       - name: Unit tests
-        run: docker compose run --rm ${{ env.PHP_SERVICE }} vendor/bin/phpunit -v
+        run: docker compose run --rm "$PHP_SERVICE" vendor/bin/phpunit -v
 
       - name: Quality selective
-        run: docker compose run --rm ${{ env.PHP_SERVICE }} composer run quality:selective
+        run: docker compose run --rm "$PHP_SERVICE" composer run quality:selective
 
       - name: Baseline check
-        run: docker compose run --rm ${{ env.PHP_SERVICE }} php baseline-check --current-phase=FOUNDATION
+        run: docker compose run --rm "$PHP_SERVICE" php baseline-check --current-phase=FOUNDATION
 
       - name: Collect artifacts (optional)
         if: always()

--- a/tests/unit/Services/MetricsTest.php
+++ b/tests/unit/Services/MetricsTest.php
@@ -13,14 +13,14 @@ namespace SmartAlloc\Tests\Unit\Services {
 
 use Exception;
 use PHPUnit\Framework\TestCase;
-use SmartAlloc\Infrastructure\Contracts\DbProxy;
+use SmartAlloc\Database\DbPort;
 use SmartAlloc\Services\Metrics;
 
 final class MetricsTest extends TestCase
 {
-    public function test_constructor_accepts_db_proxy_and_table(): void
+    public function test_constructor_accepts_db_port_and_table(): void
     {
-        $mockDb = $this->createMock(DbProxy::class);
+        $mockDb = $this->createMock(DbPort::class);
         $metrics = new Metrics($mockDb, 'wp_salloc_metrics');
 
         $this->assertInstanceOf(Metrics::class, $metrics);
@@ -28,8 +28,8 @@ final class MetricsTest extends TestCase
 
     public function test_database_exception_handling(): void
     {
-        $mockDb = $this->createMock(DbProxy::class);
-        $mockDb->method('getResults')->willThrowException(new Exception('DB Error'));
+        $mockDb = $this->createMock(DbPort::class);
+        $mockDb->method('exec')->willThrowException(new Exception('DB Error'));
 
         $metrics = new Metrics($mockDb, 'wp_salloc_metrics');
         $result = $metrics->get('foo');
@@ -39,8 +39,8 @@ final class MetricsTest extends TestCase
 
     public function test_error_logging_on_database_failure(): void
     {
-        $mockDb = $this->createMock(DbProxy::class);
-        $mockDb->method('insert')->willThrowException(new Exception('Insert failed'));
+        $mockDb = $this->createMock(DbPort::class);
+        $mockDb->method('exec')->willThrowException(new Exception('Insert failed'));
         $metrics = new Metrics($mockDb, 'wp_salloc_metrics');
 
         $temp = tempnam(sys_get_temp_dir(), 'log');
@@ -50,13 +50,10 @@ final class MetricsTest extends TestCase
         $output = file_get_contents($temp) ?: '';
         unlink($temp);
 
-        $this->assertStringContainsString('Metrics::inc: Insert failed', $output);
-    }
-
-    public function test_factory_method_creates_with_defaults(): void
-    {
-        $metrics = Metrics::createDefault();
-        $this->assertInstanceOf(Metrics::class, $metrics);
+        $this->assertStringContainsString(
+            'Metrics::inc failed for table wp_salloc_metrics: Insert failed',
+            $output
+        );
     }
 }
 


### PR DESCRIPTION
## Summary
- mock `SmartAlloc\Database\DbPort` instead of unrelated `DbProxy` in metrics tests and drop undefined factory method
- reference `$DB_SERVICE`/`$PHP_SERVICE` variables directly in CI scripts

## Testing
- `composer run quality:selective`
- `php baseline-check --current-phase=FOUNDATION`
- `./scripts/patch-guard-check.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c676dd3d00832190875ddedcb2d970