### PR TITLE
chore: enforce VIP standards and add mysql client

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -1,9 +1,17 @@
 <?xml version="1.0"?>
-<ruleset name="SmartAlloc">
-  <rule ref="PSR12"/>
-  <rule ref="SlevomatCodingStandard.Files.TypeNameMatchesFileName"/>
-  <rule ref="SlevomatCodingStandard.Namespaces.NamespaceDeclaration"/>
-  <rule ref="SlevomatCodingStandard.Namespaces.NamespaceSpacing"/>
+<ruleset name="SmartAlloc VIP">
+  <description>WordPress VIP + WPCS + Slevomat</description>
+
   <file>src</file>
-  <file>tests</file>
+  <file>includes</file>
+  <file>templates</file>
+  <exclude-pattern>vendor/*</exclude-pattern>
+  <exclude-pattern>node_modules/*</exclude-pattern>
+
+  <rule ref="WordPressVIPMinimum"/>
+  <rule ref="WordPress"/>
+  <rule ref="SlevomatCodingStandard.Namespaces.NamespaceDeclaration"/>
+  <rule ref="SlevomatCodingStandard.Files.TypeNameMatchesFileName"/>
+  <rule ref="SlevomatCodingStandard.Classes.ClassStructure"/>
+  <rule ref="SlevomatCodingStandard.Namespaces.NamespaceSpacing"/>
 </ruleset>

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM php:8.3-cli
 
 # Base tools and PHP extensions (incl. GD for phpoffice/phpspreadsheet)
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    git unzip zip curl ca-certificates libzip-dev libicu-dev mariadb-client \
+    git unzip zip curl ca-certificates libzip-dev libicu-dev \
+    default-mysql-client jq \
     libfreetype6-dev libjpeg62-turbo-dev libpng-dev libwebp-dev \
  && docker-php-ext-install -j"$(nproc)" mysqli zip intl \
  && docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp \

--- a/composer.json
+++ b/composer.json
@@ -105,8 +105,12 @@
     "plugin:check": "bash scripts/run-plugin-check.sh",
     "phpstan": "phpstan analyze --level=5 --no-progress",
     "audit": "composer audit",
-    "fix:naming": "php-cs-fixer fix src --allow-risky=yes --using-cache=no --rules='{ \"psr_autoloading\": true }'",
-    "check:naming": "phpcs -q --standard=phpcs.xml"
+    "fix:naming": "php-cs-fixer fix --allow-risky=yes --using-cache=no --rules='{ \"psr_autoloading\": true }'",
+    "check:naming": "phpcs -q --standard=phpcs.xml",
+    "check:vip": "vendor/bin/phpcs --standard=.phpcs.xml -q",
+    "fix:vip": "vendor/bin/phpcbf --standard=.phpcs.xml || true",
+    "health:check": "php scripts/site_health_check.php",
+    "doctor:mysql": "mysql --version"
   },
   "scripts-descriptions": {
     "baseline:check": "Run baseline compliance check for current phase",

--- a/includes/autoload.php
+++ b/includes/autoload.php
@@ -17,7 +17,8 @@ spl_autoload_register(
         $file           = $base_dir . str_replace('\\', '/', $relative_class) . '.php';
 
         if (file_exists($file)) {
-            require $file;
+            // phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.UsingVariable -- Autoloader requires dynamic path
+            require_once $file;
         }
     }
 );

--- a/src/Migrations/ExportLogMigrator.php
+++ b/src/Migrations/ExportLogMigrator.php
@@ -32,9 +32,9 @@ final class ExportLogMigrator
             column_name VARCHAR(100) NULL,
             message TEXT NOT NULL
         ) $charset;";
-        $upgrade = ABSPATH . 'wp-admin/includes/upgrade.php';
-        if (is_readable($upgrade)) {
-            require_once $upgrade;
+        $upgrade_path = ABSPATH . 'wp-admin/includes/upgrade.php';
+        if (is_readable($upgrade_path)) {
+            require_once ABSPATH . 'wp-admin/includes/upgrade.php';
         }
         if (function_exists('dbDelta')) {
             \dbDelta($sqlLog);


### PR DESCRIPTION
## Summary
- add default mysql client and jq to php Docker image
- introduce WordPress VIP/WPCS ruleset and composer scripts
- tighten autoloader and migration includes

## Testing
- `composer run doctor:mysql`
- `composer run health:check`
- `composer run quality:selective` *(fails: Constant ABSPATH not found)*
- `composer run check:vip` *(fails: missing doc comment and tab usage)*
- `php baseline-check --current-phase=FOUNDATION`
- `./scripts/patch-guard-check.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c67fffe2848321a50616b2e56c34c7