### PR TITLE
Configure naming rules

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<ruleset name="SmartAlloc">
+  <rule ref="PSR12"/>
+  <rule ref="SlevomatCodingStandard.Files.TypeNameMatchesFileName"/>
+  <rule ref="SlevomatCodingStandard.Namespaces.NamespaceDeclaration"/>
+  <rule ref="SlevomatCodingStandard.Namespaces.NamespaceSpacing"/>
+  <file>src</file>
+  <file>tests</file>
+</ruleset>

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -23,7 +23,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-14T08:02:54Z
+Last Updated (UTC): 2025-09-14T08:22:15Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,10 +1,10 @@
 {
-  "last_update_utc": "2025-09-14T08:02:55Z",
+  "last_update_utc": "2025-09-14T08:22:15Z",
   "repo": {
-    "default_branch": "main",
-    "last_commit": "22cb8992927d8384629a2f7b7bdd688498ac2bf3",
-    "commits_total": 1306,
-    "files_tracked": 3874
+    "default_branch": "codex/normalize-case-and-namespaces-in-project",
+    "last_commit": "2d6cfe9c7a74a0f1c76f592cd106dc0e3edd669b",
+    "commits_total": 1308,
+    "files_tracked": 3875
   },
   "quality_gate": {
     "weighted_threshold": 0.85,

--- a/composer.json
+++ b/composer.json
@@ -102,7 +102,9 @@
     "patch:guard:ps": "powershell -ExecutionPolicy Bypass -File scripts/patch-guard-check.ps1",
     "plugin:check": "bash scripts/run-plugin-check.sh",
     "phpstan": "phpstan analyze --level=5 --no-progress",
-    "audit": "composer audit"
+    "audit": "composer audit",
+    "fix:naming": "php-cs-fixer fix --allow-risky=yes --using-cache=no --rules='{ \"psr_autoloading\": true }'",
+    "check:naming": "phpcs -q"
   },
   "scripts-descriptions": {
     "baseline:check": "Run baseline compliance check for current phase",
@@ -117,11 +119,10 @@
   },
   "autoload-dev": {
     "psr-4": {
-      "SmartAlloc\\Tests\\": "tests/"
-    },
-    "exclude-from-classmap": [
-      "tests/"
-    ]
+      "SmartAlloc\\Tests\\Unit\\": "tests/Unit/",
+      "SmartAlloc\\Tests\\Integration\\": "tests/Integration/",
+      "SmartAlloc\\Tests\\E2E\\": "tests/E2E/"
+    }
   },
   "config": {
     "allow-plugins": {


### PR DESCRIPTION
## Summary
- add PSR-4 test namespaces and naming scripts in composer.json
- introduce coding standard to enforce PSR-12 and file/class name alignment

## Testing
- `composer run quality:selective`
- `php baseline-check --current-phase=FOUNDATION`
- `./scripts/patch-guard-check.sh`
- `composer dump-autoload`
- `composer run fix:naming` *(fails: php-cs-fixer: not found)*
- `composer run check:naming` *(fails: phpcs: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c679d3379c83218e9a69857bdbd894