### PR TITLE
Add workflow to toggle repository workflows

### DIFF
--- a/.github/workflows/manage-workflows.yml
+++ b/.github/workflows/manage-workflows.yml
@@ -1,0 +1,71 @@
+name: Manage Workflows (enable/disable)
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: 'disable or enable'
+        required: true
+        default: 'disable'
+      whitelist:
+        description: 'Comma-separated workflow names to keep as-is (exact name match)'
+        required: false
+        default: ''
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  manage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: List & toggle workflows via API
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const mode = core.getInput('mode').trim().toLowerCase();
+            if (!['disable','enable'].includes(mode)) {
+              core.setFailed(`Invalid mode: ${mode}`); return;
+            }
+            const raw = core.getInput('whitelist') || '';
+            const whitelist = raw.split(',').map(s=>s.trim()).filter(Boolean);
+            core.info(`Mode: ${mode} | Whitelist: [${whitelist.join(', ')}]`);
+
+            const owner = context.repo.owner;
+            const repo  = context.repo.repo;
+
+            // paginate all workflows
+            let page = 1, per_page = 100, all = [];
+            while (true) {
+              const { data } = await github.rest.actions.listRepoWorkflows({ owner, repo, per_page, page });
+              all = all.concat(data.workflows || []);
+              if (!data.workflows || data.workflows.length < per_page) break;
+              page++;
+            }
+            if (all.length === 0) {
+              core.info('No workflows found.'); return;
+            }
+
+            let touched = 0;
+            for (const wf of all) {
+              const name = wf.name || wf.path || String(wf.id);
+              if (whitelist.includes(name)) {
+                core.info(`SKIP (whitelisted): ${name}`);
+                continue;
+              }
+              try {
+                if (mode === 'disable') {
+                  await github.rest.actions.disableWorkflow({ owner, repo, workflow_id: wf.id });
+                  core.info(`DISABLED: ${name}`);
+                } else {
+                  await github.rest.actions.enableWorkflow({ owner, repo, workflow_id: wf.id });
+                  core.info(`ENABLED: ${name}`);
+                }
+                touched++;
+              } catch (e) {
+                core.warning(`FAILED ${mode.toUpperCase()}: ${name} -> ${e.message}`);
+              }
+            }
+            core.info(`Done. Total ${mode}d: ${touched}`);
+

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -23,7 +23,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-14T17:22:28Z
+Last Updated (UTC): 2025-09-14T17:22:35Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -23,7 +23,7 @@
 }
 
 ---
-Last Updated (UTC): 2025-09-14T17:10:27Z
+Last Updated (UTC): 2025-09-14T17:22:28Z
 
 <!-- AUTO-GEN:RAG START -->
 | Feature | Status | Notes |

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,9 +1,9 @@
 {
-  "last_update_utc": "2025-09-14T17:22:28Z",
+  "last_update_utc": "2025-09-14T17:22:35Z",
   "repo": {
     "default_branch": "codex/create-github-actions-management-workflow",
-    "last_commit": "a2087cc8c03a225121f6c71325d9d9340c2f2b8d",
-    "commits_total": 1381,
+    "last_commit": "04758d80500e61be1f83ad8f3148105819cac843",
+    "commits_total": 1382,
     "files_tracked": 3888
   },
   "quality_gate": {

--- a/ai_context.json
+++ b/ai_context.json
@@ -1,10 +1,10 @@
 {
-  "last_update_utc": "2025-09-14T17:10:28Z",
+  "last_update_utc": "2025-09-14T17:22:28Z",
   "repo": {
-    "default_branch": "main",
-    "last_commit": "0e018544c5b739daf7e8c235cb7f6114f2304eb4",
-    "commits_total": 1379,
-    "files_tracked": 3887
+    "default_branch": "codex/create-github-actions-management-workflow",
+    "last_commit": "a2087cc8c03a225121f6c71325d9d9340c2f2b8d",
+    "commits_total": 1381,
+    "files_tracked": 3888
   },
   "quality_gate": {
     "weighted_threshold": 0.85,


### PR DESCRIPTION
## Summary
- add workflow to enable or disable other workflows using the GitHub REST API

## Testing
- `composer run quality:selective`
- `php baseline-check --current-phase=FOUNDATION`


------
https://chatgpt.com/codex/tasks/task_e_68c6f9318c7c8321887fe325dd7ab9f7