### PR TITLE
Add modular PHPUnit bootstrap

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,28 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  phpunit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Run Unit
+        run: composer test:unit
+
+      - name: Run Integration (Docker DB)
+        run: |
+          docker compose -f docker-compose.test.yml up -d db
+          bash scripts/wait-for-db.sh 127.0.0.1 root root
+          composer test:int

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -23,7 +23,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-14T12:09:35Z
+Last Updated (UTC): 2025-09-14T12:09:39Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -23,7 +23,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-14T11:00:39Z
+Last Updated (UTC): 2025-09-14T12:09:35Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-14T12:09:36Z",
+  "last_update_utc": "2025-09-14T12:09:39Z",
   "repo": {
     "default_branch": "codex/create-modular-phpunit-bootstrap-files",
-    "last_commit": "f532210b5ecb56d72d09e49b7b5ddc3c603cb079",
-    "commits_total": 1327,
+    "last_commit": "40a2f96d0791b0311bbe0a3bea42ec76f7282031",
+    "commits_total": 1328,
     "files_tracked": 3878
   },
   "quality_gate": {

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,10 +1,10 @@
 {
-  "last_update_utc": "2025-09-14T11:00:39Z",
+  "last_update_utc": "2025-09-14T12:09:36Z",
   "repo": {
-    "default_branch": "main",
-    "last_commit": "a9e12fa84ff5ccda2d764610cb4f94d0dc68f6df",
-    "commits_total": 1325,
-    "files_tracked": 3870
+    "default_branch": "codex/create-modular-phpunit-bootstrap-files",
+    "last_commit": "f532210b5ecb56d72d09e49b7b5ddc3c603cb079",
+    "commits_total": 1327,
+    "files_tracked": 3878
   },
   "quality_gate": {
     "weighted_threshold": 0.85,

--- a/composer.json
+++ b/composer.json
@@ -70,13 +70,10 @@
     "psalm:taint": "vendor/bin/psalm --taint-analysis",
     "validate:test-env": "php bin/validate-test-environment.php",
     "setup:wp-tests": "vendor/bin/wp-phpunit-setup || echo setup",
-    "test:unit": "XDEBUG_MODE=coverage vendor/bin/phpunit --colors=always --log-junit build/junit.unit.xml --coverage-clover build/coverage.unit.xml",
-    "test:integration": "phpunit --configuration phpunit-integration.xml",
+    "test:unit": "vendor/bin/phpunit --testsuite=unit",
+    "test:int": "bash scripts/run-integration.sh",
+    "test:all": "composer test:unit && composer test:int",
     "test": "composer test:unit",
-    "test:all": [
-      "@test:unit",
-      "@test:integration"
-    ],
     "test:debug": "phpunit --configuration phpunit-unit.xml --no-coverage --verbose",
     "test:smoke": "vendor/bin/phpunit tests/Unit/BrainMonkeySmokeTest.php tests/WordPress/Smoke/BootTest.php",
     "gen:features": "php scripts/generate_features_md.php",
@@ -125,6 +122,7 @@
   },
   "autoload-dev": {
     "psr-4": {
+      "SmartAlloc\\Tests\\": "tests/",
       "SmartAlloc\\Tests\\Unit\\": "tests/Unit/",
       "SmartAlloc\\Tests\\Integration\\": "tests/Integration/",
       "SmartAlloc\\Tests\\E2E\\": "tests/E2E/"

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,17 @@
+version: "3.8"
+services:
+  db:
+    image: mysql:8.0
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: wp_test
+      MYSQL_USER: wp_test
+      MYSQL_PASSWORD: wp_test
+    ports: ["3307:3306"]
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-uroot", "-proot"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+    tmpfs:
+      - /var/lib/mysql

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,30 +1,39 @@
-<?xml version="1.0"?>
-<phpunit bootstrap="tests/bootstrap.php" colors="true">
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+  colors="true"
+  bootstrap="tools/bootstrap/autoload.php"
+  beStrictAboutOutputDuringTests="true"
+  beStrictAboutChangesToGlobalState="true"
+  failOnRisky="true"
+  failOnWarning="true"
+>
+  <php>
+    <!-- Default: Unit mode; set WP_INTEGRATION=1 when running Integration -->
+    <env name="WP_INTEGRATION" value="0"/>
+    <ini name="date.timezone" value="UTC"/>
+  </php>
+
   <testsuites>
-    <testsuite name="Unit">
-      <directory suffix="Test.php">tests/Unit</directory>
+    <testsuite name="unit">
+      <directory>tests/Unit</directory>
     </testsuite>
-    <testsuite name="Integration">
-      <directory suffix="Test.php">tests/Integration</directory>
-    </testsuite>
-    <testsuite name="E2E">
-      <directory suffix="Test.php">tests/E2E</directory>
+    <testsuite name="integration">
+      <directory>tests/Integration</directory>
     </testsuite>
   </testsuites>
 
+  <extensions>
+    <!-- Registers our BrainMonkey per-test hook -->
+    <extension class="BrainMonkeyExtension"/>
+  </extensions>
+
   <coverage processUncoveredFiles="true">
     <include>
-      <directory suffix=".php">src</directory>
+      <directory>src</directory>
     </include>
+    <report>
+      <clover outputFile="coverage.xml"/>
+      <html outputDirectory="coverage-html"/>
+    </report>
   </coverage>
-
-  <logging>
-    <junit outputFile="build/junit.xml"/>
-    <coverage-clover outputFile="build/coverage.xml"/>
-    <testdoxText outputFile="build/testdox.txt"/>
-  </logging>
-
-  <php>
-    <env name="XDEBUG_MODE" value="coverage"/>
-  </php>
 </phpunit>

--- a/scripts/run-integration.sh
+++ b/scripts/run-integration.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# 1) اگر Docker داری، DB را بالا بیار
+if command -v docker &>/dev/null; then
+  docker compose -f docker-compose.test.yml up -d db
+  bash scripts/wait-for-db.sh 127.0.0.1 root root
+  DB_HOST="127.0.0.1"
+  DB_USER="root"
+  DB_PASS="root"
+  DB_NAME="wp_test"
+else
+  # فرض: یک MySQL محلی داری
+  DB_HOST="${DB_HOST:-127.0.0.1}"
+  DB_USER="${DB_USER:-root}"
+  DB_PASS="${DB_PASS:-root}"
+  DB_NAME="${DB_NAME:-wp_test}"
+  bash scripts/wait-for-db.sh "$DB_HOST" "$DB_USER" "$DB_PASS"
+fi
+
+# 2) نصب/آپدیت محیط تست وردپرس (اگر اسکریپت استاندارد را داری)
+if [ -f "scripts/setup-wp-tests.sh" ]; then
+  bash scripts/setup-wp-tests.sh "$DB_NAME" "$DB_USER" "$DB_PASS" "$DB_HOST" latest
+fi
+
+# 3) اجرای PHPUnit در حالت Integration
+export WP_INTEGRATION=1
+# export WP_PATH=${WP_PATH:-/var/www/html}
+vendor/bin/phpunit --testsuite=integration

--- a/scripts/wait-for-db.sh
+++ b/scripts/wait-for-db.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+HOST="${1:-127.0.0.1}"
+USER="${2:-root}"
+PASS="${3:-root}"
+for i in {1..60}; do
+  if mysqladmin ping -h "$HOST" -u"$USER" -p"$PASS" --silent; then
+    exit 0
+  fi
+  sleep 2
+done
+echo "DB not ready after waiting." >&2
+exit 1

--- a/tools/bootstrap/autoload.php
+++ b/tools/bootstrap/autoload.php
@@ -1,0 +1,17 @@
+<?php
+
+// Fail-fast Composer autoload
+$autoload = __DIR__ . '/../../vendor/autoload.php';
+if (!is_file($autoload)) {
+    throw new RuntimeException("Missing Composer autoload at $autoload");
+}
+require $autoload;
+
+// Timezone & test-time helpers
+require __DIR__ . '/time.php';
+
+// Per-test Brain Monkey hooks via PHPUnit extension
+require __DIR__ . '/mocks.php';
+
+// Only for Integration (explicit opt-in)
+require __DIR__ . '/environment.php';

--- a/tools/bootstrap/environment.php
+++ b/tools/bootstrap/environment.php
@@ -1,0 +1,31 @@
+<?php
+
+// phpcs:ignoreFile
+
+// ABSPATH only when running Integration suite
+$integration = getenv('WP_INTEGRATION') === '1';
+if (! $integration || defined('ABSPATH')) {
+    return;
+}
+
+// Try common paths, override with WP_PATH env if provided
+$paths = [];
+if ($env = getenv('WP_PATH')) {
+    $paths[] = rtrim($env, '/') . '/';
+}
+$paths[] = '/var/www/html/';
+$paths[] = __DIR__ . '/../../wp/';
+$paths[] = __DIR__ . '/../../';
+
+foreach ($paths as $p) {
+    if (is_file($p . 'wp-config-sample.php') || is_file($p . 'wp-settings.php')) {
+        define('ABSPATH', $p);
+        break;
+    }
+}
+
+if (! defined('ABSPATH')) { // @phpstan-ignore-line
+    throw new RuntimeException(
+        'Could not resolve ABSPATH for Integration tests. Set WP_PATH or check your WP install.'
+    );
+}

--- a/tools/bootstrap/mocks.php
+++ b/tools/bootstrap/mocks.php
@@ -1,0 +1,22 @@
+<?php
+
+// Brain Monkey per-test without modifying your TestCase classes.
+if (!interface_exists(\PHPUnit\Runner\BeforeTestHook::class)) {
+    // PHPUnit < 8 not supported by this hook approach.
+    return;
+}
+use PHPUnit\Runner\BeforeTestHook;
+use PHPUnit\Runner\AfterTestHook;
+
+final class BrainMonkeyExtension implements BeforeTestHook, AfterTestHook {
+    public function executeBeforeTest(string $test): void {
+        if (class_exists(\Brain\Monkey::class)) {
+            \Brain\Monkey\setUp();
+        }
+    }
+    public function executeAfterTest(string $test, float $time): void {
+        if (class_exists(\Brain\Monkey::class)) {
+            \Brain\Monkey\tearDown();
+        }
+    }
+}

--- a/tools/bootstrap/time.php
+++ b/tools/bootstrap/time.php
@@ -1,0 +1,8 @@
+<?php
+
+// Enforce deterministic time behavior
+date_default_timezone_set('UTC');
+ini_set('date.timezone', 'UTC');
+
+// If you use Carbon in tests, you can set TestNow per-test as needed.
+// (Kept minimal per patch_guard)


### PR DESCRIPTION
## Summary
- add modular bootstraps for autoload, environment, mocks, and time helpers
- streamline phpunit.xml for unit/integration split with per-test Brain Monkey hooks
- add MySQL docker compose file, integration runner scripts, and GitHub workflow
- autoload SmartAlloc\Tests namespace and register BrainMonkey extension

## Testing
- `composer run quality:selective`
- `php baseline-check --current-phase=FOUNDATION`
- `composer test:unit` (fails: WordPress database connection error)
- `WP_PATH=$(pwd)/wordpress composer test:int` (fails: MySQL service not available)
- `./scripts/patch-guard-check.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c6a4b6fef88321a5212d6ec3e855cf