### PR TITLE
chore: configure standalone unit test bootstrap

### DIFF
--- a/phpunit-unit.xml
+++ b/phpunit-unit.xml
@@ -1,14 +1,41 @@
-<?xml version="1.0"?>
-<phpunit bootstrap="tests/bootstrap.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true">
-<testsuites>
-<testsuite name="unit">
-<directory>tests/Unit</directory>
-<directory>tests/Services</directory>
-</testsuite>
-</testsuites>
-<filter>
-<whitelist>
-<directory suffix=".php">src/</directory>
-</whitelist>
-</filter>
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+         bootstrap="tools/bootstrap/autoload.php"
+         colors="true"
+         stopOnFailure="false"
+         failOnRisky="true"
+         failOnWarning="true">
+
+  <testsuites>
+    <testsuite name="unit">
+      <directory>tests/Unit</directory>
+    </testsuite>
+  </testsuites>
+
+  <source>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory>src/Infra</directory>
+    </exclude>
+  </source>
+
+  <php>
+    <ini name="date.timezone" value="UTC"/>
+    <env name="WP_INTEGRATION" value="0"/>
+    <env name="WP_TESTS_DOMAIN" value="localhost"/>
+  </php>
+
+  <extensions>
+    <bootstrap class="Brain\Monkey\PHPUnit\BrainMonkeyPHPUnit"/>
+  </extensions>
+
+  <coverage includeUncoveredFiles="true">
+    <report>
+      <clover outputFile="coverage/clover.xml"/>
+      <html outputDirectory="coverage/html"/>
+    </report>
+  </coverage>
 </phpunit>


### PR DESCRIPTION
## Summary
- use standalone bootstrap for unit tests
- ensure unit suite skips WP integration and collects coverage

## Testing
- `composer run quality:selective`
- `php baseline-check --current-phase=FOUNDATION`


------
https://chatgpt.com/codex/tasks/task_e_68c6bdf807888321bee56f418d8502b2