### PR TITLE
chore: install coding style tooling

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -23,7 +23,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-14T08:24:09Z
+Last Updated (UTC): 2025-09-14T08:38:22Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -23,7 +23,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-14T08:38:22Z
+Last Updated (UTC): 2025-09-14T08:38:30Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-14T08:38:23Z",
+  "last_update_utc": "2025-09-14T08:38:30Z",
   "repo": {
     "default_branch": "codex/add-dev-dependencies-for-php-cs-tools",
-    "last_commit": "4b2d208f541e0d98eb5628d9d383babc50b6dca8",
-    "commits_total": 1312,
+    "last_commit": "f7da951bec6aa4cfad09f3aa33b5f4692a37821c",
+    "commits_total": 1313,
     "files_tracked": 3875
   },
   "quality_gate": {

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-14T08:24:09Z",
+  "last_update_utc": "2025-09-14T08:38:23Z",
   "repo": {
-    "default_branch": "main",
-    "last_commit": "2d6387ea2e67b0803200e153e3a9e8000dd0a033",
-    "commits_total": 1310,
+    "default_branch": "codex/add-dev-dependencies-for-php-cs-tools",
+    "last_commit": "4b2d208f541e0d98eb5628d9d383babc50b6dca8",
+    "commits_total": 1312,
     "files_tracked": 3875
   },
   "quality_gate": {

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "phpcompatibility/phpcompatibility-wp": "^2.1",
     "phpcompatibility/phpcompatibility-paragonie": "^1.0",
     "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
-    "squizlabs/php_codesniffer": "^3.7",
+    "squizlabs/php_codesniffer": "^3.10",
     "phpcsstandards/phpcsextra": "^1.2",
     "phpcsstandards/phpcsutils": "^1.0",
     "sirbrillig/phpcs-variable-analysis": "^2.11",
@@ -39,7 +39,9 @@
     "php-stubs/wordpress-stubs": "^6.6",
     "giorgiosironi/eris": "^1.0",
     "wp-phpunit/wp-phpunit": "6.5.*",
-    "johnpbloch/wordpress-core": "^6.5"
+    "johnpbloch/wordpress-core": "^6.5",
+    "friendsofphp/php-cs-fixer": "^3.59",
+    "slevomat/coding-standard": "^8.14"
   },
   "autoload": {
     "psr-4": {
@@ -103,8 +105,8 @@
     "plugin:check": "bash scripts/run-plugin-check.sh",
     "phpstan": "phpstan analyze --level=5 --no-progress",
     "audit": "composer audit",
-    "fix:naming": "php-cs-fixer fix --allow-risky=yes --using-cache=no --rules='{ \"psr_autoloading\": true }'",
-    "check:naming": "phpcs -q"
+    "fix:naming": "php-cs-fixer fix src --allow-risky=yes --using-cache=no --rules='{ \"psr_autoloading\": true }'",
+    "check:naming": "phpcs -q --standard=phpcs.xml"
   },
   "scripts-descriptions": {
     "baseline:check": "Run baseline compliance check for current phase",


### PR DESCRIPTION
## Summary
- add php-cs-fixer, phpcs and slevomat to dev dependencies
- ensure naming scripts target src and project phpcs.xml

## Testing
- `composer run quality:selective`
- `php baseline-check --current-phase=FOUNDATION`
- `composer run fix:naming`
- `composer run check:naming` *(fails: coding standard issues)*
- `composer audit` *(fails: 1 vulnerability)*
- `composer plugin:check` *(fails: MySQL client not found)*
- `./scripts/patch-guard-check.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c67b8fd95883219a7afe05e4ee1b5a